### PR TITLE
fix: online crash

### DIFF
--- a/BigBaseV2/src/gta_util.hpp
+++ b/BigBaseV2/src/gta_util.hpp
@@ -37,10 +37,7 @@ namespace big::gta_util
 
 	inline Network* get_network()
 	{
-		__int64 network = (__int64)(*g_pointers->m_network);
-		if (g_is_steam)
-			network += sizeof(rage::rlSessionInfo);
-		return (Network*)network;
+		return *g_pointers->m_network;
 	}
 
 	template <typename F, typename ...Args>


### PR DESCRIPTION
Seems R* is using the Steam version for all stores that you can play GTA.

With this PR I've updated the GTAV-Classes repo and removed the check on the network class.