### PR TITLE
Received clone sync hook

### DIFF
--- a/BigBaseV2/src/core/globals.hpp
+++ b/BigBaseV2/src/core/globals.hpp
@@ -78,6 +78,7 @@ namespace big
 
 			pair send_net_info_to_lobby{};
 			pair transaction_rate_limit{};
+			pair invalid_sync{};
 		};
 
 		struct player {
@@ -348,6 +349,9 @@ namespace big
 			g->notifications.reports.log = j["notifications"]["reports"]["log"];
 			g->notifications.reports.notify = j["notifications"]["reports"]["notify"];
 
+			g->notifications.invalid_sync.notify = j["notifications"]["invalid_sync"]["notify"];
+			g->notifications.invalid_sync.log = j["notifications"]["invalid_sync"]["log"];
+
 			{
 				const auto& script_handler_j = j["notifications"]["script_event_handler"];
 				auto& script_handler = this->notifications.script_event_handler;
@@ -601,7 +605,8 @@ namespace big
 							}
 						},
 						{ "send_net_info_to_lobby", return_notify_pair(g->notifications.send_net_info_to_lobby) },
-						{ "transaction_rate_limit", return_notify_pair(g->notifications.transaction_rate_limit) }
+						{ "transaction_rate_limit", return_notify_pair(g->notifications.transaction_rate_limit) },
+						{ "invalid_sync", return_notify_pair(g->notifications.invalid_sync) }
 					}
 				},
 				{

--- a/BigBaseV2/src/function_types.hpp
+++ b/BigBaseV2/src/function_types.hpp
@@ -28,4 +28,14 @@ namespace big::functions
 	using read_bitbuf_dword = bool(rage::datBitBuffer* buffer, PVOID read, int bits);
 	using send_event_ack = void(rage::netEventMgr* event_manager, CNetGamePlayer* source_player, CNetGamePlayer* target_player, int event_index, int event_handled_bitset);
 	// Received Event Signatures END
+
+	//Sync signatures START
+	using get_sync_type_info = const char* (uint16_t sync_type, char a2);
+
+	using get_sync_tree_for_type = __int64(CNetworkObjectMgr* mgr, uint16_t sync_type);
+
+	using get_net_object = rage::netObject* (__fastcall)(CNetworkObjectMgr* mgr, int16_t id, bool unk3);
+
+	using get_net_object_for_player = rage::netObject* (__fastcall) (CNetworkObjectMgr*, int16_t, CNetGamePlayer*, bool);
+	//Sync signatures END
 }

--- a/BigBaseV2/src/hooking.cpp
+++ b/BigBaseV2/src/hooking.cpp
@@ -58,6 +58,8 @@ namespace big
 		m_player_has_left_hook("PHL", g_pointers->m_player_has_left, &hooks::player_leave),
 		// Receive Net Message
 		m_receive_net_message_hook("RNM", g_pointers->m_receive_net_message, &hooks::receive_net_message),
+		// Received clone sync
+		m_received_clone_sync_hook("RCS", g_pointers->m_received_clone_sync, &hooks::received_clone_sync),
 		//Get Network Event Data
 		m_get_network_event_data_hook("GNED", g_pointers->m_get_network_event_data, &hooks::get_network_event_data)
 	{
@@ -103,12 +105,16 @@ namespace big
 		m_receive_net_message_hook.enable();
 		m_get_network_event_data_hook.enable();
 
+		m_received_clone_sync_hook.enable();
+
 		m_enabled = true;
 	}
 
 	void hooking::disable()
 	{
 		m_enabled = false;
+
+		m_received_clone_sync_hook.disable();
 
 		m_get_network_event_data_hook.disable();
 		m_receive_net_message_hook.disable();

--- a/BigBaseV2/src/hooking.hpp
+++ b/BigBaseV2/src/hooking.hpp
@@ -53,6 +53,9 @@ namespace big
 		static bool send_net_info_to_lobby(rage::netPlayerData* player, int64_t a2, int64_t a3, DWORD* a4);
 		static bool receive_net_message(void* netConnectionManager, void* a2, rage::netConnection::InFrame* frame);
 		static void get_network_event_data(__int64 a1, rage::CEventNetwork* net_event);
+
+		//SYNC
+		static signed __int64 received_clone_sync(CNetworkObjectMgr* mgr, CNetGamePlayer* src, CNetGamePlayer* dst, unsigned __int16 sync_type, unsigned __int16 obj_id, rage::datBitBuffer* a6, unsigned __int16 a7, unsigned int timestamp);
 	};
 
 	struct minhook_keepalive
@@ -99,10 +102,12 @@ namespace big
 		detour_hook m_is_dlc_present_hook;
 
 		detour_hook m_received_event_hook;
+		detour_hook m_received_clone_sync_hook;
 		
 		detour_hook m_send_net_info_to_lobby;
 		detour_hook m_receive_net_message_hook;
 		detour_hook m_get_network_event_data_hook;
+
 	};
 
 	inline hooking *g_hooking{};

