### PR TITLE
fix(BytePatch): To ensure proper cleanup make use of unique_ptr

### DIFF
--- a/BigBaseV2/src/memory/byte_patch.hpp
+++ b/BigBaseV2/src/memory/byte_patch.hpp
@@ -10,32 +10,24 @@ namespace memory
 			memcpy(m_address, m_original_bytes.data(), m_original_bytes.size());
 		}
 
-		/// <summary>
-		/// To guarantee proper restoration of bytes all shared_ptr instances will be invalidated that point to this object.
-		/// </summary>
 		void restore() const
 		{
 			if (const auto it = std::find(m_patches.begin(), m_patches.end(), this); it != m_patches.end())
 			{
-				it->reset();
 				m_patches.erase(it);
 			}
 		}
 
 		template <typename TAddr>
-		static std::shared_ptr<byte_patch> make(TAddr address, std::remove_pointer_t<std::remove_reference_t<TAddr>> value)
+		static std::unique_ptr<byte_patch>& make(TAddr address, std::remove_pointer_t<std::remove_reference_t<TAddr>> value)
 		{
-			auto patch = std::shared_ptr<byte_patch>(new byte_patch(address, value));
-			m_patches.emplace_back(patch);
-			return patch;
+			return m_patches.emplace_back(
+				std::unique_ptr<byte_patch>(new byte_patch(address, value)));
 		}
 
 		static void restore_all()
 		{
-			for (const auto& patch : m_patches)
-			{
-				patch->restore();
-			}
+			m_patches.clear();
 		}
 
 	private:
@@ -51,16 +43,16 @@ namespace memory
 		}
 
 	protected:
-		static inline std::vector<std::shared_ptr<byte_patch>> m_patches;
+		static inline std::vector<std::unique_ptr<byte_patch>> m_patches;
 
 	private:
 		void* m_address;
 		std::vector<uint8_t> m_original_bytes;
 
-		friend bool operator== (const std::shared_ptr<byte_patch> a, const byte_patch* b);
+		friend bool operator== (const std::unique_ptr<byte_patch>& a, const byte_patch* b);
 	};
 
-	bool operator== (const std::shared_ptr<byte_patch> a, const byte_patch* b)
+	bool operator== (const std::unique_ptr<byte_patch>& a, const byte_patch* b)
 	{
 		return a->m_address == b->m_address;
 	}

--- a/BigBaseV2/src/memory/byte_patch.hpp
+++ b/BigBaseV2/src/memory/byte_patch.hpp
@@ -19,7 +19,7 @@ namespace memory
 		}
 
 		template <typename TAddr>
-		static std::unique_ptr<byte_patch>& make(TAddr address, std::remove_pointer_t<std::remove_reference_t<TAddr>> value)
+		static const std::unique_ptr<byte_patch>& make(TAddr address, std::remove_pointer_t<std::remove_reference_t<TAddr>> value)
 		{
 			return m_patches.emplace_back(
 				std::unique_ptr<byte_patch>(new byte_patch(address, value)));


### PR DESCRIPTION
Because I injected the wrong DLL while testing #486, this PR is meant to fix my mistakes.