### PR TITLE
feat(Notifications): Removed old net array notification options

### DIFF
--- a/BigBaseV2/src/core/globals.hpp
+++ b/BigBaseV2/src/core/globals.hpp
@@ -66,8 +66,6 @@ namespace big
 			pair gta_thread_kill{};
 			pair gta_thread_start{};
 
-			pair net_array_error{};
-
 			pair network_player_mgr_init{};
 			pair network_player_mgr_shutdown{};
 
@@ -382,9 +380,6 @@ namespace big
 			g->notifications.gta_thread_start.log = j["notifications"]["gta_thread_start"]["log"];
 			g->notifications.gta_thread_start.notify = j["notifications"]["gta_thread_start"]["notify"];
 
-			g->notifications.net_array_error.log = j["notifications"]["net_array_error"]["log"];
-			g->notifications.net_array_error.notify = j["notifications"]["net_array_error"]["notify"];
-
 			g->notifications.network_player_mgr_init.log = j["notifications"]["network_player_mgr_init"]["log"];
 			g->notifications.network_player_mgr_init.notify = j["notifications"]["network_player_mgr_init"]["notify"];
 			g->notifications.network_player_mgr_shutdown.log = j["notifications"]["network_player_mgr_shutdown"]["log"];
@@ -664,7 +659,6 @@ namespace big
 					"notifications", {
 						{ "gta_thread_kill", return_notify_pair(g->notifications.gta_thread_kill) },
 						{ "gta_thread_start", return_notify_pair(g->notifications.gta_thread_start) },
-						{ "net_array_error", return_notify_pair(g->notifications.net_array_error) },
 						{ "network_player_mgr_init", return_notify_pair(g->notifications.network_player_mgr_init) },
 						{ "network_player_mgr_shutdown", return_notify_pair(g->notifications.network_player_mgr_shutdown) },
 						{ "player_join", {

--- a/BigBaseV2/src/views/settings/view_notification_settings.cpp
+++ b/BigBaseV2/src/views/settings/view_notification_settings.cpp
@@ -93,8 +93,7 @@ namespace big
 		ImGui::EndGroup();
 
 		components::small_text("Other");
-
-		draw_pair_option("Net Array Error", g->notifications.net_array_error);
+		
 		draw_pair_option("Reports", g->notifications.reports);
 		draw_pair_option("Transaction Error / Rate Limit", g->notifications.transaction_rate_limit);
 		draw_pair_option("Invalid sync", g->notifications.invalid_sync);


### PR DESCRIPTION
Removes the old settings that serve no purpose as the Net Array Handler hook has been removed in #360 