--- a/BigBaseV2/src/hooks/received_clone_sync.cpp
+++ b/BigBaseV2/src/hooks/received_clone_sync.cpp
@@ -1,0 +1,69 @@
+#include "hooking.hpp"
+#include "core/globals.hpp"
+
+namespace big {
+
+	/* Return types of this hook:
+	
+	case 1:
+		LOG(INFO) << "Player is not in our roaming bubble";
+		break;
+	case 2:
+		LOG(INFO) << "Wrong owner";
+		break;
+	case 4:
+		LOG(INFO) << "Can't apply data - no network object";
+		break;
+	case 6:
+		LOG(INFO) << "Can't apply data - no game object";
+		break;
+	case 7:
+		LOG(INFO) << "Can't apply data - network closed";
+		break;
+	case 8:
+		LOG(INFO) << "Succesfull sync";
+		break;
+	*/
+	
+
+	signed __int64 hooks::received_clone_sync(CNetworkObjectMgr* mgr,
+		CNetGamePlayer* src,
+		CNetGamePlayer* dst,
+		unsigned __int16 sync_type,
+		unsigned __int16 obj_id,
+		rage::datBitBuffer* buffer,
+		unsigned __int16 a7,
+		unsigned int timestamp) {
+
+		auto sync_tree = g_pointers->m_get_sync_tree_for_type(mgr, sync_type);
+		auto tree_name = g_pointers->m_get_sync_type_info(sync_type, 0);
+		auto net_obj = g_pointers->m_get_net_object(mgr, obj_id, true);
+		bool invalidsync = false;
+
+		if(!net_obj) net_obj = g_pointers->m_get_net_object_for_player(mgr, obj_id, src, true);
+
+		if (!net_obj) return 2;
+
+		if (!sync_tree || sync_type < 0 || sync_type > 14) invalidsync = true;
+
+		if (net_obj->m_object_type != sync_type) invalidsync = true;
+
+		//TO BE ADDED
+		//Node specific entity type checks
+
+
+		if (invalidsync) {
+
+			if (g->notifications.invalid_sync.log) LOG(WARNING) << "Invalid sync: " << "Type: " << sync_type << " Tree name: " << tree_name << " From: " << src->get_name();
+			if (g->notifications.invalid_sync.notify) g_notification_service->push_warning("Invalid sync " + std::string(src->get_name()), "Type: " + std::to_string(sync_type) + "\nType name: " + tree_name);
+
+			return 2;
+		}
+
+		auto result = g_hooking->m_received_clone_sync_hook.get_original<decltype(&received_clone_sync)>()(mgr, src, dst, sync_type, obj_id, buffer, a7, timestamp);
+
+		return result;
+
+	}
+
+}

--- a/BigBaseV2/src/pointers.cpp
+++ b/BigBaseV2/src/pointers.cpp
@@ -248,6 +248,37 @@ namespace big
 			m_get_network_event_data = ptr.as<PVOID>();
 		});
 
+		//Received clone sync
+		main_batch.add("RCS", "48 8B C4 48 89 58 08 48 89 68 10 48 89 70 18 48 89 78 20 41 54 41 56 41 57 48 83 EC 40 4C 8B F2", [this](memory::handle ptr)
+			{
+				m_received_clone_sync = ptr.as<decltype(m_received_clone_sync)>();
+			});
+
+		//Get sync type info
+		main_batch.add("GSTI", "44 0F B7 C1 4C 8D 0D ? ? ? ?", [this](memory::handle ptr)
+			{
+				m_get_sync_type_info = ptr.as<decltype(m_get_sync_type_info)>();
+			});
+
+		//Get sync tree for type
+		main_batch.add("GSTFT", "0F B7 CA 83 F9 07", [this](memory::handle ptr)
+			{
+				m_get_sync_tree_for_type = ptr.as<decltype(m_get_sync_tree_for_type)>();
+			});
+
+		//Get net object
+		main_batch.add("GNO", "E8 ? ? ? ? 0F B7 53 7C", [this](memory::handle ptr)
+			{
+				m_get_net_object = ptr.add(1).rip().as<decltype(m_get_net_object)>();
+			});
+
+		//Get net object for player
+		main_batch.add("GNOFP", "41 80 78 ? FF 74 2D 41 0F B6 40", [this](memory::handle ptr)
+			{
+				m_get_net_object_for_player = ptr.as<decltype(m_get_net_object_for_player)>();
+			});
+
+
 		auto mem_region = memory::module(nullptr);
 		main_batch.run(mem_region);
 

--- a/BigBaseV2/src/pointers.hpp
+++ b/BigBaseV2/src/pointers.hpp
@@ -77,10 +77,19 @@ namespace big
 		functions::send_event_ack* m_send_event_ack{};
 		// Received Event Signatures END
 
+		//Sync Signatures START
+		PVOID m_received_clone_sync;
+		functions::get_sync_tree_for_type* m_get_sync_tree_for_type{};
+		functions::get_sync_type_info* m_get_sync_type_info{};
+		functions::get_net_object* m_get_net_object{};
+		functions::get_net_object_for_player* m_get_net_object_for_player{};
+		//Sync Signatures END
+
 		PVOID m_send_net_info_to_lobby{};
 
 		PVOID m_receive_net_message{};
 		PVOID m_get_network_event_data{};
+	
 	};
 
 	inline pointers *g_pointers{};

--- a/BigBaseV2/src/views/settings/view_notification_settings.cpp
+++ b/BigBaseV2/src/views/settings/view_notification_settings.cpp
@@ -94,6 +94,7 @@ namespace big
 		draw_pair_option("Net Array Error", g->notifications.net_array_error);
 		draw_pair_option("Reports", g->notifications.reports);
 		draw_pair_option("Transaction Error / Rate Limit", g->notifications.transaction_rate_limit);
+		draw_pair_option("Invalid sync", g->notifications.invalid_sync);
 			
 	}
 


### PR DESCRIPTION
The received clone sync hook is responsible for handling all syncs from other clients. Some exploits include out of bounds sync types such as > 14. Apart from this there are several exploits to look out for and patch in the future. This hook is one of many to be added for adequate sync protection. Others include but are not limited to; can_apply_to_object, parse_synctree, remove clone sync etc.