### PR TITLE
feat(ci): error on warnings

### DIFF
--- a/.github/workflows/autolocker.yml
+++ b/.github/workflows/autolocker.yml
@@ -1,7 +1,7 @@
 name: Autolocker
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 permissions: write-all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build 64bit release DLL
         run: |
-          msbuild /p:Configuration=Release /p:Platform=x64 BigBaseV2.sln -m
+          msbuild /p:Configuration=Release /p:Platform=x64 BigBaseV2.sln -m /warnaserror
 
       - name: Check if DLL got built
         run: if (-Not (Test-Path -path "bin/Release/BigBaseV2.dll")) {throw 1}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Build 64bit release DLL
         run: |
-          msbuild /p:Configuration=Release /p:Platform=x64 BigBaseV2.sln
+          msbuild /p:Configuration=Release /p:Platform=x64 BigBaseV2.sln /warnaserror
 
       - name: Rename DLL to YimMenu.dll
         run: ren BigBaseV2.dll YimMenu.dll


### PR DESCRIPTION
As per #197, CI should run msbuild with `/warnaserror` to promote better coding practices.

Additionally, autolocker now runs on `pull_request_target` instead of `pull_request` since it/the token needs `write` permissions.

Closes: #197 