### PR TITLE
Rewrite autocloser's response & add a comment to the bug_template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,6 +24,7 @@ A clear and concise description of what you expected to happen.
 Add screenshots here,  you may remove this section if there are no screenshots applicable.
 
 **Logs**
+<!-- No logs or -->
 ```
 <paste your logs here>
 ```

--- a/.github/workflows/autocloser.yml
+++ b/.github/workflows/autocloser.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Autoclose issue that does not follow template
       uses: actions/github-script@v6
       env:
-        message: "this issue was automatically closed because it did not follow the issue template.\n\nIf you believe this is an error, please re-open it!"
+        message: "this issue was automatically closed because it did not follow the issue template.\n\nA moderator will reopen the issue if it is valid, otherwise it will be tagged with \"invalid\" afterwards."
         pattern: "(.*Describe the bug.*To Reproduce.*Expected behavior.*Logs.*Build.*)|(.*Is your feature request related to a problem. Please describe..*Describe the solution you'd like.*Provide Reasoning.*)"
       with:
         script: |


### PR DESCRIPTION
This PR does the following:

Rewrite autocloser's response to avoid confusion.
Add a comment to bug_report's template so reporters dont remove the "Logs" header