### PR TITLE
Improve and optimise session local_time

### DIFF
--- a/BigBaseV2/src/backend/looped/session/local_time.cpp
+++ b/BigBaseV2/src/backend/looped/session/local_time.cpp
@@ -3,22 +3,24 @@
 
 namespace big
 {
-	static bool lastOverride = true;
+	static bool toggled = true;
 
 	void looped::session_local_time()
 	{
-		if (lastOverride && !g->session.override_time)
-		{
-			NETWORK::NETWORK_GET_GLOBAL_MULTIPLAYER_CLOCK(&g->session.custom_time.hour, &g->session.custom_time.minute, &g->session.custom_time.second);
-			NETWORK::NETWORK_OVERRIDE_CLOCK_TIME(g->session.custom_time.hour, g->session.custom_time.minute, g->session.custom_time.second);
-			NETWORK::NETWORK_CLEAR_CLOCK_TIME_OVERRIDE();
-			lastOverride = false;
-		}
-
 		if (g->session.override_time)
 		{
+			if (toggled)
+			{
+				NETWORK::NETWORK_GET_GLOBAL_MULTIPLAYER_CLOCK(&g->session.custom_time.hour, &g->session.custom_time.minute, &g->session.custom_time.second);
+				toggled = false;
+			}
+
 			NETWORK::NETWORK_OVERRIDE_CLOCK_TIME(g->session.custom_time.hour, g->session.custom_time.minute, g->session.custom_time.second);
-			lastOverride = true;
+		}
+		else
+		{
+			NETWORK::NETWORK_CLEAR_CLOCK_TIME_OVERRIDE();
+			toggled = true;
 		}
 	}
 }


### PR DESCRIPTION
Local time has a transition to revert back to global session time when used in online.
Credits to @xM4ddy 
