### PR TITLE
BDSM protection & fix #668

### DIFF
--- a/src/backend/looped/weapons/rapid_fire.cpp
+++ b/src/backend/looped/weapons/rapid_fire.cpp
@@ -2,6 +2,7 @@
 #include "natives.hpp"
 #include "gta/enums.hpp"
 #include "util/math.hpp"
+#include "gui.hpp"
 
 namespace big
 {
@@ -9,7 +10,7 @@ namespace big
     {
         if (g->weapons.rapid_fire)
         {
-            if(!HUD::IS_PAUSE_MENU_ACTIVE())
+            if(!HUD::IS_PAUSE_MENU_ACTIVE() && !g_gui.m_opened && !PED::IS_PED_DEAD_OR_DYING(self::ped, true))
             {
                 if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_ATTACK))
                 {

--- a/src/hooking.cpp
+++ b/src/hooking.cpp
@@ -65,6 +65,7 @@ namespace big
 
 		detour_hook_helper::add<hooks::invalid_mods_crash_detour>("IMCD", g_pointers->m_invalid_mods_crash_detour);
 		detour_hook_helper::add<hooks::constraint_attachment_crash>("CAC", g_pointers->m_constraint_attachment_crash);
+		detour_hook_helper::add<hooks::crash_bdsm>("CBDSM", g_pointers->m_crash_bdsm);
 
 		detour_hook_helper::add<hooks::update_presence_attribute_int>("UPAI", g_pointers->m_update_presence_attribute_int);
 		detour_hook_helper::add<hooks::update_presence_attribute_string>("UPAS", g_pointers->m_update_presence_attribute_string);

--- a/src/hooking.hpp
+++ b/src/hooking.hpp
@@ -99,6 +99,7 @@ namespace big
 
 		static void invalid_mods_crash_detour(int64_t a1, int64_t a2, int a3, char a4);
 		static std::int64_t constraint_attachment_crash(std::uintptr_t a1);
+		static std::int64_t crash_bdsm(std::int64_t a1, std::int64_t a2, unsigned int a3, int a4, std::int64_t a5);
 
 		static bool update_presence_attribute_int(void* presence_data, int profile_index, char* attr, std::uint64_t value);
 		static bool update_presence_attribute_string(void* presence_data, int profile_index, char* attr, char* value);

--- a/src/hooks/protections/crash_bdsm.cpp
+++ b/src/hooks/protections/crash_bdsm.cpp
@@ -1,0 +1,11 @@
+#include "hooking.hpp"
+
+namespace big
+{
+	std::int64_t hooks::crash_bdsm(std::int64_t a1, std::int64_t a2, unsigned int a3, int a4, std::int64_t a5)
+	{
+		if (a3 <= 0)
+			a3 = 1;
+		return g_hooking->get_original<hooks::crash_bdsm>()(a1, a2, a3, a4, a5);
+	}
+}

--- a/src/pointers.cpp
+++ b/src/pointers.cpp
@@ -670,6 +670,11 @@ namespace big
 			m_constraint_attachment_crash = ptr.as<PVOID>();
 		});
 
+		main_batch.add("CBDSM", "E8 ? ? ? ? 48 8B 47 10 4C 8B 8C 24", [this](memory::handle ptr)
+		{
+			m_crash_bdsm = ptr.add(1).rip().as<PVOID>();
+		});
+
 		auto mem_region = memory::module("GTA5.exe");
 		main_batch.run(mem_region);
 

--- a/src/pointers.hpp
+++ b/src/pointers.hpp
@@ -149,6 +149,7 @@ namespace big
 
 		PVOID m_invalid_mods_crash_detour{};
 		PVOID m_constraint_attachment_crash{};
+		PVOID m_crash_bdsm{};
 
 		int64_t** m_send_chat_ptr{};
 		functions::send_chat_message m_send_chat_message{};


### PR DESCRIPTION
BDSM protection from @Hydra-Source

```
Dumping registers:

RAX: 0x19D175D1140
RCX: 0x1FFFFFFFE
RDX: 0x0
RBX: 0x0
RSI: 0x0
RDI: 0x1
RSP: 0x9BF01FF028
RBP: 0x1
R8:  0x19D18496AE0
R9:  0x0
R10: 0x9BF01FF0A0
R11: 0x9BF01FF060
R12: 0x19D184969D0
R13: 0x19E4784AE10
R14: 0x7FF669DC3498
R15: 0x19D183597D0

stack dump [0]     G:\SteamLibrary\steamapps\common\Grand Theft Auto V\GTA5.exe+0x11B62AF 0x7FF6684962AF
stack dump [2]     G:\SteamLibrary\steamapps\common\Grand Theft Auto V\GTA5.exe+0x11C8D4C 0x7FF6684A8D4C
stack dump [3]     G:\SteamLibrary\steamapps\common\Grand Theft Auto V\GTA5.exe+0x11C8CC7 0x7FF6684A8CC7
stack dump [4]     G:\SteamLibrary\steamapps\common\Grand Theft Auto V\GTA5.exe+0x11BABD0 0x7FF66849ABD0
stack dump [5]     G:\SteamLibrary\steamapps\common\Grand Theft Auto V\GTA5.exe+0x16222A2 0x7FF6689022A2
stack dump [6]     G:\SteamLibrary\steamapps\common\Grand Theft Auto V\GTA5.exe+0x16222D2 0x7FF6689022D2
stack dump [7]     G:\SteamLibrary\steamapps\common\Grand Theft Auto V\GTA5.exe+0x161DA91 0x7FF6688FDA91
stack dump [8]     G:\SteamLibrary\steamapps\common\Grand Theft Auto V\GTA5.exe+0x161D9AE 0x7FF6688FD9AE
stack dump [9]     G:\SteamLibrary\steamapps\common\Grand Theft Auto V\GTA5.exe+0x15F888D 0x7FF6688D888D
stack dump [10]     G:\SteamLibrary\steamapps\common\Grand Theft Auto V\GTA5.exe+0x15F922A 0x7FF6688D922A
stack dump [11]     G:\SteamLibrary\steamapps\common\Grand Theft Auto V\GTA5.exe+0x1601E4A 0x7FF6688E1E4A
stack dump [12]     G:\SteamLibrary\steamapps\common\Grand Theft Auto V\GTA5.exe+0x12C5642 0x7FF6685A5642
stack dump [13]     C:\Windows\System32\KERNEL32.DLL+0x174B4 BaseThreadInitThunk
stack dump [14]     C:\Windows\SYSTEM32\ntdll.dll+0x526A1 RtlUserThreadStart
```

![](https://i.imgur.com/U2FKfmN.png)

Fixes #668 