### PR TITLE
chore(CMake): Absolutely unnecessary CMake changes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,12 +38,11 @@ target_include_directories(YimMenu PRIVATE
     "${SRC_DIR}"
     "${json_SOURCE_DIR}/single_include"
     "${gtav_classes_SOURCE_DIR}"
-    "${minhook_SOURCE_DIR}/include"
     "${imgui_SOURCE_DIR}"
 )
 
 target_precompile_headers(YimMenu PRIVATE "${SRC_DIR}/common.hpp")
-target_link_libraries(YimMenu PRIVATE pugixml minhook g3log imgui d3dcompiler)
+target_link_libraries(YimMenu PRIVATE pugixml minhook g3log imgui)
 
 # Warnings as errors
 set_property(TARGET YimMenu PROPERTY COMPILE_WARNING_AS_ERROR ON)

--- a/scripts/gtav-classes.cmake
+++ b/scripts/gtav-classes.cmake
@@ -11,13 +11,4 @@ FetchContent_Declare(
 message("GTAV-Classes")
 if(NOT gtav_classes_POPULATED)
     FetchContent_Populate(gtav_classes)
-
-    file(GLOB_RECURSE SRC_GTAV_CLASSES "${gtav_classes_SOURCE_DIR}/*.hpp")
-
-    # Show GTAV-Classes project
-    add_library(gtav_classes "${SRC_GTAV_CLASSES}")
-
-    source_group(TREE "${gtav_classes_SOURCE_DIR}" PREFIX "GTAV-Classes" FILES "${SRC_GTAV_CLASSES}")
 endif()
-set_property(TARGET gtav_classes PROPERTY CXX_STANDARD 23)
-set_target_properties(gtav_classes PROPERTIES LINKER_LANGUAGE CXX)

--- a/scripts/imgui.cmake
+++ b/scripts/imgui.cmake
@@ -9,21 +9,4 @@ message("ImGui")
 FetchContent_GetProperties(imgui)
 if(NOT imgui_POPULATED)
     FetchContent_Populate(imgui)
-
-    file(GLOB SRC_IMGUI
-        "${imgui_SOURCE_DIR}/*.cpp"
-        "${imgui_SOURCE_DIR}/*.h"
-        "${imgui_SOURCE_DIR}/backends/imgui_impl_win32.*"
-        "${imgui_SOURCE_DIR}/backends/imgui_impl_dx11.*"
-        "${imgui_SOURCE_DIR}/misc/cpp/imgui_stdlib.*"
-    )
-
-    add_library(imgui STATIC ${SRC_IMGUI})
-    source_group(TREE ${imgui_SOURCE_DIR} PREFIX "imgui" FILES ${SRC_IMGUI} )
-    target_include_directories(imgui PRIVATE
-        "${imgui_SOURCE_DIR}"
-        "${imgui_SOURCE_DIR}/backends"
-        "${imgui_SOURCE_DIR}/misc/cpp"
-    )
 endif()
-set_property(TARGET imgui PROPERTY CXX_STANDARD 23)

--- a/scripts/imgui.cmake
+++ b/scripts/imgui.cmake
@@ -9,4 +9,20 @@ message("ImGui")
 FetchContent_GetProperties(imgui)
 if(NOT imgui_POPULATED)
     FetchContent_Populate(imgui)
+
+    file(GLOB SRC_IMGUI
+        "${imgui_SOURCE_DIR}/*.cpp"
+        "${imgui_SOURCE_DIR}/backends/imgui_impl_win32.cpp"
+        "${imgui_SOURCE_DIR}/backends/imgui_impl_dx11.cpp"
+        "${imgui_SOURCE_DIR}/misc/cpp/imgui_stdlib.cpp"
+    )
+
+    add_library(imgui STATIC ${SRC_IMGUI})
+    source_group(TREE ${imgui_SOURCE_DIR} PREFIX "imgui" FILES ${SRC_IMGUI} )
+    target_include_directories(imgui PRIVATE
+        "${imgui_SOURCE_DIR}"
+        "${imgui_SOURCE_DIR}/backends"
+        "${imgui_SOURCE_DIR}/misc/cpp"
+    )
 endif()
+set_property(TARGET imgui PROPERTY CXX_STANDARD 23)

--- a/scripts/json.cmake
+++ b/scripts/json.cmake
@@ -10,8 +10,3 @@ FetchContent_Declare(
 )
 message("json")
 FetchContent_MakeAvailable(json)
-
-# Show json project
-add_library(json ${json_SOURCE_DIR}/single_include/nlohmann/json.hpp)
-set_property(TARGET json PROPERTY CXX_STANDARD 23)
-set_target_properties(json PROPERTIES LINKER_LANGUAGE CXX)

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1,1 +1,0 @@
-#include "common.hpp"


### PR DESCRIPTION
# Changes
- Remove empty libraries.
- Remove unneeded `common.cpp` file.
- Remove unneeded MinHook include.

Did this while trying to get partial compilation to work (failed to do so).