### PR TITLE
refactor: Cleaned up Received Clone Sync hook

### DIFF
--- a/BigBaseV2/src/hooks/protections/received_clone_sync.cpp
+++ b/BigBaseV2/src/hooks/protections/received_clone_sync.cpp
@@ -1,49 +1,26 @@
 #include "hooking.hpp"
 #include "core/globals.hpp"
-#include "natives.hpp"
 #include "network/netObject.hpp"
 #include "base/CBaseModelInfo.hpp"
 #include "vehicle/CVehicleModelInfo.hpp"
 #include "base/CObject.hpp"
+#include "util/model_info.hpp"
 
-namespace big {
-
-	/* Return types of this hook:
+namespace big
+{
+	enum SyncResponse : int64_t
+	{
+		NoSyncTreeFound = 1, // No sync tree found
+		PlayerIsNotInOurRoamingBubble = 1, // Player is not in our roaming bubble
+		WrongOwner = 2, // Wrong owner
+		ObjectIsBeingReassinged = 2, // Object is being reassigned
+		CantApplyData_NoNetworkObject = 4, // Can't apply data - no network object
+		CantApplyData = 6, // Can't apply data
+		CantApplyData_NoGameObject = 6, // Can't apply data - no game object
+		CantApplyData_NetworkClosed = 7, // Can't apply data - network closed
+		SuccessfullSync = 8
+	};
 	
-	case 1:
-		LOG(INFO) << "Player is not in our roaming bubble";
-		break;
-	case 2:
-		LOG(INFO) << "Wrong owner";
-		break;
-	case 4:
-		LOG(INFO) << "Can't apply data - no network object";
-		break;
-	case 6:
-		LOG(INFO) << "Can't apply data - no game object";
-		break;
-	case 7:
-		LOG(INFO) << "Can't apply data - network closed";
-		break;
-	case 8:
-		LOG(INFO) << "Succesfull sync";
-		break;
-	*/
-	
-	const CVehicleModelInfo* get_model_data(rage::joaat_t hash) {
-		auto modelTble = g_pointers->m_model_table;
-		for (auto i = modelTble->m_lookup_table[hash % modelTble->m_lookup_key]; i; i = i->m_next)
-		{
-			if (i->m_hash == hash)
-			{
-				if (const auto model = modelTble->m_data[i->m_idx]; model)
-				{
-					return reinterpret_cast<CVehicleModelInfo*>(model);
-				}
-			}
-		}
-		return nullptr;
-	}
 	int64_t hooks::received_clone_sync(CNetworkObjectMgr* mgr, CNetGamePlayer* src, CNetGamePlayer* dst, eObjType sync_type, uint16_t obj_id, rage::datBitBuffer* buffer, uint16_t unk, uint32_t timestamp) {
 		if (auto sync_tree = g_pointers->m_get_sync_tree_for_type(mgr, sync_type); sync_tree && *g_pointers->m_is_session_started)
 		{
@@ -66,30 +43,34 @@ namespace big {
 					if (g->notifications.mismatch_sync_type.notify)
 						g_notification_service->push_warning(fmt::format("Mismatch Sync from {}", src->get_name()), fmt::format("Type {} in sync tree {}", sync_type, tree_name));
 
-					return 2;
+					return SyncResponse::WrongOwner;
 				}
 				else if (auto game_obj = net_obj->GetGameObject(); game_obj)
 				{
 					if (auto model_info = game_obj->m_model_info)
 					{
-						if (!STREAMING::IS_MODEL_VALID(model_info->m_model_hash))
+						if (!model_info::does_model_exist(model_info->m_model_hash))
 						{
-							return 2;
+							return SyncResponse::WrongOwner;
 						}
-						else if (reinterpret_cast<CVehicleModelInfo*>(model_info)->m_vehicle_type != get_model_data(model_info->m_model_hash)->m_vehicle_type)
+						
+						const auto model = model_info::get_model(model_info->m_model_hash);
+						if (model_info->m_model_type != model->m_model_type)
 						{
-							return 2;
+							return SyncResponse::WrongOwner;
 						}
-						else if (model_info->m_model_type != get_model_data(model_info->m_model_hash)->m_model_type)
+
+						if (model->m_model_type == eModelType::Vehicle &&
+							reinterpret_cast<CVehicleModelInfo*>(model_info)->m_vehicle_type != reinterpret_cast<CVehicleModelInfo*>(model)->m_vehicle_type)
 						{
-							return 2;
+							return SyncResponse::WrongOwner;
 						}
 					}
 				}
 			}
 			else if (sync_type != eObjType::pedObjType) //We don't want to not sync a player, so we ensure it's not a ped
 			{
-				return 2;
+				return SyncResponse::WrongOwner;
 			}
 		}
 		return g_hooking->m_received_clone_sync_hook.get_original<decltype(&received_clone_sync)>()(mgr, src, dst, sync_type, obj_id, buffer, unk, timestamp);

--- a/BigBaseV2/src/hooks/protections/received_clone_sync.cpp
+++ b/BigBaseV2/src/hooks/protections/received_clone_sync.cpp
@@ -49,13 +49,8 @@ namespace big
 				{
 					if (auto model_info = game_obj->m_model_info)
 					{
-						if (!model_info::does_model_exist(model_info->m_model_hash))
-						{
-							return SyncResponse::WrongOwner;
-						}
-						
 						const auto model = model_info::get_model(model_info->m_model_hash);
-						if (model_info->m_model_type != model->m_model_type)
+						if (!model || model_info->m_model_type != model->m_model_type)
 						{
 							return SyncResponse::WrongOwner;
 						}


### PR DESCRIPTION
Don't rely on the native IS_MODEL_VALID in a hook and instead use the model_info wrapper class I made.
This should fix the issue where the received clone sync hook calls the native without being cached yet.

I cleaned up some of the if statements and added an enum for the return values.