### PR TITLE
feat(ci): autolocker

### DIFF
--- a/.github/workflows/autolocker.yml
+++ b/.github/workflows/autolocker.yml
@@ -1,0 +1,22 @@
+name: Autolocker
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  autolock:
+#     if: ${{ github.event.pull_request.merged }} # Uncomment if you want it to run only when a PR gets MERGED
+    runs-on: ubuntu-latest
+    name: Autolocker
+    steps:
+    - name: Autolock PRs that got merged or closed
+      uses: actions/github-script@v6
+      with:
+        script: |     
+            github.rest.issues.lock({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              lock_reason: "resolved" // ["off-topic", "too heated", "resolved", "spam"]
+            })


### PR DESCRIPTION
This PR adds an action that auto-locks PRs after they get merged or closed.

There's a commented line to limit it to just merged PRs.

Turns out locked reason cannot be custom but has to be one of the following: ["off-topic", "too heated", "resolved", "spam"]. I picked "resolved". Let me know if you want a different one or for the action to send a message!

Tests:

![Random pull request that got closed and the action locked it with the reason 'resolved'](https://user-images.githubusercontent.com/18014039/167629116-3f71304b-bb99-431e-95df-798d92f5b730.png)
![Random pull request that got merged and the action locked it with the reason 'resolved'](https://user-images.githubusercontent.com/18014039/167629164-1dbb0dd3-99f0-4f18-9f57-bdd59fa911ab.png)
