### PR TITLE
feat(renderer): add UI scaling

### DIFF
--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -110,6 +110,8 @@ namespace big
 			g->window.font_icon = io.Fonts->AddFontFromMemoryTTF(const_cast<std::uint8_t*>(font_icons), sizeof(font_icons), 24.f, &font_icons_cfg);
 		}
 
+		rescale(g->window.gui_scale);
+
 		g_gui.dx_init();
 		g_renderer = this;
 	}
@@ -150,6 +152,14 @@ namespace big
 
 		ImGui::Render();
 		ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
+	}
+
+	void renderer::rescale(float rel_size)
+	{
+		pre_reset();
+		ImGui::GetStyle().ScaleAllSizes(rel_size);
+		ImGui::GetIO().FontGlobalScale = rel_size;
+		post_reset();
 	}
 
 	void renderer::pre_reset()

--- a/src/renderer.hpp
+++ b/src/renderer.hpp
@@ -12,6 +12,8 @@ namespace big
 
 		void on_present();
 
+		void rescale(float rel_size);
+
 		void pre_reset();
 		void post_reset();
 

--- a/src/views/settings/view_gui_settings.cpp
+++ b/src/views/settings/view_gui_settings.cpp
@@ -1,9 +1,19 @@
 #include "views/view.hpp"
+#include "renderer.hpp"
 
 namespace big
 {
 	void view::gui_settings()
 	{
+		components::sub_title("UI Scale");
+		ImGui::SliderFloat("##gui-scale", &g->window.gui_scale, 1.f, 1.5f, "%.2f");
+		ImGui::SameLine();
+		if (ImGui::Button("Apply##gui-scale"))
+			g_renderer->rescale(g->window.gui_scale);
+		if (ImGui::IsItemHovered())
+			ImGui::SetTooltip("Changing the UI scale may break rendering and require you to unload and inject YimMenu again.");
+
+		components::sub_title("Colors");
 		static ImVec4 col_gui = ImGui::ColorConvertU32ToFloat4(g->window.color);
 		if (ImGui::ColorEdit4("Gui Color##gui_picker", (float*)&col_gui, ImGuiColorEditFlags_InputRGB | ImGuiColorEditFlags_NoSidePreview))
 		{


### PR DESCRIPTION
Values above 1.25 aren't recommended as the original UI did not account for scaling.

Closes #587