### PR TITLE
feat(hotkeys): Teleport to waypoint

### DIFF
--- a/BigBaseV2/src/core/globals.hpp
+++ b/BigBaseV2/src/core/globals.hpp
@@ -448,6 +448,7 @@ namespace big
 			this->self.super_run = j["self"]["super_run"];
 
 			this->settings.hotkeys.menu_toggle = j["settings"]["hotkeys"]["menu_toggle"];
+			this->settings.hotkeys.teleport_waypoint = j["settings"]["hotkeys"]["teleport_waypoint"];
 
 			this->spawn.preview_vehicle = j["spawn"]["preview_vehicle"];
 			this->spawn.spawn_inside = j["spawn"]["spawn_inside"];
@@ -664,7 +665,8 @@ namespace big
 				{
 					"settings", {
 						{ "hotkeys", {
-								{ "menu_toggle", this->settings.hotkeys.menu_toggle }
+								{ "menu_toggle", this->settings.hotkeys.menu_toggle },
+								{ "teleport_waypoint", this->settings.hotkeys.teleport_waypoint }
 							}
 						}
 					}

--- a/BigBaseV2/src/features.cpp
+++ b/BigBaseV2/src/features.cpp
@@ -4,11 +4,16 @@
 #include "script.hpp"
 
 #include "backend/backend.hpp"
+#include "util/teleport.hpp"
 
 namespace big
 {
 	void features::run_tick()
 	{
+		if (GetAsyncKeyState(g->settings.hotkeys.teleport_waypoint)) {
+			teleport::to_waypoint();
+		}
+
 		backend::loop();
 	}
 

--- a/BigBaseV2/src/views/settings/view_settings.cpp
+++ b/BigBaseV2/src/views/settings/view_settings.cpp
@@ -11,7 +11,6 @@ namespace big
 		if (ImGui::Hotkey("Menu Toggle", &g->settings.hotkeys.menu_toggle))
 			g->settings.hotkeys.editing_menu_toggle = true; // make our menu reappear
 
-		ImGui::Text("(Below hotkey is not implemented)");
 		ImGui::Hotkey("Teleport to waypoint", &g->settings.hotkeys.teleport_waypoint);
 
 		ImGui::PopItemWidth();


### PR DESCRIPTION
I don't like the use of `GetAsyncKeyState()`, we should probably rely on `renderer::wndproc()` instead.

The problem is that calling `teleport::to_waypoint()` from there causes a crash.
Does perhaps the function call need to be queued in the thread pool?