### PR TITLE
fix(ci): give autolocker write permissions

### DIFF
--- a/.github/workflows/autolocker.yml
+++ b/.github/workflows/autolocker.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [closed]
 
+permissions: write-all
+
 jobs:
   autolock:
 #     if: ${{ github.event.pull_request.merged }} # Uncomment if you want it to run only when a PR gets MERGED


### PR DESCRIPTION
GitHub hardened action permissions and autolocker (#192) was unable to successfully lock the PR. This PR gives autolocker write-all permissions (write to all available scopes).