### PR TITLE
fix(NetPlayer): Prevent a crash when user select own player in singleplayer

### DIFF
--- a/BigBaseV2/src/gui/window/player/player_info.cpp
+++ b/BigBaseV2/src/gui/window/player/player_info.cpp
@@ -12,13 +12,17 @@ namespace big
 
 			ImGui::Text("Player ID: %d", g.selected_player.id);
 
-			CPlayerInfo* player_info = g.selected_player.net_player->player_info;
-			if (g.selected_player.net_player != nullptr && player_info != nullptr)
+			CNetGamePlayer* net_player = g.selected_player.net_player;
+			if (net_player != nullptr)
 			{
-				ImGui::Text("Session Host: %s", g.selected_player.net_player->is_host() ? "Yes" : "No");
+				CPlayerInfo* player_info = net_player->player_info;
+				if (player_info != nullptr)
+				{
+					ImGui::Text("Session Host: %s", net_player->is_host() ? "Yes" : "No");
 
-				ImGui::Text("Rockstar ID: %d", player_info->m_rockstar_id);
-				ImGui::Text("IP Address: %d.%d.%d.%d:%d", player_info->m_external_ip.m_field1, player_info->m_external_ip.m_field2, player_info->m_external_ip.m_field3, player_info->m_external_ip.m_field4, player_info->m_external_port);
+					ImGui::Text("Rockstar ID: %d", player_info->m_rockstar_id);
+					ImGui::Text("IP Address: %d.%d.%d.%d:%d", player_info->m_external_ip.m_field1, player_info->m_external_ip.m_field2, player_info->m_external_ip.m_field3, player_info->m_external_ip.m_field4, player_info->m_external_port);
+				}
 			}
 
 			ImGui::EndTabItem();


### PR DESCRIPTION
.selected_player.net_player is null in singleplayer and its getting deferenced without being checked first