### PR TITLE
fix(ci): gh output on powershell and wildcard deleting older cached versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,7 @@ jobs:
 
       - name: Rename DLL to YimMenu-dev-{GITHUB_SHA}.dll
         run: |
-          if (Test-Path -path "YimMenu-dev-${{github.sha}}.dll") {
-            DEL YimMenu-dev-${{github.sha}}.dll
-          }
+          del YimMenu-dev-*.dll
           ren YimMenu.dll YimMenu-dev-${{github.sha}}.dll
         working-directory: build/Release/
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Generate Build Info
         id: var
         run: |
-          echo "full_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-          echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "full_sha=$(git rev-parse HEAD)" >> $env:GITHUB_OUTPUT
+          echo "short_sha=$(git rev-parse --short HEAD)" >> $env:GITHUB_OUTPUT
 
   check_detections:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Apparently on powershell we have to append to `$env:GITHUB_OUTPUT`