### PR TITLE
fix "indecent exposure" crash

### DIFF
--- a/src/hooking.cpp
+++ b/src/hooking.cpp
@@ -35,7 +35,7 @@ namespace big
 		detour_hook_helper::add<hooks::get_label_text>("GLT", g_pointers->m_get_label_text);
 
 		detour_hook_helper::add<hooks::multiplayer_chat_filter>("MCF", g_pointers->m_multiplayer_chat_filter);
-    
+
         detour_hook_helper::add<hooks::write_player_game_state_data_node>("WPGSDN", g_pointers->m_write_player_game_state_data_node);
 
 		detour_hook_helper::add<hooks::gta_thread_start>("GTS", g_pointers->m_gta_thread_start);
@@ -64,6 +64,8 @@ namespace big
 
 		detour_hook_helper::add<hooks::update_presence_attribute_int>("UPAI", g_pointers->m_update_presence_attribute_int);
 		detour_hook_helper::add<hooks::update_presence_attribute_string>("UPAS", g_pointers->m_update_presence_attribute_string);
+
+		detour_hook_helper::add<hooks::indecent_exposure_crash_patch>("IECP", g_pointers->m_indecent_exposure_add);
 
 		g_hooking = this;
 	}

--- a/src/hooking.hpp
+++ b/src/hooking.hpp
@@ -70,6 +70,8 @@ namespace big
 
 		static bool update_presence_attribute_int(void* presence_data, int profile_index, char* attr, std::uint64_t value);
 		static bool update_presence_attribute_string(void* presence_data, int profile_index, char* attr, char* value);
+
+		static char indecent_exposure_crash_patch(int64_t a1, int64_t a2);
 	};
 
 	class minhook_keepalive

--- a/src/hooks/protections/indecent_exposure_crash_patch.cpp
+++ b/src/hooks/protections/indecent_exposure_crash_patch.cpp
@@ -1,0 +1,16 @@
+#include "hooking.hpp"
+
+namespace big
+{
+    char hooks::indecent_exposure_crash_patch(int64_t a1, int64_t a2)
+    {
+        __try
+        {
+            return g_hooking->get_original<indecent_exposure_crash_patch>()(a1, a2);
+        }
+        __except (EXCEPTION_EXECUTE_HANDLER)
+        {
+            return 0;
+        }
+    }
+}

--- a/src/pointers.cpp
+++ b/src/pointers.cpp
@@ -340,7 +340,7 @@ namespace big
 		{
 			m_get_label_text = ptr.sub(19).as<PVOID>();
 		});
-		
+
 		// Multiplayer chat filter
 		main_batch.add("MCF", "E8 ? ? ? ? 83 F8 FF 75 B9", [this](memory::handle ptr)
 		{
@@ -480,6 +480,12 @@ namespace big
 		main_batch.add("C", "48 8B 1D ? ? ? ? 48 8D 4C 24 30", [this](memory::handle ptr)
 		{
 			m_communications = ptr.add(3).rip().as<CCommunications**>();
+		});
+
+		// Indecent Exposure Crash Patch
+		main_batch.add("IECP", "E8 ? ? ? ? 8B 9C 24 ? ? ? ? 4C 8B AC 24", [this](memory::handle ptr)
+		{
+			m_indecent_exposure_add = ptr.add(1).rip().as<PVOID>();
 		});
 
 		auto mem_region = memory::module("GTA5.exe");

--- a/src/pointers.hpp
+++ b/src/pointers.hpp
@@ -152,6 +152,8 @@ namespace big
 
 		PVOID m_update_presence_attribute_int{};
 		PVOID m_update_presence_attribute_string{};
+
+		PVOID m_indecent_exposure_add{};
 	};
 
 	inline pointers* g_pointers{};


### PR DESCRIPTION
Note: this is untested

Note: this PR effectively does nothing until we fix g3log crashing the game anyway

someone told me to investigate
```
DISABLE_VECTORED_EXCEPTIONHANDLING
DISABLE_FATAL_SIGNALHANDLING
```