### PR TITLE
feat(Detection): Disable sig scanner

### DIFF
--- a/BigBaseV2/src/backend/backend.cpp
+++ b/BigBaseV2/src/backend/backend.cpp
@@ -1,8 +1,6 @@
 #include "api/api.hpp"
 #include "backend.hpp"
-#include "fiber_pool.hpp"
 #include "looped/looped.hpp"
-#include "script.hpp"
 #include "thread_pool.hpp"
 
 namespace big
@@ -10,15 +8,16 @@ namespace big
 	void backend::loop()
 	{
 		g->attempt_save();
+		looped::system_disable_sigscanner();
 		looped::system_self_globals();
 		looped::system_update_pointers();
 
 		if (g_local_player != nullptr && !api::util::signed_in())
 		{
 			g_thread_pool->push([]
-				{
-					looped::api_login_session();
-				});
+			{
+				looped::api_login_session();
+			});
 		}
 	}
 }

--- a/BigBaseV2/src/backend/looped/looped.hpp
+++ b/BigBaseV2/src/backend/looped/looped.hpp
@@ -33,6 +33,7 @@ namespace big
 
 		static void session_local_time();
 
+		static void system_disable_sigscanner();
 		static void system_self_globals();
 		static void system_update_pointers();
 

--- a/BigBaseV2/src/backend/looped/system/disable_sigscanner.cpp
+++ b/BigBaseV2/src/backend/looped/system/disable_sigscanner.cpp
@@ -1,0 +1,21 @@
+#include "backend/looped/looped.hpp"
+#include "pointers.hpp"
+
+namespace big
+{
+	// credits: @brunph
+	void looped::system_disable_sigscanner()
+	{
+		if (g_pointers->m_tunables->isValid())
+		{
+			if (const auto ptr = g_pointers->m_tunables->getInstance(); ptr)
+			{
+				// sets the signature counter to 0
+				// preventing the array from being looped
+				// this is just an alternative protection
+				// to the one found in pointers.cpp
+				ptr->m_bCount = 0;
+			}
+		}
+	}
+}

--- a/BigBaseV2/src/pointers.cpp
+++ b/BigBaseV2/src/pointers.cpp
@@ -256,37 +256,49 @@ namespace big
 
 		//Received clone sync
 		main_batch.add("RCS", "48 8B C4 48 89 58 08 48 89 68 10 48 89 70 18 48 89 78 20 41 54 41 56 41 57 48 83 EC 40 4C 8B F2", [this](memory::handle ptr)
-			{
-				m_received_clone_sync = ptr.as<decltype(m_received_clone_sync)>();
-			});
+		{
+			m_received_clone_sync = ptr.as<decltype(m_received_clone_sync)>();
+		});
 
 		//Get sync type info
 		main_batch.add("GSTI", "44 0F B7 C1 4C 8D 0D ? ? ? ?", [this](memory::handle ptr)
-			{
-				m_get_sync_type_info = ptr.as<decltype(m_get_sync_type_info)>();
-			});
+		{
+			m_get_sync_type_info = ptr.as<decltype(m_get_sync_type_info)>();
+		});
 
 		//Get sync tree for type
 		main_batch.add("GSTFT", "0F B7 CA 83 F9 07", [this](memory::handle ptr)
-			{
-				m_get_sync_tree_for_type = ptr.as<decltype(m_get_sync_tree_for_type)>();
-			});
+		{
+			m_get_sync_tree_for_type = ptr.as<decltype(m_get_sync_tree_for_type)>();
+		});
 
 		//Get net object
 		main_batch.add("GNO", "E8 ? ? ? ? 0F B7 53 7C", [this](memory::handle ptr)
-			{
-				m_get_net_object = ptr.add(1).rip().as<decltype(m_get_net_object)>();
-			});
+		{
+			m_get_net_object = ptr.add(1).rip().as<decltype(m_get_net_object)>();
+		});
 
 		//Get net object for player
 		main_batch.add("GNOFP", "41 80 78 ? FF 74 2D 41 0F B6 40", [this](memory::handle ptr)
-			{
-				m_get_net_object_for_player = ptr.as<decltype(m_get_net_object_for_player)>();
-			});
+		{
+			m_get_net_object_for_player = ptr.as<decltype(m_get_net_object_for_player)>();
+		});
 
+		// CTunables
+		main_batch.add("T", "BF 02 00 00 00 44 8B C7", [this](memory::handle ptr)
+		{
+			m_tunables = ptr.sub(4).rip().as<decltype(m_tunables)>();
+		});
 
 		auto mem_region = memory::module(nullptr);
 		main_batch.run(mem_region);
+
+		// Credits: @brunph
+		if (auto bonus_string = mem_region.scan("62 6F 6E 75 73 00"); bonus_string)
+		{
+			const auto patch = "nyeee";
+			std::memcpy(bonus_string.as<void*>(), patch, sizeof(patch));
+		}
 
 		/**
 		 * Freemode thread restorer through VM patch

--- a/BigBaseV2/src/pointers.hpp
+++ b/BigBaseV2/src/pointers.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include "common.hpp"
+#include "atSingleton.hpp"
 #include "CNetworkPlayerMgr.hpp"
+#include "CTunables.hpp"
 #include "FriendRegistry.hpp"
 #include "gta/fwddec.hpp"
 #include "gta/enums.hpp"
@@ -24,6 +26,7 @@ namespace big
 		CPedFactory** m_ped_factory{};
 		CNetworkPlayerMgr** m_network_player_mgr{};
 		CNetworkObjectMgr** m_network_object_mgr{};
+		rage::atSingleton<rage::CTunables>* m_tunables{};
 
 		rage::CReplayInterface** m_replay_interface{};
 		functions::ptr_to_handle* m_ptr_to_handle{};

--- a/BigBaseV2/src/views/vehicle/view_spawn.cpp
+++ b/BigBaseV2/src/views/vehicle/view_spawn.cpp
@@ -29,7 +29,7 @@ namespace big
 			Ped ped = self::ped;
 
 			const auto location = ENTITY::GET_OFFSET_FROM_ENTITY_IN_WORLD_COORDS(ped, 2.f, 2.f, 0.f);
-			const Vehicle veh = vehicle::spawn(model, location, g_local_player->m_player_info->m_ped->m_navigation->m_heading + 90.f);
+			const Vehicle veh = vehicle::spawn(model, location, g_local_player->m_player_info->m_ped->m_navigation->m_right.x + 90.f);
 
 			if (g->spawn.spawn_inside)
 				PED::SET_PED_INTO_VEHICLE(PLAYER::PLAYER_PED_ID(), veh, -1);


### PR DESCRIPTION
With this PR we prevent the signature scanner from running.

This is in response to one of the strings specifically only present in YimMenu being added to signature scanner:
![image](https://user-images.githubusercontent.com/24669514/171860625-bf551670-9c23-494f-838b-efa065c52eab.png)


Credits: @brunph