### PR TITLE
feat(Actions): autocloser

### DIFF
--- a/.github/workflows/autocloser.yml
+++ b/.github/workflows/autocloser.yml
@@ -1,0 +1,38 @@
+name: Autocloser
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  autoclose:
+    runs-on: ubuntu-latest
+    name: Autocloser
+    steps:
+    - name: Autoclose issue that does not follow template
+      uses: actions/github-script@v6
+      env:
+        message: "this issue was automatically closed because it did not follow the issue template.\n\nIf you believe this is an error, please re-open it!"
+        pattern: "(.*Describe the bug.*To Reproduce.*Expected behavior.*Logs.*Build.*)|(.*Is your feature request related to a problem. Please describe..*Describe the solution you'd like.*Provide Reasoning.*)"
+      with:
+        script: |
+          const { message, pattern } = process.env
+          if (!context.payload.sender) return;
+
+          const body = context.payload.issue.body;
+          const templateRegex = new RegExp(pattern, "s")
+
+          if (!body || !body.match(templateRegex)) {
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `@${context.payload.sender.login}, ${message}`
+            })
+            github.rest.issues.update({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed'
+            })
+          }


### PR DESCRIPTION
This PR adds an action that auto closes issues that don't follow the template.

The current pattern is `(.*Describe the bug.*To Reproduce.*Expected behavior.*Logs.*Build.*)|(.*Is your feature request related to a problem. Please describe..*Describe the solution you'd like.*Provide Reasoning.*)`

so it checks if the following exist:
- Describe the bug
- To Reproduce
- Expected behavior
- Logs
- Build

or

- Is your feature request related to a problem? Please describe.
- Describe the solution you'd like
- Provide Reasoning

Fields like `Additional context` have been purposely omitted as issue authors might remove them.

When an issue closes, the following message gets sent:
```
@{ISSUE_AUTHOR}, this issue was automatically closed because it did not follow the issue template.

If you believe this is an error, please re-open it!
```

See it in action:
Issues missing stuff: https://github.com/geopjr-forks/YimMenu/issues/24 https://github.com/geopjr-forks/YimMenu/issues/23
Corrent issues: https://github.com/geopjr-forks/YimMenu/issues/21 https://github.com/geopjr-forks/YimMenu/issues/22