### PR TITLE
Fix player still being able to perform certain in-game actions even though they are not supposed to

### DIFF
--- a/BigBaseV2/src/backend/backend.hpp
+++ b/BigBaseV2/src/backend/backend.hpp
@@ -2,18 +2,21 @@
 #include "common.hpp"
 #include "looped/looped.hpp"
 #include "script.hpp"
+#include "services/context_menu_service.hpp"
 
 namespace big
 {
-	class backend {
+	class backend
+	{
 	public:
 		static void loop();
 
-		static void self_loop() {
-
+		static void self_loop()
+		{
 			LOG(INFO) << "Starting script: Self";
 
-			while (g_running) {
+			while (g_running)
+			{
 				looped::self_clean_player();
 				looped::self_free_cam();
 				looped::self_godmode();
@@ -25,14 +28,14 @@ namespace big
 
 				script::get_current()->yield();
 			}
-
-
 		}
-		static void weapons_loop() {
 
+		static void weapons_loop()
+		{
 			LOG(INFO) << "Starting script: Weapons";
 
-			while (g_running) {
+			while (g_running)
+			{
 				looped::weapons_ammo_special_type();
 				looped::weapons_cage_gun();
 				looped::weapons_delete_gun();
@@ -49,13 +52,14 @@ namespace big
 
 				script::get_current()->yield();
 			}
-
 		}
-		static void vehicles_loop() {
 
+		static void vehicles_loop()
+		{
 			LOG(INFO) << "Starting script: Vehicles";
 
-			while (g_running) {
+			while (g_running)
+			{
 				looped::vehicle_auto_drive_to_waypoint();
 				looped::vehicle_auto_drive_wander();
 				looped::vehicle_despawn_bypass();
@@ -68,45 +72,41 @@ namespace big
 				looped::vehicle_seatbelt();
 				looped::vehicle_speedo_meter();
 
-
 				script::get_current()->yield();
 			}
-
 		}
 
-		static void turnsignal_loop() {
-
+		static void turnsignal_loop()
+		{
 			LOG(INFO) << "Starting script: turnsignal";
 
-			while (g_running) {
-
+			while (g_running)
+			{
 				looped::vehicle_turn_signals();
 
 				script::get_current()->yield();
 			}
-
 		}
 
-		static void rgbrandomizer_loop() {
-
+		static void rgbrandomizer_loop()
+		{
 			LOG(INFO) << "Starting script: rgbrandomizer";
 
-			while (g_running) {
-
+			while (g_running)
+			{
 				looped::rgb_synced_fade();
 				looped::rgb_synced_spasm();
 
 				script::get_current()->yield();
 			}
-
 		}
 
-		static void misc_loop() {
-
+		static void misc_loop()
+		{
 			LOG(INFO) << "Starting script: Miscellaneous";
 
-			while (g_running) {
-
+			while (g_running)
+			{
 				looped::hud_transition_state();
 				looped::tunables_disable_phone();
 				looped::tunables_no_idle_kick();
@@ -114,61 +114,72 @@ namespace big
 
 				script::get_current()->yield();
 			}
-
 		}
 
-		static void remote_loop() {
-
+		static void remote_loop()
+		{
 			LOG(INFO) << "Starting script: Remote";
 
-			while (g_running) {
-
+			while (g_running)
+			{
 				looped::player_never_wanted();
 				looped::player_spectate();
 
 				script::get_current()->yield();
 			}
-
 		}
 
-		static void noclip_loop() {
-
+		static void noclip_loop()
+		{
 			LOG(INFO) << "Starting script: No clip";
 
-			while (g_running) {
-
+			while (g_running)
+			{
 				looped::self_noclip();
 
 				script::get_current()->yield();
 			}
-
 		}
 
-		static void lscustoms_loop() {
-
+		static void lscustoms_loop()
+		{
 			LOG(INFO) << "Starting script: Ls customs";
 
-			while (g_running) {
-
+			while (g_running)
+			{
 				looped::vehicle_ls_customs();
 
 				script::get_current()->yield();
 			}
-
 		}
 
-		static void vehiclefly_loop() {
-
+		static void vehiclefly_loop()
+		{
 			LOG(INFO) << "Starting script: Vehicle fly";
 
-			while (g_running) {
-
+			while (g_running)
+			{
 				looped::vehicle_fly();
 
 				script::get_current()->yield();
 			}
-
 		}
 
+		static void disable_control_action_loop()
+		{
+			LOG(INFO) << "Starting script: Disable Control Action";
+
+			while (g_running)
+			{
+				looped::self_free_cam_disable_control_action();
+				looped::self_noclip_disable_control_action();
+
+				looped::custom_gun_disable_control_action();
+
+				context_menu_service::disable_control_action_loop();
+
+				script::get_current()->yield();
+			}
+		}
 	};
 }

--- a/BigBaseV2/src/backend/looped/looped.hpp
+++ b/BigBaseV2/src/backend/looped/looped.hpp
@@ -22,9 +22,11 @@ namespace big
 		static void protections_replay_interface();
 
 		static void self_clean_player();
+		static void self_free_cam_disable_control_action();
 		static void self_free_cam();
 		static void self_godmode();
 		static void self_invisibility();
+		static void self_noclip_disable_control_action();
 		static void self_noclip();
 		static void self_no_ragdoll();
 		static void self_off_radar();
@@ -32,7 +34,7 @@ namespace big
 		static void self_super_run();
 
 		static void session_local_time();
-		
+
 		static void system_self_globals();
 		static void system_update_pointers();
 
@@ -53,6 +55,7 @@ namespace big
 
 		static void weapons_ammo_special_type();
 		static void weapons_cage_gun();
+		static void custom_gun_disable_control_action();
 		static void weapons_delete_gun();
 		static void weapons_force_crosshairs();
 		static void weapons_gravity_gun();

--- a/BigBaseV2/src/backend/looped/self/free_cam.cpp
+++ b/BigBaseV2/src/backend/looped/self/free_cam.cpp
@@ -14,6 +14,33 @@ namespace big
 	static Vector3 vecPosition;
 	static Vector3 vecRot;
 
+	static const ControllerInputs controls[] =
+	{
+		ControllerInputs::INPUT_LOOK_LR,
+		ControllerInputs::INPUT_LOOK_UD,
+		ControllerInputs::INPUT_LOOK_UP_ONLY,
+		ControllerInputs::INPUT_LOOK_DOWN_ONLY,
+		ControllerInputs::INPUT_LOOK_LEFT_ONLY,
+		ControllerInputs::INPUT_LOOK_RIGHT_ONLY,
+		ControllerInputs::INPUT_LOOK_LEFT,
+		ControllerInputs::INPUT_LOOK_RIGHT,
+		ControllerInputs::INPUT_LOOK_UP,
+		ControllerInputs::INPUT_LOOK_DOWN
+	};
+
+	void looped::self_free_cam_disable_control_action()
+	{
+		if (g_local_player == nullptr) return;
+
+		if (g->self.free_cam && !bLastFreeCam)
+		{
+			PAD::DISABLE_ALL_CONTROL_ACTIONS(0);
+
+			for (const auto& control : controls)
+				PAD::DISABLE_CONTROL_ACTION(0, static_cast<int>(control), true);
+		}
+	}
+
 	void looped::self_free_cam()
 	{
 		if (g_local_player == nullptr) return;
@@ -49,24 +76,6 @@ namespace big
 
 			return;
 		}
-
-		PAD::DISABLE_ALL_CONTROL_ACTIONS(0);
-
-		const int controls[] = {
-			(int)ControllerInputs::INPUT_LOOK_LR,
-			(int)ControllerInputs::INPUT_LOOK_UD,
-			(int)ControllerInputs::INPUT_LOOK_UP_ONLY,
-			(int)ControllerInputs::INPUT_LOOK_DOWN_ONLY,
-			(int)ControllerInputs::INPUT_LOOK_LEFT_ONLY,
-			(int)ControllerInputs::INPUT_LOOK_RIGHT_ONLY,
-			(int)ControllerInputs::INPUT_LOOK_LEFT,
-			(int)ControllerInputs::INPUT_LOOK_RIGHT,
-			(int)ControllerInputs::INPUT_LOOK_UP,
-			(int)ControllerInputs::INPUT_LOOK_DOWN
-		};
-
-		for (int control : controls)
-			PAD::ENABLE_CONTROL_ACTION(2, control, true);
 
 		Vector3 vecChange = { 0.f, 0.f, 0.f };
 

--- a/BigBaseV2/src/backend/looped/self/noclip.cpp
+++ b/BigBaseV2/src/backend/looped/self/noclip.cpp
@@ -7,13 +7,14 @@
 
 namespace big
 {
-	static const int controls[] = {
-		(int)ControllerInputs::INPUT_SPRINT,
-		(int)ControllerInputs::INPUT_MOVE_UP_ONLY,
-		(int)ControllerInputs::INPUT_MOVE_DOWN_ONLY,
-		(int)ControllerInputs::INPUT_MOVE_LEFT_ONLY,
-		(int)ControllerInputs::INPUT_MOVE_RIGHT_ONLY,
-		(int)ControllerInputs::INPUT_DUCK
+	static const ControllerInputs controls[] =
+	{
+		ControllerInputs::INPUT_SPRINT,
+		ControllerInputs::INPUT_MOVE_UP_ONLY,
+		ControllerInputs::INPUT_MOVE_DOWN_ONLY,
+		ControllerInputs::INPUT_MOVE_LEFT_ONLY,
+		ControllerInputs::INPUT_MOVE_RIGHT_ONLY,
+		ControllerInputs::INPUT_DUCK
 	};
 
 	static float speed = 20.f;
@@ -24,7 +25,17 @@ namespace big
 	static Entity prev = -1;
 	static Vector3 rot{};
 
-	void looped::self_noclip() {
+	void looped::self_noclip_disable_control_action()
+	{
+		if (g->self.noclip)
+		{
+			for (const auto& control : controls)
+				PAD::DISABLE_CONTROL_ACTION(0, static_cast<int>(control), true);
+		}
+	}
+
+	void looped::self_noclip()
+	{
 		bool bNoclip = g->self.noclip;
 
 		Vector3 location = self::pos;
@@ -41,9 +52,6 @@ namespace big
 
 		if (bNoclip)
 		{
-			for (int control : controls)
-				PAD::DISABLE_CONTROL_ACTION(0, control, true);
-
 			Vector3 vel = { 0.f, 0.f, 0.f };
 			float heading = 0.f;
 

--- a/BigBaseV2/src/backend/looped/weapons/cage_gun.cpp
+++ b/BigBaseV2/src/backend/looped/weapons/cage_gun.cpp
@@ -5,12 +5,6 @@
 
 namespace big
 {
-	static const int controls[] = {
-		(int)ControllerInputs::INPUT_WEAPON_WHEEL_NEXT,
-		(int)ControllerInputs::INPUT_WEAPON_WHEEL_PREV,
-		(int)ControllerInputs::INPUT_ATTACK
-	};
-
 	void looped::weapons_cage_gun()
 	{
 		bool bCageGun = g->weapons.custom_weapon == CustomWeapon::CAGE_GUN;
@@ -19,10 +13,6 @@ namespace big
 		{
 			if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_AIM))
 			{
-				PLAYER::DISABLE_PLAYER_FIRING(self::id, true);
-				for (int control : controls)
-					PAD::DISABLE_CONTROL_ACTION(0, control, true);
-
 				if (PAD::IS_DISABLED_CONTROL_JUST_RELEASED(0, (int)ControllerInputs::INPUT_ATTACK))
 				{
 					Entity entity;

--- a/BigBaseV2/src/backend/looped/weapons/custom_gun_disable_control_action.cpp
+++ b/BigBaseV2/src/backend/looped/weapons/custom_gun_disable_control_action.cpp
@@ -1,0 +1,29 @@
+#include "backend/looped/looped.hpp"
+#include "natives.hpp"
+#include <gta/enums.hpp>
+
+namespace big
+{
+	static const ControllerInputs attack_controls[] =
+	{
+		ControllerInputs::INPUT_WEAPON_WHEEL_NEXT,
+		ControllerInputs::INPUT_WEAPON_WHEEL_PREV,
+		ControllerInputs::INPUT_ATTACK,
+		ControllerInputs::INPUT_ATTACK2,
+		ControllerInputs::INPUT_VEH_ATTACK,
+		ControllerInputs::INPUT_VEH_ATTACK2,
+		ControllerInputs::INPUT_VEH_PASSENGER_ATTACK,
+		ControllerInputs::INPUT_VEH_FLY_ATTACK,
+		ControllerInputs::INPUT_VEH_FLY_ATTACK2,
+	};
+
+	void looped::custom_gun_disable_control_action()
+	{
+		bool is_custom_gun_selected = g->weapons.custom_weapon != CustomWeapon::NONE;
+		if (is_custom_gun_selected)
+		{
+			for (const auto& control : attack_controls)
+				PAD::DISABLE_CONTROL_ACTION(0, static_cast<int>(control), true);
+		}
+	}
+}

--- a/BigBaseV2/src/backend/looped/weapons/delete_gun.cpp
+++ b/BigBaseV2/src/backend/looped/weapons/delete_gun.cpp
@@ -6,12 +6,6 @@
 
 namespace big
 {
-	static const int controls[] = {
-		(int)ControllerInputs::INPUT_WEAPON_WHEEL_NEXT,
-		(int)ControllerInputs::INPUT_WEAPON_WHEEL_PREV,
-		(int)ControllerInputs::INPUT_ATTACK
-	};
-
 	void looped::weapons_delete_gun()
 	{
 		bool bCageGun = g->weapons.custom_weapon == CustomWeapon::DELETE_GUN;
@@ -20,10 +14,6 @@ namespace big
 		{
 			if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_AIM))
 			{
-				PLAYER::DISABLE_PLAYER_FIRING(self::id, true);
-				for (int control : controls)
-					PAD::DISABLE_CONTROL_ACTION(0, control, true);
-
 				if (PAD::IS_DISABLED_CONTROL_JUST_RELEASED(0, (int)ControllerInputs::INPUT_ATTACK))
 				{
 					Entity entity;

--- a/BigBaseV2/src/backend/looped/weapons/gravity_gun.cpp
+++ b/BigBaseV2/src/backend/looped/weapons/gravity_gun.cpp
@@ -12,28 +12,19 @@ namespace big
 	static float dist;
 
 	static const int scroll = 0;
-	static const int controls[] = {
-		(int)ControllerInputs::INPUT_WEAPON_WHEEL_NEXT,
-		(int)ControllerInputs::INPUT_WEAPON_WHEEL_PREV,
-		(int)ControllerInputs::INPUT_ATTACK
-	};
 
 	void looped::weapons_gravity_gun()
 	{
-		bool bGravityGun = g->weapons.custom_weapon == CustomWeapon::GRAVITY_GUN;
-		double multiplier = 3.0;
+		bool is_gravity_gun_selected = g->weapons.custom_weapon == CustomWeapon::GRAVITY_GUN;
+		constexpr double multiplier = 3.0;
 
-		// ZOOMED IN
-		if (bGravityGun && PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_AIM))
+		auto is_zoomed_in = is_gravity_gun_selected && PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_AIM);
+		if (is_zoomed_in)
 		{
-			PLAYER::DISABLE_PLAYER_FIRING(self::id, true);
-			for (int control : controls)
-				PAD::DISABLE_CONTROL_ACTION(0, control, true);
-
 			location = self::pos;
 
-			// Attack RELEASED
-			if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_ATTACK) && ent == 0)
+			auto is_attack_released = PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_ATTACK) && ent == 0;
+			if (is_attack_released)
 			{
 				if (entity::raycast(&ent))
 				{

--- a/BigBaseV2/src/backend/looped/weapons/repair_gun.cpp
+++ b/BigBaseV2/src/backend/looped/weapons/repair_gun.cpp
@@ -5,12 +5,6 @@
 
 namespace big
 {
-	static const int controls[] = {
-		(int)ControllerInputs::INPUT_WEAPON_WHEEL_NEXT,
-		(int)ControllerInputs::INPUT_WEAPON_WHEEL_PREV,
-		(int)ControllerInputs::INPUT_ATTACK
-	};
-
 	void looped::weapons_repair_gun()
 	{
 		bool bRepairGun = g->weapons.custom_weapon == CustomWeapon::REPAIR_GUN;
@@ -19,10 +13,6 @@ namespace big
 		{
 			if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_AIM))
 			{
-				PLAYER::DISABLE_PLAYER_FIRING(self::id, true);
-				for (int control : controls)
-					PAD::DISABLE_CONTROL_ACTION(0, control, true);
-
 				if (PAD::IS_DISABLED_CONTROL_JUST_RELEASED(0, (int)ControllerInputs::INPUT_ATTACK))
 				{
 					Entity entity;

--- a/BigBaseV2/src/backend/looped/weapons/steal_vehicle_gun.cpp
+++ b/BigBaseV2/src/backend/looped/weapons/steal_vehicle_gun.cpp
@@ -5,11 +5,6 @@
 
 namespace big
 {
-	static const int controls[] = {
-		(int)ControllerInputs::INPUT_WEAPON_WHEEL_NEXT,
-		(int)ControllerInputs::INPUT_WEAPON_WHEEL_PREV,
-		(int)ControllerInputs::INPUT_ATTACK
-	};
 	static Entity ent;
 
 	void looped::weapons_steal_vehicle_gun()
@@ -18,10 +13,6 @@ namespace big
 		{
 			if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_AIM))
 			{
-				PLAYER::DISABLE_PLAYER_FIRING(self::id, true);
-				for (const int control : controls)
-					PAD::DISABLE_CONTROL_ACTION(0, control, true);
-
 				if (PAD::IS_DISABLED_CONTROL_JUST_RELEASED(0, (int)ControllerInputs::INPUT_ATTACK))
 				{
 					if (entity::raycast(&ent))

--- a/BigBaseV2/src/backend/looped/weapons/vehicle_gun.cpp
+++ b/BigBaseV2/src/backend/looped/weapons/vehicle_gun.cpp
@@ -5,11 +5,6 @@
 
 namespace big
 {
-	static const int controls[] = {
-		(int)ControllerInputs::INPUT_WEAPON_WHEEL_NEXT,
-		(int)ControllerInputs::INPUT_WEAPON_WHEEL_PREV,
-		(int)ControllerInputs::INPUT_ATTACK
-	};
 
 	void looped::weapons_vehicle_gun()
 	{
@@ -17,13 +12,8 @@ namespace big
 
 		if (bVehicleGun)
 		{
-
 			if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_AIM))
 			{
-				PLAYER::DISABLE_PLAYER_FIRING(self::id, true);
-				for (int control : controls)
-					PAD::DISABLE_CONTROL_ACTION(0, control, true);
-
 				if (PAD::IS_DISABLED_CONTROL_JUST_RELEASED(0, (int)ControllerInputs::INPUT_ATTACK))
 				{
 					Vector3 location = self::pos;

--- a/BigBaseV2/src/main.cpp
+++ b/BigBaseV2/src/main.cpp
@@ -94,6 +94,7 @@ BOOL APIENTRY DllMain(HMODULE hmod, DWORD reason, PVOID)
 				g_script_mgr.add_script(std::make_unique<script>(&backend::vehiclefly_loop));
 				g_script_mgr.add_script(std::make_unique<script>(&backend::rgbrandomizer_loop));
 				g_script_mgr.add_script(std::make_unique<script>(&backend::turnsignal_loop));
+				g_script_mgr.add_script(std::make_unique<script>(&backend::disable_control_action_loop));
 				g_script_mgr.add_script(std::make_unique<script>(&context_menu_service::context_menu));
 				LOG(INFO) << "Scripts registered.";
 

--- a/BigBaseV2/src/services/context_menu_service.cpp
+++ b/BigBaseV2/src/services/context_menu_service.cpp
@@ -110,7 +110,6 @@ namespace big
 					const auto pos = temp_pointer->m_navigation->m_position;
 					HUD::GET_HUD_SCREEN_POSITION_FROM_WORLD_POSITION(pos.x, pos.y, pos.z, &screen_pos.x, &screen_pos.y);
 					if (distance_to_middle_of_screen(screen_pos) < distance &&
-						ENTITY::HAS_ENTITY_CLEAR_LOS_TO_ENTITY(PLAYER::PLAYER_PED_ID(), temp_handle, 17) &&
 						temp_handle != PLAYER::PLAYER_PED_ID()) {
 						m_handle = temp_handle;
 						m_pointer = temp_pointer;
@@ -138,6 +137,31 @@ namespace big
 			menu.menu_size = { (10.f * static_cast<float>(max_size)) + 10.f , 2 * (10.f * static_cast<float>(menu.options.size())) + 10.f };
 		}
 	}
+
+	static const ControllerInputs controls[] =
+	{
+		ControllerInputs::INPUT_NEXT_WEAPON,
+		ControllerInputs::INPUT_PREV_WEAPON,
+		ControllerInputs::INPUT_VEH_NEXT_RADIO,
+		ControllerInputs::INPUT_VEH_SELECT_NEXT_WEAPON,
+		ControllerInputs::INPUT_SELECT_NEXT_WEAPON,
+		ControllerInputs::INPUT_SELECT_PREV_WEAPON,
+		ControllerInputs::INPUT_WEAPON_WHEEL_NEXT,
+		ControllerInputs::INPUT_WEAPON_WHEEL_PREV,
+		ControllerInputs::INPUT_ATTACK,
+		ControllerInputs::INPUT_SPECIAL_ABILITY,
+		ControllerInputs::INPUT_VEH_MOUSE_CONTROL_OVERRIDE,
+	};
+
+	void context_menu_service::disable_control_action_loop()
+	{
+		if (g_context_menu_service->enabled)
+		{
+			for (const auto& control : controls)
+				PAD::DISABLE_CONTROL_ACTION(0, static_cast<int>(control), true);
+		}
+	}
+
 	void context_menu_service::context_menu()
 	{
 		while (g_running)
@@ -156,18 +180,6 @@ namespace big
 
 			if (g_context_menu_service->enabled)
 			{
-				PAD::DISABLE_CONTROL_ACTION(0, (int)ControllerInputs::INPUT_NEXT_WEAPON, true);
-				PAD::DISABLE_CONTROL_ACTION(0, (int)ControllerInputs::INPUT_PREV_WEAPON, true);
-				PAD::DISABLE_CONTROL_ACTION(0, (int)ControllerInputs::INPUT_VEH_NEXT_RADIO, true);
-				PAD::DISABLE_CONTROL_ACTION(0, (int)ControllerInputs::INPUT_VEH_SELECT_NEXT_WEAPON, true);
-				PAD::DISABLE_CONTROL_ACTION(0, (int)ControllerInputs::INPUT_SELECT_NEXT_WEAPON, true);
-				PAD::DISABLE_CONTROL_ACTION(0, (int)ControllerInputs::INPUT_SELECT_PREV_WEAPON, true);
-				PAD::DISABLE_CONTROL_ACTION(0, (int)ControllerInputs::INPUT_WEAPON_WHEEL_NEXT, true);
-				PAD::DISABLE_CONTROL_ACTION(0, (int)ControllerInputs::INPUT_WEAPON_WHEEL_PREV, true);
-				PAD::DISABLE_CONTROL_ACTION(0, (int)ControllerInputs::INPUT_ATTACK, true);
-				PAD::DISABLE_CONTROL_ACTION(0, (int)ControllerInputs::INPUT_SPECIAL_ABILITY, true);
-				PAD::DISABLE_CONTROL_ACTION(0, (int)ControllerInputs::INPUT_VEH_MOUSE_CONTROL_OVERRIDE, true);
-
 				g_context_menu_service->get_entity_closest_to_screen_center();
 
 				const auto cm = g_context_menu_service->get_context_menu();

--- a/BigBaseV2/src/services/context_menu_service.hpp
+++ b/BigBaseV2/src/services/context_menu_service.hpp
@@ -48,6 +48,7 @@ namespace big
 		void get_entity_closest_to_screen_center();
 		void load_shared();
 
+		static void disable_control_action_loop();
 		static void context_menu();
 
 		Entity m_handle;


### PR DESCRIPTION
Multiple menu features disable in-game actions with native calls like `DISABLE_CONTROL_ACTION`.
Currently most of them are not working as expected.
My understanding is that some of the looped scripts that these natives are used in are "too big" and are not fast enough to be called every frame, making `DISABLE_CONTROL_ACTION` not work correctly.

Fix: Make `DISABLE_CONTROL_ACTION` calls in their own script thread