### PR TITLE
Fix reinjection after unloading (#472)

### DIFF
--- a/BigBaseV2/src/memory/range.cpp
+++ b/BigBaseV2/src/memory/range.cpp
@@ -106,6 +106,22 @@ namespace memory
 
 		return true;
 	}
+
+	handle range::bruteforce_scan(pattern const& sig)
+	{
+		auto data = sig.m_bytes.data();
+		auto length = sig.m_bytes.size();
+
+		const auto scan_end = m_size - length;
+		for (std::uintptr_t i{}; i != scan_end; ++i)
+		{
+			if (pattern_matches(m_base.add(i).as<std::uint8_t*>(), data, length))
+			{
+				return m_base.add(i);
+			}
+		}
+	}
+
 	std::vector<handle> range::scan_all(pattern const &sig)
 	{
 		std::vector<handle> result{};

--- a/BigBaseV2/src/memory/range.cpp
+++ b/BigBaseV2/src/memory/range.cpp
@@ -120,6 +120,8 @@ namespace memory
 				return m_base.add(i);
 			}
 		}
+
+		return nullptr;
 	}
 
 	std::vector<handle> range::scan_all(pattern const &sig)

--- a/BigBaseV2/src/memory/range.hpp
+++ b/BigBaseV2/src/memory/range.hpp
@@ -17,6 +17,7 @@ namespace memory
 		bool contains(handle h);
 
 		handle scan(pattern const& sig);
+		handle bruteforce_scan(pattern const& sig);
 		std::vector<handle> scan_all(pattern const& sig);
 	protected:
 		handle m_base;

--- a/BigBaseV2/src/pointers.cpp
+++ b/BigBaseV2/src/pointers.cpp
@@ -345,13 +345,13 @@ namespace big
 		 * Freemode thread restorer through VM patch
 		*/
 
-		if (auto pat1 = mem_region.scan("3b 0a 0f 83 ? ? ? ? 48 ff c7"))
+		if (auto pat1 = mem_region.bruteforce_scan("3b 0a 0f 83 ? ? ? ? 48 ff c7"))
 		{
 			*pat1.add(2).as<uint32_t*>() = 0xc9310272;
 			*pat1.add(6).as<uint16_t*>() = 0x9090;
 		}
 
-		if (auto pat2 = mem_region.scan("3b 0a 0f 83 ? ? ? ? 49 03 fa"))
+		if (auto pat2 = mem_region.bruteforce_scan("3b 0a 0f 83 ? ? ? ? 49 03 fa"))
 		{
 			*pat2.add(2).as<uint32_t*>() = 0xc9310272;
 			*pat2.add(6).as<uint16_t*>() = 0x9090;


### PR DESCRIPTION
Issue was persistent with PR #470 & #471, Reasoning was the Script VM patch failing to be found after byte patch (Pattern scanner works by jumping around bytes, and when they change, it fails)
Solution: Create a legacy bruteforce_scan function for patches