### PR TITLE
feat(premake): commented debug build

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -4,9 +4,8 @@ workspace "BigBaseV2"
 
 	configurations
 	{
-		"Debug",
-		"Release",
-		"Dist"
+		-- "Debug", -- Debug isn't buildable and causes confusion for new people
+		"Release"
 	}
 
 	outputdir = "%{cfg.buildcfg}"
@@ -239,10 +238,6 @@ workspace "BigBaseV2"
 		    defines { "DEBUG" }
 
 		filter "configurations:Release"
-		    flags { "NoManifest" }
-		    defines { "RELEASE" }
-		    optimize "speed"
-		filter "configurations:Dist"
 		    flags { "FatalWarnings", "NoManifest" }
-		    defines { "DIST" }
+		    defines { "RELEASE" }
 		    optimize "speed"


### PR DESCRIPTION
This PR removes the debug build option as it causes confusion for people who use YimMenu for the first time.

People who still wish to use the debug build are free to uncomment the line in `premake5.lua`.
The debug build is not buildable due to some conflicting definitions but that's for you to figure out.