### PR TITLE
refactor: simplify metric logger

### DIFF
--- a/BigBaseV2/src/core/globals.hpp
+++ b/BigBaseV2/src/core/globals.hpp
@@ -17,7 +17,12 @@ namespace big
 
 		struct debug
 		{
-			bool script_event_logging = false;
+			struct
+			{
+				bool metric_logs{};
+
+				bool script_event_logs = false;
+			} logs{};
 		};
 
 		struct notifications
@@ -294,14 +299,8 @@ namespace big
 			char vehicle_gun_model[12] = "bus";
 		};
 
-		struct window {
-			bool debug = false;
-			bool handling = false;
-			bool log = false;
-			bool main = true;
-			bool users = true;
-			bool player = false;
-
+		struct window
+		{
 			ImU32 color = 3357612055;
 			float gui_scale = 1.f;
 
@@ -395,7 +394,8 @@ namespace big
 
 		void from_json(const nlohmann::json& j)
 		{
-			this->debug.script_event_logging = j["debug"]["script_event_logging"];
+			this->debug.logs.metric_logs = j["debug"]["logs"]["metric_logs"];
+			this->debug.logs.script_event_logs = j["debug"]["logs"]["script_event_logs"];
 
 			g->notifications.gta_thread_kill.log = j["notifications"]["gta_thread_kill"]["log"];
 			g->notifications.gta_thread_kill.notify = j["notifications"]["gta_thread_kill"]["notify"];
@@ -631,11 +631,6 @@ namespace big
 
 			this->window.color = j["window"]["color"];
 			this->window.gui_scale = j["window"]["gui_scale"];
-			this->window.debug = j["window"]["debug"];
-			this->window.handling = j["window"]["handling"];
-			this->window.log = j["window"]["log"];
-			this->window.main = j["window"]["main"];
-			this->window.users = j["window"]["users"];
 
 			this->context_menu.enabled = j["context_menu"]["enabled"];
 			this->context_menu.allowed_entity_types = j["context_menu"]["allowed_entity_types"];
@@ -688,7 +683,13 @@ namespace big
 				{
 					"debug",
 					{
-						{ "script_event_logging", this->debug.script_event_logging }
+						{
+							"logs",
+							{
+								{ "metric_logs", this->debug.logs.metric_logs },
+								{ "script_event_logs", this->debug.logs.script_event_logs }
+							}
+						}
 					}
 				},
 				{
@@ -937,12 +938,7 @@ namespace big
 				{
 					"window", {
 						{ "color", this->window.color },
-						{ "gui_scale", this->window.gui_scale },
-						{ "debug", this->window.debug },
-						{ "handling", this->window.handling },
-						{ "log", this->window.log },
-						{ "main", this->window.main },
-						{ "users", this->window.users }
+						{ "gui_scale", this->window.gui_scale }
 					}
 				},
 				{

--- a/BigBaseV2/src/hooking.cpp
+++ b/BigBaseV2/src/hooking.cpp
@@ -55,11 +55,8 @@ namespace big
 		m_get_network_event_data_hook("GNED", g_pointers->m_get_network_event_data, &hooks::get_network_event_data),
 		m_write_player_gamer_data_node_hook("WPGDN", g_pointers->m_write_player_gamer_data_node, &hooks::write_player_gamer_data_node),
 
-		// Send Metrics
-		m_send_metric_a("SMA", g_pointers->m_send_metric_a, &hooks::send_metric_a),
-		m_send_metric_b1("SMB1", g_pointers->m_send_metric_b_1, &hooks::send_metric_b1),
-		m_send_metric_b2("SMB2", g_pointers->m_send_metric_b_2, &hooks::send_metric_b2),
-		m_send_metric_c("SMC", g_pointers->m_send_metric_c, &hooks::send_metric_c)
+		// Format Metric For Sending
+		m_format_metric_for_sending("FMFS", g_pointers->m_format_metric_for_sending, &hooks::format_metric_for_sending)
 	{
 		m_swapchain_hook.hook(hooks::swapchain_present_index, &hooks::swapchain_present);
 		m_swapchain_hook.hook(hooks::swapchain_resizebuffers_index, &hooks::swapchain_resizebuffers);
@@ -94,6 +91,7 @@ namespace big
 		m_get_network_event_data_hook.enable();
 		m_received_clone_sync_hook.enable();
 		m_write_player_gamer_data_node_hook.enable();
+		m_format_metric_for_sending.enable();
 
 		MH_ApplyQueued();
 
@@ -104,6 +102,7 @@ namespace big
 	{
 		m_enabled = false;
 
+		m_format_metric_for_sending.disable();
 		m_write_player_gamer_data_node_hook.disable();
 		m_received_clone_sync_hook.disable();
 		m_get_network_event_data_hook.disable();

--- a/BigBaseV2/src/hooking.hpp
+++ b/BigBaseV2/src/hooking.hpp
@@ -56,10 +56,7 @@ namespace big
 
 		static void* assign_physical_index(CNetworkPlayerMgr* netPlayerMgr, CNetGamePlayer* player, uint8_t new_index);
 
-		static bool send_metric_a(void* metric_mgr, rage::rlMetric* metric);
-		static bool send_metric_b1(void* metric_mgr, rage::rlMetric* metric);
-		static bool send_metric_b2(void* metric_mgr, rage::rlMetric* metric);
-		static bool send_metric_c(void* metric_mgr, rage::rlMetric* metric);
+		static void format_metric_for_sending(int a1, int64_t a2, int64_t a3, rage::rlMetric* metric);
 
 		//SYNC
 		static int64_t received_clone_sync(CNetworkObjectMgr* mgr, CNetGamePlayer* src, CNetGamePlayer* dst, eObjType sync_type, uint16_t obj_id, rage::datBitBuffer* bufer, uint16_t unk, uint32_t timestamp);
@@ -119,10 +116,7 @@ namespace big
 		detour_hook m_receive_net_message_hook;
 		detour_hook m_get_network_event_data_hook;
 
-		detour_hook m_send_metric_a;
-		detour_hook m_send_metric_b1;
-		detour_hook m_send_metric_b2;
-		detour_hook m_send_metric_c;
+		detour_hook m_format_metric_for_sending;
 
 		detour_hook m_write_player_gamer_data_node_hook;
 

--- a/BigBaseV2/src/hooks/metrics/send_metric.cpp
+++ b/BigBaseV2/src/hooks/metrics/send_metric.cpp
@@ -43,32 +43,12 @@ namespace big
 
 		metric->serialize(&serializer);
 
-		LOG(WARNING) << "METRIC: " << metric->get_name() << "; DATA: " << serializer.get_string();
+		LOG_IF(G3LOG_DEBUG, g->debug.logs.metric_logs) << "METRIC: " << metric->get_name() << "; DATA: " << serializer.get_string();
 	}
 
 	using send_metric_f = bool(*)(void* metric_mgr, rage::rlMetric*);
-	bool hooks::send_metric_a(void* metric_mgr, rage::rlMetric* metric)
+	void hooks::format_metric_for_sending(int a1, int64_t a2, int64_t a3, rage::rlMetric* metric)
 	{
 		log_metric(metric);
-
-		return g_hooking->m_send_metric_a.get_original<send_metric_f>()(metric_mgr, metric);
-	}
-	bool hooks::send_metric_b1(void* metric_mgr, rage::rlMetric* metric)
-	{
-		log_metric(metric);
-
-		return g_hooking->m_send_metric_b1.get_original<send_metric_f>()(metric_mgr, metric);
-	}
-	bool hooks::send_metric_b2(void* metric_mgr, rage::rlMetric* metric)
-	{
-		log_metric(metric);
-
-		return g_hooking->m_send_metric_b2.get_original<send_metric_f>()(metric_mgr, metric);
-	}
-	bool hooks::send_metric_c(void* metric_mgr, rage::rlMetric* metric)
-	{
-		log_metric(metric);
-
-		return g_hooking->m_send_metric_c.get_original<send_metric_f>()(metric_mgr, metric);
 	}
 }

--- a/BigBaseV2/src/hooks/protections/script_event_handler.cpp
+++ b/BigBaseV2/src/hooks/protections/script_event_handler.cpp
@@ -323,7 +323,7 @@ namespace big
 		}
 
 
-		if (g->debug.script_event_logging)
+		if (g->debug.logs.script_event_logs)
 		{
 			LOG(INFO) << "== Begin of Script Event ==";
 			LOG(INFO) << "Player: " << player->get_name();

--- a/BigBaseV2/src/pointers.cpp
+++ b/BigBaseV2/src/pointers.cpp
@@ -392,30 +392,10 @@ namespace big
 			m_online_version = ptr.add(0x24).rip().add(0x20).as<const char*>();
 		});
 
-		// Send Metric a
-		main_batch.add("SMA", "48 89 5C 24 08 57 48 83 EC 20 48 8B D9 33 C9 48 8B FA E8 ? ? ? ? 48", [this](memory::handle ptr)
+		// Format Metric For Sending
+		main_batch.add("FMFS", "48 8B C4 48 89 58 ? 48 89 70 ? 48 89 78 ? 4C 89 70 ? 55 48 8D A8 ? ? ? ? 48 81 EC ? ? ? ? 48 83 3D", [this](memory::handle ptr)
 		{
-			m_send_metric_a = ptr.as<PVOID>();
-		});
-
-		// Send Metric b1
-		main_batch.add("SMB1", "4C 8B DC 49 89 5B 08 49 89 6B 10 49 89 73 18 49 89 7B 20 41 56 48 83 EC 30 33 C0 4C 8B F2 48 63 D9 49 89 43 E8 49 89 43 F0 66 89 44 24 ? 85 C9 0F 85", [this](memory::handle ptr)
-		{
-			m_send_metric_b_1 = ptr.as<PVOID>();
-			*reinterpret_cast<uint8_t*>(m_send_metric_b_1) = 0x90; // mangle
-		});
-
-		// Send Metric b2
-		main_batch.add("SMB2", "4C 8B DC 49 89 5B 08 49 89 6B 10 49 89 73 18 49 89 7B 20 41 56 48 83 EC 30 33 C0 4C 8B F2 48 63 D9 49 89 43 E8 49 89 43 F0 66 89 44 24 ? 85 C9 0F 85", [this](memory::handle ptr)
-		{
-			m_send_metric_b_2 = ptr.as<PVOID>();
-			*reinterpret_cast<uint8_t*>(m_send_metric_b_1) = 0x4C; // restore
-		});
-
-		// Send Metric c
-		main_batch.add("SMC", "48 8B C4 48 89 58 08 48 89 68 10 48 89 70 18 48 89 78 20 41 56 48 83 EC 30 83 3D", [this](memory::handle ptr)
-		{
-			m_send_metric_c = ptr.as<PVOID>();
+			m_format_metric_for_sending = ptr.as<PVOID>();
 		});
 
 		auto mem_region = memory::module(nullptr);

--- a/BigBaseV2/src/pointers.hpp
+++ b/BigBaseV2/src/pointers.hpp
@@ -102,10 +102,7 @@ namespace big
 		PVOID m_get_network_event_data{};
 		PVOID m_assign_physical_index{};
 
-		PVOID m_send_metric_a;
-		PVOID m_send_metric_b_1;
-		PVOID m_send_metric_b_2;
-		PVOID m_send_metric_c;
+		PVOID m_format_metric_for_sending;
 
 		Network** m_network;
 

--- a/BigBaseV2/src/views/debug/view_debug.cpp
+++ b/BigBaseV2/src/views/debug/view_debug.cpp
@@ -12,6 +12,7 @@ namespace big
 		{
 			ImGui::BeginTabBar("debug_tabbar");
 			misc();
+			logs();
 			globals();
 			locals();
 			script_events();

--- a/BigBaseV2/src/views/debug/view_debug.hpp
+++ b/BigBaseV2/src/views/debug/view_debug.hpp
@@ -3,9 +3,10 @@
 namespace big::debug
 {
 	extern void globals();
+	extern void locals();
+	extern void logs();
 	extern void misc();
 	extern void script_events();
-	extern void locals();
 
 	extern void main();
 }

--- a/BigBaseV2/src/views/debug/views_debug_log.cpp
+++ b/BigBaseV2/src/views/debug/views_debug_log.cpp
@@ -1,0 +1,14 @@
+#include "view_debug.hpp"
+
+namespace big
+{
+	void debug::logs()
+	{
+		if (ImGui::BeginTabItem("Logs"))
+		{
+			ImGui::Checkbox("Log Metrics", &g->debug.logs.metric_logs);
+
+			ImGui::EndTabItem();
+		}
+	}
+}


### PR DESCRIPTION
In this PR:
 - Removed some unused globals
 - Added new "Logs" tab under Settings -> Debug
 - Added log option for metrics under Settings -> Debug -> Logs
 - Switched from using 4 hooks to 1 hook
 - Enabled metric hook (they were previously not enabled)