### PR TITLE
feat(Actions): Add nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,13 +52,13 @@ jobs:
         working-directory: bin/Release/
 
       - name: Get commit short sha for nightly name
-        id: short-sha
+        id: short_sha
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
 
       - name: Nightly Release
         uses: softprops/action-gh-release@v1
         with:
-          name: Nightly Release ${{ steps.vars.outputs.sha_short }}
+          name: Nightly Release ${{ steps.short_sha.outputs.sha_short }}
           tag_name: nightly
           body: |
             This nightly release is provided for testing purposes only, there's no warrenty provided if your account gets banned online.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,7 +59,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           name: Nightly Release ${{ steps.vars.outputs.sha_short }}
-          tag_name: nightly_${{ steps.vars.outputs.sha_short }}
+          tag_name: nightly
           body: |
             This nightly release is provided for testing purposes only, there's no warrenty provided if your account gets banned online.
 
@@ -71,4 +71,4 @@ jobs:
       - name: Keep only the last 7 nightly builds, any other nightlies will be removed
         uses: dev-drprasad/delete-older-releases@v0.2.0
         keep_latest: 7
-        delete_tag_pattern: "nightly_*"
+        delete_tag_pattern: nightly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -70,6 +70,8 @@ jobs:
 
       - name: Keep only the last 7 nightly builds, any other nightlies will be removed
         uses: dev-drprasad/delete-older-releases@v0.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           keep_latest: 7
           delete_tag_pattern: nightly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,6 +33,8 @@ jobs:
       
       - name: Setup premake
         uses: abel0b/setup-premake@v2
+        with:
+          version: "5.0.0-beta1"
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -70,5 +70,6 @@ jobs:
 
       - name: Keep only the last 7 nightly builds, any other nightlies will be removed
         uses: dev-drprasad/delete-older-releases@v0.2.0
-        keep_latest: 7
-        delete_tag_pattern: nightly
+        with:
+          keep_latest: 7
+          delete_tag_pattern: nightly

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -47,22 +47,28 @@ jobs:
         run: |
           msbuild /p:Configuration=Release /p:Platform=x64 BigBaseV2.sln
 
+      - name: Rename DLL to YimMenu.dll
+        run: ren BigBaseV2.dll YimMenu.dll
+        working-directory: bin/Release/
+
       - name: Get commit short sha for nightly name
         id: short-sha
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
 
-      - name: Create nightly release
-        id: create_release
-        uses: viperproject/create-nightly-release@v1.1.5
-        env:
-          # This token is provided by Actions, you do not need to create your own token
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Nightly Release
+        uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ steps.vars.outputs.sha_short }}
-          release_name: Nightly Release ${{ steps.vars.outputs.sha_short }}
+          name: Nightly Release ${{ steps.vars.outputs.sha_short }}
+          tag_name: nightly_${{ steps.vars.outputs.sha_short }}
           body: |
-            This nightly release is provided for testing purpose only, there's no warrenty provided if your account gets banned online.
+            This nightly release is provided for testing purposes only, there's no warrenty provided if your account gets banned online.
 
-            Use this to test and see if you can run the menu as-is, if it works and you're unable to use your own version check if your build environment is setup correctly.
-          keep_num: 0
-          keep_tags: false
+            Use this to test and see if you can run the menu as-is in single player, if it works and you're unable to use your own version check if your build environment is setup correctly.
+          prerelease: true
+          files: |
+            bin/Release/YimMenu.dll
+
+      - name: Keep only the last 7 nightly builds, any other nightlies will be removed
+        uses: dev-drprasad/delete-older-releases@v0.2.0
+        keep_latest: 7
+        delete_tag_pattern: 'nightly_*'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,7 +35,7 @@ jobs:
         uses: abel0b/setup-premake@v2
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.1.1
+        uses: microsoft/setup-msbuild@v1.1
 
       - name: Generate premake5 project
         run: premake5 vs2019

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -58,13 +58,12 @@ jobs:
       - name: Nightly Release
         uses: softprops/action-gh-release@v1
         with:
-          name: Nightly Release ${{ steps.short_sha.outputs.sha_short }}
+          name: Nightly ${{ steps.short_sha.outputs.sha_short }}
           tag_name: nightly
           body: |
-            This nightly release is provided for testing purposes only, there's no warrenty provided if your account gets banned online.
+            This nightly release is provided for testing purposes only, there's no warranty provided if your account gets banned online.
 
             Use this to test and see if you can run the menu as-is in single player, if it works and you're unable to use your own version check if your build environment is setup correctly.
-          prerelease: true
           files: |
             bin/Release/YimMenu.dll
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,7 +59,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           name: Nightly ${{ steps.short_sha.outputs.sha_short }}
-          tag_name: nightly
+          tag_name: nightly_${{ steps.short_sha.outputs.sha_short }}
           body: |
             This nightly release is provided for testing purposes only, there's no warranty provided if your account gets banned online.
 
@@ -73,4 +73,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           keep_latest: 7
-          delete_tag_pattern: nightly
+          delete_tag_pattern: 'nightly_*'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -71,4 +71,4 @@ jobs:
       - name: Keep only the last 7 nightly builds, any other nightlies will be removed
         uses: dev-drprasad/delete-older-releases@v0.2.0
         keep_latest: 7
-        delete_tag_pattern: 'nightly_*'
+        delete_tag_pattern: "nightly_*"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,66 @@
+name: Nightly Public Build
+
+on:
+  schedule:
+    # cronjob that triggers every day at 2PM UTC
+    - cron: '0 14 * * *'
+  workflow_dispatch:
+
+jobs:
+  check_date:
+    runs-on: ubuntu-latest
+    name: Check latest commit
+    outputs:
+      should_run: ${{ steps.should_run.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - id: should_run
+        continue-on-error: true
+        name: Check if latest commit date is within the previous 24 hours
+        if: ${{ github.event_name == 'schedule' }}
+        run: test -z $(git rev-list  --after="24 hours"  ${{ github.sha }}) && echo "::set-output name=should_run::false"
+
+  build-nightly:
+    runs-on: windows-latest
+    name: Build Nightly
+    needs: check_date
+    if: ${{ needs.check_date.outputs.should_run != 'false' }}
+    steps:
+      - uses: actions/checkout@v2.4.0
+        with:
+          submodules: recursive
+      
+      - name: Setup premake
+        uses: abel0b/setup-premake@v2
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.1.1
+
+      - name: Generate premake5 project
+        run: premake5 vs2019
+        shell: bash
+
+      - name: Build 64bit release DLL
+        run: |
+          msbuild /p:Configuration=Release /p:Platform=x64 BigBaseV2.sln
+
+      - name: Get commit short sha for nightly name
+        id: short-sha
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+
+      - name: Create nightly release
+        id: create_release
+        uses: viperproject/create-nightly-release@v1.1.5
+        env:
+          # This token is provided by Actions, you do not need to create your own token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.vars.outputs.sha_short }}
+          release_name: Nightly Release ${{ steps.vars.outputs.sha_short }}
+          body: |
+            This nightly release is provided for testing purpose only, there's no warrenty provided if your account gets banned online.
+
+            Use this to test and see if you can run the menu as-is, if it works and you're unable to use your own version check if your build environment is setup correctly.
+          keep_num: 0
+          keep_tags: false


### PR DESCRIPTION
Nightly builds will be made @ 2PM UTC every day as long as a new commit has been made to the master branch in the last 24 hours.

These nightly builds are provided so people with injection problems can try and see if their build environment is faulty or not by comparing the public nightly build with what they have.