### PR TITLE
fix(Console): Issue with disabling the close button of console

### DIFF
--- a/BigBaseV2/src/main.cpp
+++ b/BigBaseV2/src/main.cpp
@@ -50,7 +50,7 @@ BOOL APIENTRY DllMain(HMODULE hmod, DWORD reason, PVOID)
 				file_manager_instance->get_project_file("./cout.log")
 			);
 
-			EnableMenuItem(GetSystemMenu(FindWindowA(NULL, "YimMenu"), 0), SC_CLOSE, MF_BYCOMMAND | MF_DISABLED | MF_GRAYED);
+			EnableMenuItem(GetSystemMenu(GetConsoleWindow(), 0), SC_CLOSE, MF_BYCOMMAND | MF_DISABLED | MF_GRAYED);
 
 			try
 			{


### PR DESCRIPTION
This PR fixes an issue where YimMenu would disable the close button not of itself but could possibly disable the close button of other windows that were called "YimMenu".

Example to reproduce the bug:
1. Open Windows Explorer
2. Create folder called "YimMenu"
3. Inject YimMenu
4. Result YimMenu might disable the close button of Windows Explorer instead of the console Window