### PR TITLE
Feat vehicle gun improv 

### DIFF
--- a/BigBaseV2/src/backend/looped/weapons/vehicle_gun.cpp
+++ b/BigBaseV2/src/backend/looped/weapons/vehicle_gun.cpp
@@ -3,7 +3,6 @@
 #include "util/math.hpp"
 #include "util/vehicle.hpp"
 #include <gui.hpp>
-#include <chrono>
 
 namespace big
 {

--- a/BigBaseV2/src/backend/looped/weapons/vehicle_gun.cpp
+++ b/BigBaseV2/src/backend/looped/weapons/vehicle_gun.cpp
@@ -2,7 +2,7 @@
 #include "core/enums.hpp"
 #include "util/math.hpp"
 #include "util/vehicle.hpp"
-#include <gui.hpp>
+#include "gui.hpp"
 
 namespace big
 {
@@ -12,7 +12,7 @@ namespace big
 	{
 		const bool is_vehicle_gun_selected = g->weapons.custom_weapon == CustomWeapon::VEHICLE_GUN;
 
-		auto time_now = std::chrono::steady_clock::now();
+		const auto time_now = std::chrono::steady_clock::now();
 
 		const auto elapsed_time_in_ms = std::chrono::duration_cast<std::chrono::milliseconds>(time_now - last_time).count();
 

--- a/BigBaseV2/src/backend/looped/weapons/vehicle_gun.cpp
+++ b/BigBaseV2/src/backend/looped/weapons/vehicle_gun.cpp
@@ -2,47 +2,62 @@
 #include "core/enums.hpp"
 #include "util/math.hpp"
 #include "util/vehicle.hpp"
+#include <gui.hpp>
+#include <chrono>
 
 namespace big
 {
+	static auto last_time = std::chrono::steady_clock::now();
 
 	void looped::weapons_vehicle_gun()
 	{
-		bool bVehicleGun = g->weapons.custom_weapon == CustomWeapon::VEHICLE_GUN;
+		const bool is_vehicle_gun_selected = g->weapons.custom_weapon == CustomWeapon::VEHICLE_GUN;
 
-		if (bVehicleGun)
+		auto time_now = std::chrono::steady_clock::now();
+
+		const auto elapsed_time_in_ms = std::chrono::duration_cast<std::chrono::milliseconds>(time_now - last_time).count();
+
+		if (is_vehicle_gun_selected &&
+			!g_gui.m_opened &&
+			elapsed_time_in_ms >= 100 &&
+			PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_ATTACK))
 		{
-			if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_AIM))
+			Vector3 location = self::pos;
+
+			constexpr int rotation_order = 2;
+
+			Vector3 rot = CAM::GET_GAMEPLAY_CAM_ROT(rotation_order);
+			float pitch = math::deg_to_rad(rot.x); // vertical
+			//float roll = rot.y;
+			float yaw = math::deg_to_rad(rot.z + 90); // horizontal
+
+			float dist = 10.f;
+			location.x += dist * cos(pitch) * cos(yaw);
+			location.y += dist * sin(yaw) * cos(pitch);
+			location.z += dist * sin(pitch);
+			Vehicle veh = vehicle::spawn(
+				(const char*)g->weapons.vehicle_gun_model,
+				location,
+				ENTITY::GET_ENTITY_HEADING(self::ped)
+			);
+
+			dist = 150.f;
+			Vector3 velocity
 			{
-				if (PAD::IS_DISABLED_CONTROL_JUST_RELEASED(0, (int)ControllerInputs::INPUT_ATTACK))
-				{
-					Vector3 location = self::pos;
+				dist * cos(pitch) * cos(yaw),
+				dist * sin(yaw) * cos(pitch),
+				dist * sin(pitch)
+			};
 
-					Vector3 rot = CAM::GET_GAMEPLAY_CAM_ROT(2);
-					float pitch = math::deg_to_rad(rot.x); // vertical
-					//float roll = rot.y;
-					float yaw = math::deg_to_rad(rot.z + 90); // horizontal
+			ENTITY::SET_ENTITY_ROTATION(veh, rot.x, rot.y, rot.z, rotation_order, 1);
+			ENTITY::SET_ENTITY_VELOCITY(veh, velocity.x, velocity.y, velocity.z);
 
-					float dist = 10.f;
-					location.x += dist * cos(pitch) * cos(yaw);
-					location.y += dist * sin(yaw) * cos(pitch);
-					location.z += dist * sin(pitch);
-					Vehicle veh = vehicle::spawn(
-						(const char*)g->weapons.vehicle_gun_model,
-						location,
-						ENTITY::GET_ENTITY_HEADING(self::ped)
-					);
+			// flagging the veh as no longer needed so that the game can remove it
+			// when reaching the maximum vehicle limit,
+			// allowing the vehicle gun to keep working
+			ENTITY::SET_VEHICLE_AS_NO_LONGER_NEEDED(&veh);
 
-					Vector3 velocity;
-					dist = 150.f;
-					velocity.x = dist * cos(pitch) * cos(yaw);
-					velocity.y = dist * sin(yaw) * cos(pitch);
-					velocity.z = dist * sin(pitch);
-
-					ENTITY::SET_ENTITY_ROTATION(veh, rot.x, rot.y, rot.z, 2, 1);
-					ENTITY::SET_ENTITY_VELOCITY(veh, velocity.x, velocity.y, velocity.z);
-				}
-			}
+			last_time = time_now;
 		}
 	}
 }

--- a/BigBaseV2/src/views/self/view_weapons.cpp
+++ b/BigBaseV2/src/views/self/view_weapons.cpp
@@ -89,8 +89,10 @@ namespace big
 		switch (selected)
 		{
 		case CustomWeapon::VEHICLE_GUN:
-			ImGui::Text("Shooting Model:");
-			ImGui::InputText("##vehicle_gun_model", g->weapons.vehicle_gun_model, 12);
+			components::input_text_with_hint(
+				"Shooting Model",
+				"Name of the vehicle model",
+				g->weapons.vehicle_gun_model, sizeof(g->weapons.vehicle_gun_model));
 
 			break;
 		}


### PR DESCRIPTION
- add some delay between shoots so that freshly spawned car doesnt replace the last one
- mark veh as no longer needed so that we can always keep shooting
- fix game input not correctly disabled while typing vehicle gun model text