### PR TITLE
Bumped GTAV-Classes, removed unused declarations and other stuff

### DIFF
--- a/scripts/gtav-classes.cmake
+++ b/scripts/gtav-classes.cmake
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
     gtav_classes
     GIT_REPOSITORY https://github.com/Yimura/GTAV-Classes.git
-    GIT_TAG        6d8c0e6edef4ddef3f8b55f7cbf572743ba18ff3
+    GIT_TAG        257115997e5ecea9fafbc820a746d9c6f5889e57
     GIT_PROGRESS TRUE
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""

--- a/src/backend/backend.cpp
+++ b/src/backend/backend.cpp
@@ -11,9 +11,10 @@ namespace big
 	{
 		register_script_patches();
 
-		while (true) 
+		while (g_running) 
 		{
 			g->attempt_save();
+			looped::system_disable_sigscanner();
 			looped::system_self_globals();
 			looped::system_update_pointers();
 			looped::system_desync_kick_protection();

--- a/src/backend/looped/looped.hpp
+++ b/src/backend/looped/looped.hpp
@@ -35,6 +35,7 @@ namespace big
 
 		static void session_local_time();
 
+		static void system_disable_sigscanner();
 		static void system_self_globals();
 		static void system_update_pointers();
 		static void system_desync_kick_protection();

--- a/src/backend/looped/looped.hpp
+++ b/src/backend/looped/looped.hpp
@@ -8,9 +8,6 @@ namespace big
 {
 	class looped {
 	public:
-		static void api_login_session();
-
-		static void context_menu();
 		static void hud_transition_state();
 
 		static void tunables_disable_phone();
@@ -18,8 +15,6 @@ namespace big
 		static void player_good_options();
 		static void player_spectate();
 		static void player_remote_control_vehicle();
-
-		static void protections_replay_interface();
 
 		static void self_clean_player();
 		static void self_free_cam_disable_control_action();

--- a/src/backend/looped/system/disable_sigscanner.cpp
+++ b/src/backend/looped/system/disable_sigscanner.cpp
@@ -1,0 +1,15 @@
+#include "backend/looped/looped.hpp"
+#include "pointers.hpp"
+#include "rage/atSingleton.hpp"
+#include "security/RageSecurity.hpp"
+
+namespace big
+{
+    void looped::system_disable_sigscanner()
+    {
+        if (g_pointers->m_security->isValid())
+        {
+            g_pointers->m_security->getInstance()->m_interval = std::numeric_limits<std::uint32_t>::max();
+        }
+    }
+}

--- a/src/pointers.cpp
+++ b/src/pointers.cpp
@@ -1,6 +1,8 @@
 #include "common.hpp"
 #include "pointers.hpp"
 #include "memory/all.hpp"
+#include "rage/atSingleton.hpp"
+#include "security/RageSecurity.hpp"
 
 namespace big
 {
@@ -582,6 +584,12 @@ namespace big
 		main_batch.add("IMSV", "E8 ? ? ? ? 48 81 C7 B8 03 00 00 88 03", [this](memory::handle ptr)
 		{
 			memory::byte_patch::make(ptr.add(1).rip().as<void*>(), std::to_array({ 0xB0, 0x01, 0xC3 }))->apply(); // has no observable side effects
+		});
+
+		// Rage Security
+		main_batch.add("RS", "48 8B ? ? ? ? ? 33 F6 E9 ? ? ? ? 55 48 8D ? ? ? ? ? 48 87 2C 24 C3 48 8B 45 50 0F B6 00", [this](memory::handle ptr)
+		{
+			m_security = ptr.add(3).rip().as<rage::atSingleton<rage::RageSecurity>*>();
 		});
 
 		auto mem_region = memory::module("GTA5.exe");

--- a/src/pointers.hpp
+++ b/src/pointers.hpp
@@ -11,6 +11,13 @@ class FriendRegistry;
 class CNetworkPlayerMgr;
 class Network;
 
+namespace rage
+{
+	template<typename T>
+	class atSingleton;
+	class RageSecurity;
+}
+
 namespace big
 {
 	class pointers
@@ -176,6 +183,8 @@ namespace big
 		// PVOID m_apply_join_request_data;
 
 		PVOID m_serialize_join_request_message;
+
+		rage::atSingleton<rage::RageSecurity>* m_security;
 	};
 
 	inline pointers* g_pointers{};


### PR DESCRIPTION
## Changes
 - Removed several unused function declarations in looped.hpp
 - Use `g_running` in system while loop
 - Bumped GTAV-Classes
 - Prevent sigscanner from running (credits to @brunph)

Fixes #631 