### PR TITLE
fix(hotkey_service): duplicate key overwrite & add noclip hotkey

### DIFF
--- a/src/core/globals.hpp
+++ b/src/core/globals.hpp
@@ -226,6 +226,7 @@ namespace big
 				int menu_toggle = VK_INSERT;
 				int teleport_waypoint = 0;
 				int teleport_objective = 0;
+				int noclip = 0;
 			};
 
 			bool dev_dlc = false;
@@ -665,6 +666,7 @@ namespace big
 			this->settings.hotkeys.menu_toggle = j["settings"]["hotkeys"]["menu_toggle"];
 			this->settings.hotkeys.teleport_waypoint = j["settings"]["hotkeys"]["teleport_waypoint"];
 			this->settings.hotkeys.teleport_objective = j["settings"]["hotkeys"]["teleport_objective"];
+			this->settings.hotkeys.noclip = j["settings"]["hotkeys"]["noclip"];
 
 			this->spawn_vehicle.preview_vehicle = j["spawn_vehicle"]["preview_vehicle"];
 			this->spawn_vehicle.spawn_inside = j["spawn_vehicle"]["spawn_inside"];
@@ -1012,7 +1014,8 @@ namespace big
 						{ "hotkeys", {
 								{ "menu_toggle", this->settings.hotkeys.menu_toggle },
 								{ "teleport_waypoint", this->settings.hotkeys.teleport_waypoint },
-								{ "teleport_objective", this->settings.hotkeys.teleport_objective }
+								{ "teleport_objective", this->settings.hotkeys.teleport_objective },
+								{ "noclip", this->settings.hotkeys.noclip }
 							}
 						}
 					}

--- a/src/services/hotkey/hotkey_functions.cpp
+++ b/src/services/hotkey/hotkey_functions.cpp
@@ -1,0 +1,14 @@
+#include "common.hpp"
+#include "hotkey_functions.hpp"
+#include "services/notifications/notification_service.hpp"
+
+namespace big::hotkey_funcs
+{
+    void toggle_noclip()
+    {
+        const auto state = !g->self.noclip;
+        g_notification_service->push("Noclip", std::format("Noclip has been {}.", state ? "enabled" : "disabled"));
+
+        g->self.noclip = state;
+    }
+}

--- a/src/services/hotkey/hotkey_functions.hpp
+++ b/src/services/hotkey/hotkey_functions.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace big::hotkey_funcs
+{
+    extern void toggle_noclip();
+}

--- a/src/services/hotkey/hotkey_service.hpp
+++ b/src/services/hotkey/hotkey_service.hpp
@@ -10,7 +10,7 @@ namespace big
         DOWN = WM_KEYDOWN
     };
 
-    using hotkey_map = std::map<key_t, hotkey>;
+    using hotkey_map = std::multimap<key_t, hotkey>;
 
     class hotkey_service final
     {

--- a/src/views/settings/view_settings.cpp
+++ b/src/views/settings/view_settings.cpp
@@ -42,6 +42,9 @@ namespace big
 		if (ImGui::Hotkey("Teleport to objective", &g->settings.hotkeys.teleport_objective))
 			g_hotkey_service->update_hotkey("objective", g->settings.hotkeys.teleport_objective);
 
+		if (ImGui::Hotkey("Toggle Noclip", &g->settings.hotkeys.noclip))
+			g_hotkey_service->update_hotkey("noclip", g->settings.hotkeys.noclip);
+
 
 		ImGui::PopItemWidth();
 


### PR DESCRIPTION
- Switched to std::multimap to prevent hotkeys from being overwritten when hotkeys have the same key
- Added noclip hotkey