### PR TITLE
refactor(globals): use macro's for to_json/from_json

### DIFF
--- a/src/backend/backend.cpp
+++ b/src/backend/backend.cpp
@@ -13,7 +13,6 @@ namespace big
 
 		while (g_running) 
 		{
-			g->attempt_save();
 			looped::system_self_globals();
 			looped::system_update_pointers();
 			looped::system_desync_kick_protection();

--- a/src/backend/looped/player/good_options.cpp
+++ b/src/backend/looped/player/good_options.cpp
@@ -24,17 +24,17 @@ namespace big
 
 		g_player_service->iterate([](const player_entry& entry)
 		{
-			if ((g->session.off_radar_all || entry.second->off_radar) && offRadarPlayer == entry.second->id())
+			if ((g.session.off_radar_all || entry.second->off_radar) && offRadarPlayer == entry.second->id())
 				globals::give_remote_otr(entry.second->id());
 		});
 
 		g_player_service->iterate([](const player_entry& entry)
 		{
-			if ((g->session.never_wanted_all || entry.second->never_wanted) && PLAYER::GET_PLAYER_WANTED_LEVEL(entry.second->id()) > 0 && neverWantedPlayer == entry.second->id())
+			if ((g.session.never_wanted_all || entry.second->never_wanted) && PLAYER::GET_PLAYER_WANTED_LEVEL(entry.second->id()) > 0 && neverWantedPlayer == entry.second->id())
 				globals::clear_wanted_player(entry.second->id());
 		});
 
-		if (g->session.semi_godmode_all)
+		if (g.session.semi_godmode_all)
 		{
 			g_pointers->m_give_pickup_rewards(-1, REWARD_HEALTH);
 			g_pointers->m_give_pickup_rewards(-1, REWARD_ARMOUR);

--- a/src/backend/looped/player/remote_control_vehicle.cpp
+++ b/src/backend/looped/player/remote_control_vehicle.cpp
@@ -8,32 +8,32 @@ namespace big
 {
 	void looped::player_remote_control_vehicle()
 	{
-		if (g->m_remote_controller_vehicle == -1) 
+		if (g.m_remote_controller_vehicle == -1) 
 			return;
 
-		if (!ENTITY::DOES_ENTITY_EXIST(g->m_remote_controlled_vehicle))
+		if (!ENTITY::DOES_ENTITY_EXIST(g.m_remote_controlled_vehicle))
 		{
-			g->m_remote_controlled_vehicle = -1;
-			g->m_remote_controlled_vehicle = -1;
-			return;
-		}
-
-		if (!ENTITY::DOES_ENTITY_EXIST(g->m_remote_controller_vehicle))
-		{
-			g->m_remote_controlled_vehicle = -1;
-			g->m_remote_controlled_vehicle = -1;
+			g.m_remote_controlled_vehicle = -1;
+			g.m_remote_controlled_vehicle = -1;
 			return;
 		}
 
-		if (VEHICLE::IS_VEHICLE_SEAT_FREE(g->m_remote_controller_vehicle, -1, TRUE))
+		if (!ENTITY::DOES_ENTITY_EXIST(g.m_remote_controller_vehicle))
 		{
-			auto controlled = g->m_remote_controlled_vehicle;
-			auto controller = g->m_remote_controller_vehicle;
+			g.m_remote_controlled_vehicle = -1;
+			g.m_remote_controlled_vehicle = -1;
+			return;
+		}
+
+		if (VEHICLE::IS_VEHICLE_SEAT_FREE(g.m_remote_controller_vehicle, -1, TRUE))
+		{
+			auto controlled = g.m_remote_controlled_vehicle;
+			auto controller = g.m_remote_controller_vehicle;
 			g_fiber_pool->queue_job([controlled, controller]
 			{
 				if (entity::take_control_of(controlled))
 				{
-					ENTITY::SET_ENTITY_COLLISION(g->m_remote_controlled_vehicle, TRUE, TRUE);
+					ENTITY::SET_ENTITY_COLLISION(g.m_remote_controlled_vehicle, TRUE, TRUE);
 					ENTITY::DETACH_ENTITY(controlled, TRUE, TRUE);
 					VEHICLE::SET_VEHICLE_DOORS_LOCKED(controlled, 0);
 					VEHICLE::SET_VEHICLE_DOORS_LOCKED_FOR_ALL_PLAYERS(controlled, FALSE);
@@ -43,8 +43,8 @@ namespace big
 			});
 
 
-			g->m_remote_controller_vehicle = -1;
-			g->m_remote_controlled_vehicle = -1;
+			g.m_remote_controller_vehicle = -1;
+			g.m_remote_controlled_vehicle = -1;
 		}
 	}
 };

--- a/src/backend/looped/player/spectate.cpp
+++ b/src/backend/looped/player/spectate.cpp
@@ -12,9 +12,9 @@ namespace big
 		const auto vehicle = self::veh;
 		const auto ped = self::ped;
 
-		if (!g_player_service->get_selected()->is_valid() || !g->player.spectating)
+		if (!g_player_service->get_selected()->is_valid() || !g.player.spectating)
 		{
-			if (g->player.spectating) g->player.spectating = false;
+			if (g.player.spectating) g.player.spectating = false;
 
 			if (!bReset)
 			{

--- a/src/backend/looped/self/clean_player.cpp
+++ b/src/backend/looped/self/clean_player.cpp
@@ -6,7 +6,7 @@ namespace big
 {
 	void looped::self_clean_player()
 	{
-		if (g->self.clean_player) {
+		if (g.self.clean_player) {
 			entity::clean_ped(self::ped);
 		}
 	}

--- a/src/backend/looped/self/dance_mode.cpp
+++ b/src/backend/looped/self/dance_mode.cpp
@@ -9,10 +9,10 @@ namespace big
 	bool bLastDanceMode = false;
 	void looped::self_dance_mode()
 	{
-		if (g->self.dance_mode && SCRIPT::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH(RAGE_JOAAT("maintransition")) > 0)
-			g->self.dance_mode = false;
+		if (g.self.dance_mode && SCRIPT::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH(RAGE_JOAAT("maintransition")) > 0)
+			g.self.dance_mode = false;
 
-		if (g->self.dance_mode && g->self.dance_mode != bLastDanceMode)
+		if (g.self.dance_mode && g.self.dance_mode != bLastDanceMode)
 		{
 			scripts::request_script(RAGE_JOAAT("am_mp_nightclub"));
 			if (!scripts::wait_till_loaded(RAGE_JOAAT("am_mp_nightclub")))
@@ -24,12 +24,12 @@ namespace big
 			if (!thread)
 				return;
 
-			g->m_dance_thread = gta_util::find_script_thread(RAGE_JOAAT("am_mp_nightclub"));
-			g->m_dance_program = gta_util::find_script_program(RAGE_JOAAT("am_mp_nightclub"));
+			g.m_dance_thread = gta_util::find_script_thread(RAGE_JOAAT("am_mp_nightclub"));
+			g.m_dance_program = gta_util::find_script_program(RAGE_JOAAT("am_mp_nightclub"));
 
-			(*g_pointers->m_script_handler_mgr)->attach_thread(g->m_dance_thread);
+			(*g_pointers->m_script_handler_mgr)->attach_thread(g.m_dance_thread);
 
-			g->m_dance_thread->m_context.m_state = rage::eThreadState::unk_3;
+			g.m_dance_thread->m_context.m_state = rage::eThreadState::unk_3;
 
 			// perform initial setup
 			gta_util::execute_as_script(RAGE_JOAAT("am_mp_nightclub"), []
@@ -43,25 +43,25 @@ namespace big
 			return;
 		}
 
-		if (!g->self.dance_mode && g->self.dance_mode != bLastDanceMode)
+		if (!g.self.dance_mode && g.self.dance_mode != bLastDanceMode)
 		{
-			if (g->m_dance_thread)
-				g->m_dance_thread->kill();
+			if (g.m_dance_thread)
+				g.m_dance_thread->kill();
 
-			g->m_dance_thread = nullptr;
-			g->m_dance_program = nullptr;
+			g.m_dance_thread = nullptr;
+			g.m_dance_program = nullptr;
 
 			bLastDanceMode = false;
 			return;
 		}
 
-		if (g->self.dance_mode && g->m_dance_thread->m_handler)
+		if (g.self.dance_mode && g.m_dance_thread->m_handler)
 		{
 			*script_global(1950102).as<bool*>() = true;
 			misc::set_bit(scr_globals::gpbd_fm_1.at(self::id, scr_globals::size::gpbd_fm_1).at(267).at(310).at(7).as<int*>(), 0);
 			misc::set_bit(scr_globals::gpbd_fm_1.at(self::id, scr_globals::size::gpbd_fm_1).at(267).at(310).at(7).as<int*>(), 1);
 			misc::set_bit(scr_globals::gpbd_fm_1.at(self::id, scr_globals::size::gpbd_fm_1).at(267).at(310).at(7).as<int*>(), 2);
-			scr_functions::dance_loop.call(g->m_dance_thread, g->m_dance_program, {});
+			scr_functions::dance_loop.call(g.m_dance_thread, g.m_dance_program, {});
 		}
 	}
 }

--- a/src/backend/looped/self/fast_respawn.cpp
+++ b/src/backend/looped/self/fast_respawn.cpp
@@ -5,7 +5,7 @@ namespace big
 {
     void looped::self_fast_respawn()
     {
-        if (g->self.fast_respawn)
+        if (g.self.fast_respawn)
         {
             if(PED::IS_PED_DEAD_OR_DYING(self::ped, true))
             {

--- a/src/backend/looped/self/free_cam.cpp
+++ b/src/backend/looped/self/free_cam.cpp
@@ -33,7 +33,7 @@ namespace big
 	{
 		if (g_local_player == nullptr) return;
 
-		if (g->self.free_cam)
+		if (g.self.free_cam)
 		{
 			PAD::DISABLE_ALL_CONTROL_ACTIONS(0);
 
@@ -48,9 +48,9 @@ namespace big
 
 		const auto vehicle = self::veh;
 		const auto ped = self::ped;
-		if (!g->self.free_cam && !bLastFreeCam) return;
+		if (!g.self.free_cam && !bLastFreeCam) return;
 
-		if (g->self.free_cam && !bLastFreeCam)
+		if (g.self.free_cam && !bLastFreeCam)
 		{
 			cCam = CAM::CREATE_CAM("DEFAULT_SCRIPTED_CAMERA", 0);
 
@@ -66,7 +66,7 @@ namespace big
 
 			bLastFreeCam = true;
 		}
-		else if (!g->self.free_cam && bLastFreeCam)
+		else if (!g.self.free_cam && bLastFreeCam)
 		{
 			CAM::SET_CAM_ACTIVE(cCam, false);
 			CAM::RENDER_SCRIPT_CAMS(false, true, 500, true, true, 0);

--- a/src/backend/looped/self/godmode.cpp
+++ b/src/backend/looped/self/godmode.cpp
@@ -12,7 +12,7 @@ namespace big
 			return;
 		}
 
-		uint32_t bits = g->self.proof_mask;
+		uint32_t bits = g.self.proof_mask;
 		uint32_t changed_bits = bits ^ last_bits;
 		uint32_t changed_or_enabled_bits = bits | changed_bits;
 

--- a/src/backend/looped/self/hud.cpp
+++ b/src/backend/looped/self/hud.cpp
@@ -9,11 +9,11 @@ namespace big
 
 	void looped::self_hud()
 	{
-		const bool bHideRadar = g->self.hide_radar;
-		const bool bHideAmmo = g->self.hide_ammo;
-		const bool bForceShowElement = g->self.force_show_hud_element;
-		const bool bForceShowHUD = g->self.force_show_hud;
-		auto& bHudComponents = g->self.hud_components_states;
+		const bool bHideRadar = g.self.hide_radar;
+		const bool bHideAmmo = g.self.hide_ammo;
+		const bool bForceShowElement = g.self.force_show_hud_element;
+		const bool bForceShowHUD = g.self.force_show_hud;
+		auto& bHudComponents = g.self.hud_components_states;
 
 		if (bHideRadar)
 		{

--- a/src/backend/looped/self/invisibility.cpp
+++ b/src/backend/looped/self/invisibility.cpp
@@ -9,25 +9,25 @@ namespace big
 	{
 		Ped ped = self::ped;
 
-		bool bInvisibility = g->self.invisibility;
+		bool bInvisibility = g.self.invisibility;
 
 		if (bInvisibility || (!bInvisibility && bInvisibility != bLastInvisibility))
 		{
-			ENTITY::SET_ENTITY_VISIBLE(ped, !g->self.invisibility, 0);
+			ENTITY::SET_ENTITY_VISIBLE(ped, !g.self.invisibility, 0);
 
-			bLastInvisibility = g->self.invisibility;
+			bLastInvisibility = g.self.invisibility;
 		}
 
 		if (NETWORK::NETWORK_IS_SESSION_STARTED())
 		{
-			if (g->self.invisibility && g->self.local_visibility)
+			if (g.self.invisibility && g.self.local_visibility)
 			{
 				NETWORK::SET_ENTITY_LOCALLY_VISIBLE(ped);
 			}
 		}
 		else 
 		{
-			if (g->self.local_visibility)
+			if (g.self.local_visibility)
 			{
 				ENTITY::SET_ENTITY_VISIBLE(ped, true, 0);
 			}

--- a/src/backend/looped/self/mobile_radio.cpp
+++ b/src/backend/looped/self/mobile_radio.cpp
@@ -7,7 +7,7 @@ namespace big
 
 	void looped::self_mobile_radio()
 	{
-		const bool bMobileRadio = g->self.mobile_radio;
+		const bool bMobileRadio = g.self.mobile_radio;
 
 		if (bMobileRadio)
 		{

--- a/src/backend/looped/self/no_collision.cpp
+++ b/src/backend/looped/self/no_collision.cpp
@@ -10,7 +10,7 @@ namespace big
 	{
 		if (g_local_player == nullptr) return;
 
-		bool bNoCollsion = g->self.no_collision;
+		bool bNoCollsion = g.self.no_collision;
 
 		if (bNoCollsion)
 		{

--- a/src/backend/looped/self/no_ragdoll.cpp
+++ b/src/backend/looped/self/no_ragdoll.cpp
@@ -7,13 +7,13 @@ namespace big
 
 	void looped::self_no_ragdoll()
 	{
-		bool bNoRagdoll = g->self.no_ragdoll;
+		bool bNoRagdoll = g.self.no_ragdoll;
 
 		if (bNoRagdoll || (!bNoRagdoll && bNoRagdoll != bLastNoRagdoll))
 		{
-			PED::SET_PED_CAN_RAGDOLL(self::ped, !g->self.no_ragdoll);
+			PED::SET_PED_CAN_RAGDOLL(self::ped, !g.self.no_ragdoll);
 
-			bLastNoRagdoll = g->self.no_ragdoll;
+			bLastNoRagdoll = g.self.no_ragdoll;
 		}
 	}
 }

--- a/src/backend/looped/self/no_water_collision.cpp
+++ b/src/backend/looped/self/no_water_collision.cpp
@@ -8,7 +8,7 @@ namespace big
 	{
 		if (g_local_player == nullptr) return;
 
-		bool bNoWaterCollsion = g->self.no_water_collision;
+		bool bNoWaterCollsion = g.self.no_water_collision;
 
 		if (bNoWaterCollsion)
 		{

--- a/src/backend/looped/self/noclip.cpp
+++ b/src/backend/looped/self/noclip.cpp
@@ -26,7 +26,7 @@ namespace big
 
 	void looped::self_noclip_disable_control_action()
 	{
-		if (g->self.noclip)
+		if (g.self.noclip)
 		{
 			for (const auto& control : controls)
 				PAD::DISABLE_CONTROL_ACTION(0, static_cast<int>(control), true);
@@ -35,7 +35,7 @@ namespace big
 
 	void looped::self_noclip()
 	{
-		const auto bNoclip = g->self.noclip;
+		const auto bNoclip = g.self.noclip;
 
 		const auto location = self::pos;
 		const Entity ent = (self::veh != 0 && g_local_player->m_ped_task_flag & (int)ePedTask::TASK_DRIVING) ? self::veh : self::ped;

--- a/src/backend/looped/self/off_radar.cpp
+++ b/src/backend/looped/self/off_radar.cpp
@@ -5,7 +5,7 @@ namespace big
 {
 	void looped::self_off_radar()
 	{
-		if (g->self.off_radar)
-			mobile::lester::off_radar(g->self.off_radar);
+		if (g.self.off_radar)
+			mobile::lester::off_radar(g.self.off_radar);
 	}
 }

--- a/src/backend/looped/self/police.cpp
+++ b/src/backend/looped/self/police.cpp
@@ -9,7 +9,7 @@ namespace big
 
 		static bool bLast = false;
 
-		bool b = g->self.never_wanted;
+		bool b = g.self.never_wanted;
 
 		if (b)
 		{
@@ -25,7 +25,7 @@ namespace big
 			bLast = b;
 		}
 
-		if(g->self.force_wanted_level && !b)
-			g_local_player->m_player_info->m_wanted_level = g->self.wanted_level;
+		if(g.self.force_wanted_level && !b)
+			g_local_player->m_player_info->m_wanted_level = g.self.wanted_level;
 	}
 }

--- a/src/backend/looped/self/super_run.cpp
+++ b/src/backend/looped/self/super_run.cpp
@@ -11,7 +11,7 @@ namespace big
 
 	void looped::self_super_run()
 	{
-		if (g->self.super_run && PAD::IS_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_SPRINT))
+		if (g.self.super_run && PAD::IS_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_SPRINT))
 		{
 			if (run_speed < run_cap) run_speed += .5f;
 
@@ -38,7 +38,7 @@ namespace big
 
 			g_local_player->m_player_info->m_run_speed = .7f;
 		}
-		else if (!g->self.super_run && g->self.super_run != super_run_state)
+		else if (!g.self.super_run && g.self.super_run != super_run_state)
 		{
 			g_local_player->m_player_info->m_run_speed = 1.f;
 		}
@@ -48,6 +48,6 @@ namespace big
 			g_local_player->m_player_info->m_run_speed = 1.f;
 		}
 
-		super_run_state = g->self.super_run;
+		super_run_state = g.self.super_run;
 	}
 }

--- a/src/backend/looped/self/unlimited_oxygen.cpp
+++ b/src/backend/looped/self/unlimited_oxygen.cpp
@@ -6,7 +6,7 @@ namespace big
 	{
 		if (g_local_player == nullptr) return;
 
-		if (g->self.unlimited_oxygen)
+		if (g.self.unlimited_oxygen)
 			g_local_player->m_oxygen_info->m_oxygen_time = 0;
 	}
 }

--- a/src/backend/looped/session/auto_kick_host.cpp
+++ b/src/backend/looped/session/auto_kick_host.cpp
@@ -8,7 +8,7 @@ namespace big
 	static bool bLastKickHost = false;
 	void looped::session_auto_kick_host()
 	{
-		bool kick_host = *g_pointers->m_is_session_started && g->session.force_session_host && g->session.kick_host_when_forcing_host;
+		bool kick_host = *g_pointers->m_is_session_started && g.session.force_session_host && g.session.kick_host_when_forcing_host;
 		if (kick_host && !bLastKickHost)
 		{
 			g_player_service->iterate([](auto& plyr)

--- a/src/backend/looped/session/force_thunder.cpp
+++ b/src/backend/looped/session/force_thunder.cpp
@@ -10,7 +10,7 @@ namespace big
 
 	void looped::session_force_thunder()
 	{
-		bool used = g->session.force_thunder && *g_pointers->m_is_session_started;
+		bool used = g.session.force_thunder && *g_pointers->m_is_session_started;
 		if (!bLastForceThunderEnabled && used)
 		{
 			if (!STREAMING::IS_PLAYER_SWITCH_IN_PROGRESS() && gta_util::find_script_thread(RAGE_JOAAT("freemode")) && SCRIPT::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH(RAGE_JOAAT("maintransition")) == 0)

--- a/src/backend/looped/session/local_time.cpp
+++ b/src/backend/looped/session/local_time.cpp
@@ -7,15 +7,15 @@ namespace big
 
 	void looped::session_local_time()
 	{
-		if (g->session.override_time)
+		if (g.session.override_time)
 		{
 			if (toggled)
 			{
-				NETWORK::NETWORK_GET_GLOBAL_MULTIPLAYER_CLOCK(&g->session.custom_time.hour, &g->session.custom_time.minute, &g->session.custom_time.second);
+				NETWORK::NETWORK_GET_GLOBAL_MULTIPLAYER_CLOCK(&g.session.custom_time.hour, &g.session.custom_time.minute, &g.session.custom_time.second);
 				toggled = false;
 			}
 
-			NETWORK::NETWORK_OVERRIDE_CLOCK_TIME(g->session.custom_time.hour, g->session.custom_time.minute, g->session.custom_time.second);
+			NETWORK::NETWORK_OVERRIDE_CLOCK_TIME(g.session.custom_time.hour, g.session.custom_time.minute, g.session.custom_time.second);
 		}
 		else
 		{

--- a/src/backend/looped/session/pop_multiplier_areas.cpp
+++ b/src/backend/looped/session/pop_multiplier_areas.cpp
@@ -12,27 +12,27 @@ namespace big
 
 	void looped::session_pop_multiplier_areas()
 	{
-		bool used = (g->session.disable_traffic || g->session.disable_peds) && *g_pointers->m_is_session_started;
+		bool used = (g.session.disable_traffic || g.session.disable_peds) && *g_pointers->m_is_session_started;
 		if (!bLastPopMultiplierAreasEnabled && used)
 		{
 			if (!STREAMING::IS_PLAYER_SWITCH_IN_PROGRESS() && gta_util::find_script_thread(RAGE_JOAAT("freemode")) && SCRIPT::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH(RAGE_JOAAT("maintransition")) == 0)
 			{
 				gta_util::execute_as_script(RAGE_JOAAT("freemode"), []
 				{
-					pop_multiplier_id = MISC::ADD_POP_MULTIPLIER_SPHERE(1.1f, 1.1f, 1.1f, 15000.0f, g->session.disable_peds ? 0.0f : 1.0f, g->session.disable_traffic ? 0.0f : 1.0f, false, true);
+					pop_multiplier_id = MISC::ADD_POP_MULTIPLIER_SPHERE(1.1f, 1.1f, 1.1f, 15000.0f, g.session.disable_peds ? 0.0f : 1.0f, g.session.disable_traffic ? 0.0f : 1.0f, false, true);
 
-					bLastBlockPeds = g->session.disable_peds;
-					bLastBlockVehs = g->session.disable_traffic;
+					bLastBlockPeds = g.session.disable_peds;
+					bLastBlockVehs = g.session.disable_traffic;
 					bLastPopMultiplierAreasEnabled = true;
 
 					MISC::CLEAR_AREA(1.1f, 1.1f, 1.1f, 19999.9f, true, false, false, true);
 				});
 			}
 		}
-		else if (bLastPopMultiplierAreasEnabled && (g->session.disable_traffic != bLastBlockVehs || g->session.disable_peds != bLastBlockPeds))
+		else if (bLastPopMultiplierAreasEnabled && (g.session.disable_traffic != bLastBlockVehs || g.session.disable_peds != bLastBlockPeds))
 		{
-			bLastBlockPeds = g->session.disable_peds;
-			bLastBlockVehs = g->session.disable_traffic;
+			bLastBlockPeds = g.session.disable_peds;
+			bLastBlockVehs = g.session.disable_traffic;
 			used = false;
 		}
 

--- a/src/backend/looped/session/randomize_ceo_colors.cpp
+++ b/src/backend/looped/session/randomize_ceo_colors.cpp
@@ -9,7 +9,7 @@ namespace big
 {
 	void looped::session_randomize_ceo_colors()
 	{
-		if (g->session.randomize_ceo_colors && *g_pointers->m_is_session_started && !STREAMING::IS_PLAYER_SWITCH_IN_PROGRESS() && SCRIPT::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH(RAGE_JOAAT("maintransition")) == 0)
+		if (g.session.randomize_ceo_colors && *g_pointers->m_is_session_started && !STREAMING::IS_PLAYER_SWITCH_IN_PROGRESS() && SCRIPT::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH(RAGE_JOAAT("maintransition")) == 0)
 		{
 			if (auto freemode = gta_util::find_script_thread(RAGE_JOAAT("freemode")); freemode && freemode->m_net_component && freemode->m_net_component->is_local_player_host())
 			{

--- a/src/backend/looped/system/auto_tp.cpp
+++ b/src/backend/looped/system/auto_tp.cpp
@@ -11,18 +11,18 @@ namespace big
 	{
 		bool temp_disable_tp = (!*g_pointers->m_is_session_started) && CUTSCENE::IS_CUTSCENE_ACTIVE();
 
-		if ((!g->self.auto_tp || temp_disable_tp) && bLastAutoTP)
+		if ((!g.self.auto_tp || temp_disable_tp) && bLastAutoTP)
 		{
 			MISC::USING_MISSION_CREATOR(false);
 			MISC::ALLOW_MISSION_CREATOR_WARP(false);
 		}
 
-		if (g->self.auto_tp && !temp_disable_tp)
+		if (g.self.auto_tp && !temp_disable_tp)
 		{
 			MISC::USING_MISSION_CREATOR(true);
 			MISC::ALLOW_MISSION_CREATOR_WARP(true);
 		}
 
-		bLastAutoTP = g->self.auto_tp;
+		bLastAutoTP = g.self.auto_tp;
 	}
 }

--- a/src/backend/looped/system/mission_creator.cpp
+++ b/src/backend/looped/system/mission_creator.cpp
@@ -10,15 +10,15 @@ namespace big
 	bool bLastMissionCreator = false;
 	void looped::system_mission_creator()
 	{
-		if (g->m_mission_creator_thread)
+		if (g.m_mission_creator_thread)
 		{
 			*scr_globals::terminate_creator.as<bool*>() = false;
 
 			if (SCRIPT::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH(RAGE_JOAAT("maintransition")) > 0)
 			{
-				if (g->m_mission_creator_thread)
-					g->m_mission_creator_thread->kill();
-				g->m_mission_creator_thread = nullptr;
+				if (g.m_mission_creator_thread)
+					g.m_mission_creator_thread->kill();
+				g.m_mission_creator_thread = nullptr;
 				return;
 			}
 

--- a/src/backend/looped/system/spoofing.cpp
+++ b/src/backend/looped/system/spoofing.cpp
@@ -8,12 +8,12 @@ namespace big
 	static bool bLastForceHost = false;
 	void looped::system_spoofing()
 	{
-		if (bLastForceHost != g->session.force_session_host && gta_util::get_network()->m_game_session_state == 0)
+		if (bLastForceHost != g.session.force_session_host && gta_util::get_network()->m_game_session_state == 0)
 		{
 			std::uint64_t host_token;
 			g_pointers->m_generate_uuid(&host_token);
 
-			host_token = g->session.force_session_host ? (rand() % 10000) : host_token;
+			host_token = g.session.force_session_host ? (rand() % 10000) : host_token;
 
 			*g_pointers->m_host_token = host_token;
 
@@ -27,17 +27,17 @@ namespace big
 			if (g_local_player && g_local_player->m_player_info)
 				g_local_player->m_player_info->m_net_player_data.m_host_token = host_token;
 
-			bLastForceHost = g->session.force_session_host;
+			bLastForceHost = g.session.force_session_host;
 		}
 
-		if (g->spoofing.rockstar_id != g->spoofing.applied_spoof_rockstar_id && gta_util::get_network()->m_game_session_state == 0)
+		if (g.spoofing.rockstar_id != g.spoofing.applied_spoof_rockstar_id && gta_util::get_network()->m_game_session_state == 0)
 		{
-			g->spoofing.applied_spoof_rockstar_id = g->spoofing.spoof_rockstar_id;
+			g.spoofing.applied_spoof_rockstar_id = g.spoofing.spoof_rockstar_id;
 		}
 
-		if (g->spoofing.spoof_rockstar_id != g->spoofing.should_spoof_rockstar_id && gta_util::get_network()->m_game_session_state == 0)
+		if (g.spoofing.spoof_rockstar_id != g.spoofing.should_spoof_rockstar_id && gta_util::get_network()->m_game_session_state == 0)
 		{
-			g->spoofing.should_spoof_rockstar_id = g->spoofing.spoof_rockstar_id;
+			g.spoofing.should_spoof_rockstar_id = g.spoofing.spoof_rockstar_id;
 		}
 	}
 }

--- a/src/backend/looped/tunables/disable_phone.cpp
+++ b/src/backend/looped/tunables/disable_phone.cpp
@@ -5,6 +5,6 @@ namespace big
 {
 	void looped::tunables_disable_phone()
 	{
-		*script_global(20366).as<bool*>() = g->tunables.disable_phone; // Who even uses that...
+		*script_global(20366).as<bool*>() = g.tunables.disable_phone; // Who even uses that...
 	}
 }

--- a/src/backend/looped/vehicle/auto_drive.cpp
+++ b/src/backend/looped/vehicle/auto_drive.cpp
@@ -21,10 +21,10 @@ namespace big
 		static bool started = false;
 		static Vector3 waypoint;
 
-		if (g->vehicle.auto_drive_destination != AutoDriveDestination::STOPPED)
+		if (g.vehicle.auto_drive_destination != AutoDriveDestination::STOPPED)
 		{
-			current_destination = g->vehicle.auto_drive_destination;
-			g->vehicle.auto_drive_destination = AutoDriveDestination::STOPPED;
+			current_destination = g.vehicle.auto_drive_destination;
+			g.vehicle.auto_drive_destination = AutoDriveDestination::STOPPED;
 			changing_driving_styles = true;
 		}
 
@@ -35,11 +35,11 @@ namespace big
 			g_notification_service->push_warning("Warning", "Please be in a car first then try again.");
 		}
 		else if (
-			current_driving_flag != driving_style_flags[g->vehicle.auto_drive_style] ||
-			current_speed != g->vehicle.auto_drive_speed
+			current_driving_flag != driving_style_flags[g.vehicle.auto_drive_style] ||
+			current_speed != g.vehicle.auto_drive_speed
 		) {
-			current_driving_flag = driving_style_flags[g->vehicle.auto_drive_style];
-			current_speed = g->vehicle.auto_drive_speed;
+			current_driving_flag = driving_style_flags[g.vehicle.auto_drive_style];
+			current_speed = g.vehicle.auto_drive_speed;
 			changing_driving_styles = true;
 		}
 

--- a/src/backend/looped/vehicle/boost_behavior.cpp
+++ b/src/backend/looped/vehicle/boost_behavior.cpp
@@ -10,12 +10,12 @@ namespace big
 
 		if (vehicle && VEHICLE::GET_HAS_ROCKET_BOOST(self::veh))
 		{
-			if (g->vehicle.boost_behavior == eBoostBehaviors::INSTANT_REFIL && (vehicle->m_boost == 0.f || !vehicle->m_boost_state)) // Instant Refill
+			if (g.vehicle.boost_behavior == eBoostBehaviors::INSTANT_REFIL && (vehicle->m_boost == 0.f || !vehicle->m_boost_state)) // Instant Refill
 			{
 				vehicle->m_boost_allow_recharge = true;
 				vehicle->m_boost = 3.f;
 			}
-			else if (g->vehicle.boost_behavior == eBoostBehaviors::INFINITE_BOOST) // Infinite Boost
+			else if (g.vehicle.boost_behavior == eBoostBehaviors::INFINITE_BOOST) // Infinite Boost
 			{
 				vehicle->m_boost_allow_recharge = true;
 				vehicle->m_boost = 3.f;

--- a/src/backend/looped/vehicle/drive_on_water.cpp
+++ b/src/backend/looped/vehicle/drive_on_water.cpp
@@ -29,7 +29,7 @@ namespace big
 
 	void looped::vehicle_drive_on_water()
 	{
-		if (!g->vehicle.drive_on_water || self::veh == 0) {
+		if (!g.vehicle.drive_on_water || self::veh == 0) {
 			drive_on_water_hide_surface();
 			return;
 		}

--- a/src/backend/looped/vehicle/fly.cpp
+++ b/src/backend/looped/vehicle/fly.cpp
@@ -14,9 +14,9 @@ namespace big
 
         Vector3 cam_pos = CAM::GET_GAMEPLAY_CAM_ROT(0);
         ENTITY::SET_ENTITY_ROTATION(vehicle, cam_pos.x, cam_pos.y, cam_pos.z, 1, true);
-        ENTITY::SET_ENTITY_COLLISION(vehicle, !g->vehicle.fly.no_collision, true);
+        ENTITY::SET_ENTITY_COLLISION(vehicle, !g.vehicle.fly.no_collision, true);
 
-        float locspeed = g->vehicle.fly.speed;
+        float locspeed = g.vehicle.fly.speed;
 
         if (PAD::IS_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_VEH_MOVE_UP_ONLY))
         {
@@ -26,9 +26,9 @@ namespace big
 
         if (PAD::IS_CONTROL_PRESSED(2, (int)ControllerInputs::INPUT_VEH_ACCELERATE))
         {
-            if (g->vehicle.fly.dont_stop)
+            if (g.vehicle.fly.dont_stop)
             {
-                ENTITY::APPLY_FORCE_TO_ENTITY(vehicle, 1, 0.0, g->vehicle.fly.speed, 0.0, 0.0, 0.0, 0.0, 0, 1, 1, 1, 0, 1);
+                ENTITY::APPLY_FORCE_TO_ENTITY(vehicle, 1, 0.0, g.vehicle.fly.speed, 0.0, 0.0, 0.0, 0.0, 0, 1, 1, 1, 0, 1);
             }
             else
             {
@@ -38,12 +38,12 @@ namespace big
 
         if (PAD::IS_CONTROL_PRESSED(2, (int)ControllerInputs::INPUT_VEH_BRAKE))
         {
-            float lsp = g->vehicle.fly.speed;
+            float lsp = g.vehicle.fly.speed;
             if (!PAD::IS_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_VEH_MOVE_UP_ONLY))
             {
-                lsp = (g->vehicle.fly.speed * 2);
+                lsp = (g.vehicle.fly.speed * 2);
             }
-            if (g->vehicle.fly.dont_stop)
+            if (g.vehicle.fly.dont_stop)
             {
                 ENTITY::APPLY_FORCE_TO_ENTITY(vehicle, 1, 0.0, 0 - (lsp), 0.0, 0.0, 0.0, 0.0, 0, 1, 1, 1, 0, 1);
             }
@@ -55,12 +55,12 @@ namespace big
 
         if (PAD::IS_CONTROL_PRESSED(2, (int)ControllerInputs::INPUT_VEH_MOVE_LEFT_ONLY))
         {
-            float lsp = ((0 - g->vehicle.fly.speed) * 2);
+            float lsp = ((0 - g.vehicle.fly.speed) * 2);
             if (!PAD::IS_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_VEH_MOVE_UP_ONLY))
             {
-                lsp = (0 - g->vehicle.fly.speed);
+                lsp = (0 - g.vehicle.fly.speed);
             }
-            if (g->vehicle.fly.dont_stop)
+            if (g.vehicle.fly.dont_stop)
             {
                 ENTITY::APPLY_FORCE_TO_ENTITY(vehicle, 1, (lsp), 0.0, 0.0, 0.0, 0.0, 0.0, 0, 1, 1, 1, 0, 1);
             }
@@ -72,12 +72,12 @@ namespace big
 
         if (PAD::IS_CONTROL_PRESSED(2, (int)ControllerInputs::INPUT_VEH_MOVE_RIGHT_ONLY))
         {
-            float lsp = g->vehicle.fly.speed;
+            float lsp = g.vehicle.fly.speed;
             if (!PAD::IS_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_VEH_MOVE_UP_ONLY))
             {
-                lsp = (g->vehicle.fly.speed * 2);
+                lsp = (g.vehicle.fly.speed * 2);
             }
-            if (g->vehicle.fly.dont_stop)
+            if (g.vehicle.fly.dont_stop)
             {
                 ENTITY::APPLY_FORCE_TO_ENTITY(vehicle, 1, lsp, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 1, 1, 1, 0, 1);
             }
@@ -87,17 +87,17 @@ namespace big
             }
         }
 
-        if (!g->vehicle.fly.dont_stop && !PAD::IS_CONTROL_PRESSED(2, (int)ControllerInputs::INPUT_VEH_ACCELERATE) && !PAD::IS_CONTROL_PRESSED(2, (int)ControllerInputs::INPUT_VEH_BRAKE))
+        if (!g.vehicle.fly.dont_stop && !PAD::IS_CONTROL_PRESSED(2, (int)ControllerInputs::INPUT_VEH_ACCELERATE) && !PAD::IS_CONTROL_PRESSED(2, (int)ControllerInputs::INPUT_VEH_BRAKE))
         {
             VEHICLE::SET_VEHICLE_FORWARD_SPEED(vehicle, 0.0);
         }
 
         if (TASK::GET_IS_TASK_ACTIVE(self::ped, 2))
         {
-            g->vehicle.fly.enabled = false;
+            g.vehicle.fly.enabled = false;
             VEHICLE::SET_VEHICLE_GRAVITY(vehicle, true);
             ENTITY::SET_ENTITY_COLLISION(vehicle, true, true);
-            if (g->vehicle.fly.stop_on_exit)
+            if (g.vehicle.fly.stop_on_exit)
             {
                 VEHICLE::SET_VEHICLE_FORWARD_SPEED(vehicle, 0.0);
             }
@@ -107,7 +107,7 @@ namespace big
 	void looped::vehicle_fly()
 	{
         Vehicle vehicle = self::veh;
-		if (g->vehicle.fly.enabled)
+		if (g.vehicle.fly.enabled)
 		{
 
             last_fly_tick = true;
@@ -115,7 +115,7 @@ namespace big
             if (!vehicle)
             {
                 g_notification_service->push_warning("Warning", "Please be in a vehicle before enabling vehicle fly.");
-                g->vehicle.fly.enabled = false;
+                g.vehicle.fly.enabled = false;
                 return;
             }
             else 

--- a/src/backend/looped/vehicle/horn_boost.cpp
+++ b/src/backend/looped/vehicle/horn_boost.cpp
@@ -10,7 +10,7 @@ namespace big
 
 	void looped::vehicle_horn_boost()
 	{
-		if (!g->vehicle.horn_boost) return;
+		if (!g.vehicle.horn_boost) return;
 		
 		Vehicle vehicle = self::veh;
 

--- a/src/backend/looped/vehicle/instant_brake.cpp
+++ b/src/backend/looped/vehicle/instant_brake.cpp
@@ -7,7 +7,7 @@ namespace big
 
 	void looped::vehicle_instant_brake()
 	{
-		if (!g->vehicle.instant_brake) return;
+		if (!g.vehicle.instant_brake) return;
 
 		Vehicle vehicle = self::veh;
 

--- a/src/backend/looped/vehicle/is_targetable.cpp
+++ b/src/backend/looped/vehicle/is_targetable.cpp
@@ -5,6 +5,6 @@ namespace big
 	void looped::vehicle_is_targetable()
 	{
 		if (g_local_player && g_local_player->m_vehicle)
-			g_local_player->m_vehicle->m_is_targetable = g->vehicle.is_targetable;
+			g_local_player->m_vehicle->m_is_targetable = g.vehicle.is_targetable;
 	}
 }

--- a/src/backend/looped/vehicle/keep_vehicle_repaired.cpp
+++ b/src/backend/looped/vehicle/keep_vehicle_repaired.cpp
@@ -5,7 +5,7 @@ namespace big
 {
 	void looped::vehicle_keep_vehicle_repaired()
 	{
-		if (g->vehicle.keep_vehicle_repaired && VEHICLE::GET_DOES_VEHICLE_HAVE_DAMAGE_DECALS(self::veh)) {
+		if (g.vehicle.keep_vehicle_repaired && VEHICLE::GET_DOES_VEHICLE_HAVE_DAMAGE_DECALS(self::veh)) {
 			vehicle::repair(self::veh);
 		}
 	}

--- a/src/backend/looped/vehicle/ls_customs.cpp
+++ b/src/backend/looped/vehicle/ls_customs.cpp
@@ -18,7 +18,7 @@ namespace big
 		busy = true;
 
 		constexpr int hash = RAGE_JOAAT("carmod_shop");
-		if (g->vehicle.ls_customs && g->vehicle.ls_customs == state)
+		if (g.vehicle.ls_customs && g.vehicle.ls_customs == state)
 		{
 			if (
 				auto carmod_shop_thread = gta_util::find_script_thread(hash);
@@ -26,19 +26,19 @@ namespace big
 				*script_local(carmod_shop_thread, CARMOD_SHOP_STRUCT).at(11).as<int*>() != 4
 				)
 			{
-				g->vehicle.ls_customs = false;
+				g.vehicle.ls_customs = false;
 
 				*script_local(carmod_shop_thread, CARMOD_SHOP_STRUCT).as<int*>() = 1; // cleanup
 			}
 		}
 
-		if (g->vehicle.ls_customs && g->vehicle.ls_customs != state)
+		if (g.vehicle.ls_customs && g.vehicle.ls_customs != state)
 		{
 			Vehicle veh = self::veh;
 			if (!ENTITY::DOES_ENTITY_EXIST(veh) || ENTITY::IS_ENTITY_DEAD(veh, false))
 			{
 				busy = false;
-				g->vehicle.ls_customs = false;
+				g.vehicle.ls_customs = false;
 
 				g_notification_service->push_warning("LS Customs", "You aren't in a vehicle.");
 
@@ -67,6 +67,6 @@ namespace big
 		}
 
 		busy = false;
-		state = g->vehicle.ls_customs;
+		state = g.vehicle.ls_customs;
 	}
 }

--- a/src/backend/looped/vehicle/no_water_collision.cpp
+++ b/src/backend/looped/vehicle/no_water_collision.cpp
@@ -8,7 +8,7 @@ namespace big
 	{
 		if (g_local_player == nullptr || g_local_player->m_vehicle == nullptr) return;
 
-		bool bNoWaterCollsion = g->vehicle.no_water_collision;
+		bool bNoWaterCollsion = g.vehicle.no_water_collision;
 
 		if (bNoWaterCollsion)
 		{

--- a/src/backend/looped/vehicle/rgb_paint.cpp
+++ b/src/backend/looped/vehicle/rgb_paint.cpp
@@ -25,17 +25,17 @@ namespace big
 		static int green = 0;
 		static int blue = 0;
 
-		if (self::veh && g->vehicle.rainbow_paint.type != RainbowPaintType::Off && last_rgb_run_time + delay < std::chrono::system_clock::now())
+		if (self::veh && g.vehicle.rainbow_paint.type != RainbowPaintType::Off && last_rgb_run_time + delay < std::chrono::system_clock::now())
 		{
 			int delay_step = 100;
 
-			if (g->vehicle.rainbow_paint.type == RainbowPaintType::Spasm)
+			if (g.vehicle.rainbow_paint.type == RainbowPaintType::Spasm)
 			{
 				red = rand() % 256;
 				green = rand() % 256;
 				blue = rand() % 256;
 			}
-			else if (g->vehicle.rainbow_paint.type == RainbowPaintType::Fade)
+			else if (g.vehicle.rainbow_paint.type == RainbowPaintType::Fade)
 			{
 				delay_step = 10;
 
@@ -103,24 +103,24 @@ namespace big
 
 			Vehicle vehicle = self::veh;
 
-			if (g->vehicle.rainbow_paint.primary) {
+			if (g.vehicle.rainbow_paint.primary) {
 				VEHICLE::SET_VEHICLE_CUSTOM_PRIMARY_COLOUR(vehicle, red, green, blue);
 			}
-			if (g->vehicle.rainbow_paint.secondary) {
+			if (g.vehicle.rainbow_paint.secondary) {
 				VEHICLE::SET_VEHICLE_CUSTOM_SECONDARY_COLOUR(vehicle, red, green, blue);
 			}
-			if (g->vehicle.rainbow_paint.neon) {
+			if (g.vehicle.rainbow_paint.neon) {
 				VEHICLE::SET_VEHICLE_NEON_ENABLED(vehicle, 0, 1);
 				VEHICLE::SET_VEHICLE_NEON_ENABLED(vehicle, 1, 1);
 				VEHICLE::SET_VEHICLE_NEON_ENABLED(vehicle, 2, 1);
 				VEHICLE::SET_VEHICLE_NEON_ENABLED(vehicle, 3, 1);
 				VEHICLE::SET_VEHICLE_NEON_COLOUR(vehicle, red, green, blue);
 			}
-			if (g->vehicle.rainbow_paint.smoke) {
+			if (g.vehicle.rainbow_paint.smoke) {
 				VEHICLE::SET_VEHICLE_TYRE_SMOKE_COLOR(vehicle, red, green, blue);
 			}
 
-			delay = std::chrono::milliseconds(((delay_step * 10) + 10) - (g->vehicle.rainbow_paint.speed * delay_step));
+			delay = std::chrono::milliseconds(((delay_step * 10) + 10) - (g.vehicle.rainbow_paint.speed * delay_step));
 			last_rgb_run_time = std::chrono::system_clock::now();
 		}
 	}

--- a/src/backend/looped/vehicle/seatbelt.cpp
+++ b/src/backend/looped/vehicle/seatbelt.cpp
@@ -7,15 +7,15 @@ namespace big
 
 	void looped::vehicle_seatbelt()
 	{
-		bool b_seatbelt = g->vehicle.seatbelt;
+		bool b_seatbelt = g.vehicle.seatbelt;
 
 		if (b_seatbelt || (!b_seatbelt && b_seatbelt != b_last_seatbelt))
 		{
-			PED::SET_PED_CONFIG_FLAG(self::ped, 32, g->vehicle.seatbelt);
+			PED::SET_PED_CONFIG_FLAG(self::ped, 32, g.vehicle.seatbelt);
 
-			PED::SET_PED_CAN_BE_KNOCKED_OFF_VEHICLE(self::ped, g->vehicle.seatbelt);
+			PED::SET_PED_CAN_BE_KNOCKED_OFF_VEHICLE(self::ped, g.vehicle.seatbelt);
 
-			b_last_seatbelt = g->vehicle.seatbelt;
+			b_last_seatbelt = g.vehicle.seatbelt;
 		}
 	}
 }

--- a/src/backend/looped/vehicle/speedo_meter.cpp
+++ b/src/backend/looped/vehicle/speedo_meter.cpp
@@ -7,7 +7,7 @@ namespace big
 	void looped::vehicle_speedo_meter()
 	{
 		if (
-			!g->vehicle.speedo_meter.enabled ||
+			!g.vehicle.speedo_meter.enabled ||
 			self::veh == 0 ||
 			HUD::IS_PAUSE_MENU_ACTIVE() ||
 			HUD::IS_WARNING_MESSAGE_ACTIVE() ||
@@ -24,10 +24,10 @@ namespace big
 
 		float veh_speed = vehicle::mps_to_speed(
 			ENTITY::GET_ENTITY_SPEED(self::veh),
-			g->vehicle.speed_unit
+			g.vehicle.speed_unit
 		);
 
-		switch (g->vehicle.speed_unit)
+		switch (g.vehicle.speed_unit)
 		{
 		case SpeedUnit::KMPH:
 			strcpy(speed_type, "kmph");
@@ -41,21 +41,21 @@ namespace big
 			break;
 		}
 
-		sprintf(speed, "%*d", g->vehicle.speedo_meter.left_side ? 0 : char_width, (int)veh_speed);
+		sprintf(speed, "%*d", g.vehicle.speedo_meter.left_side ? 0 : char_width, (int)veh_speed);
 
 		HUD::SET_TEXT_FONT(2);
 		HUD::SET_TEXT_SCALE(.9f, .9f);
 		HUD::SET_TEXT_OUTLINE();
 		HUD::BEGIN_TEXT_COMMAND_DISPLAY_TEXT("STRING");
 		HUD::ADD_TEXT_COMPONENT_SUBSTRING_PLAYER_NAME(speed_type);
-		HUD::END_TEXT_COMMAND_DISPLAY_TEXT(g->vehicle.speedo_meter.x, g->vehicle.speedo_meter.y, 1);
+		HUD::END_TEXT_COMMAND_DISPLAY_TEXT(g.vehicle.speedo_meter.x, g.vehicle.speedo_meter.y, 1);
 
 		HUD::SET_TEXT_FONT(2);
 		HUD::SET_TEXT_SCALE(.9f, .9f);
 		HUD::SET_TEXT_OUTLINE();
 		HUD::BEGIN_TEXT_COMMAND_DISPLAY_TEXT("STRING");
 		HUD::ADD_TEXT_COMPONENT_SUBSTRING_PLAYER_NAME(speed);
-		HUD::END_TEXT_COMMAND_DISPLAY_TEXT(g->vehicle.speedo_meter.x + (g->vehicle.speedo_meter.left_side ? 0 : .003f), g->vehicle.speedo_meter.y + .04f, 1);
+		HUD::END_TEXT_COMMAND_DISPLAY_TEXT(g.vehicle.speedo_meter.x + (g.vehicle.speedo_meter.left_side ? 0 : .003f), g.vehicle.speedo_meter.y + .04f, 1);
 
 	}
 }

--- a/src/backend/looped/vehicle/turn_signals.cpp
+++ b/src/backend/looped/vehicle/turn_signals.cpp
@@ -81,7 +81,7 @@ inline void set_turn_signals(int signal_state, bool on)
 {
 	static constexpr int off = 0;
 
-	if (self::veh && big::g->vehicle.turn_signals)
+	if (self::veh && big::g.vehicle.turn_signals)
 	{
 		switch (signal_state)
 		{
@@ -110,7 +110,7 @@ namespace big
 	void looped::vehicle_turn_signals()
 	{
 		static bool hazzards = false;
-		bool b_turn_signals = g->vehicle.turn_signals;
+		bool b_turn_signals = g.vehicle.turn_signals;
 
 		if (!b_turn_signals && b_turn_signals != b_last_turn_signals)
 		{
@@ -118,7 +118,7 @@ namespace big
 			VEHICLE::SET_VEHICLE_INDICATOR_LIGHTS(PED::GET_VEHICLE_PED_IS_IN(PLAYER::PLAYER_PED_ID(), false), 1, 0);
 		}
 
-		if (g->vehicle.turn_signals)
+		if (g.vehicle.turn_signals)
 		{
 			static bool ran_once = []
 			{
@@ -130,12 +130,12 @@ namespace big
 
 		update_key_states();
 
-		if (left_signal_key.state == key_state::just_pressed || g->vehicle.auto_turn_signals && PAD::IS_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_VEH_MOVE_LEFT_ONLY))
+		if (left_signal_key.state == key_state::just_pressed || g.vehicle.auto_turn_signals && PAD::IS_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_VEH_MOVE_LEFT_ONLY))
 		{
 			set_turn_signals(signal_state::left, true);
 		}
 
-		if (right_signal_key.state == key_state::just_pressed || g->vehicle.auto_turn_signals && PAD::IS_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_VEH_MOVE_RIGHT_ONLY))
+		if (right_signal_key.state == key_state::just_pressed || g.vehicle.auto_turn_signals && PAD::IS_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_VEH_MOVE_RIGHT_ONLY))
 		{
 			set_turn_signals(signal_state::right, true);
 		}
@@ -145,7 +145,7 @@ namespace big
 			set_turn_signals(signal_state::hazzards, true);
 			hazzards = true;
 		}
-		else if (hazzards_key.state == key_state::just_pressed && hazzards || !g->vehicle.turn_signals)
+		else if (hazzards_key.state == key_state::just_pressed && hazzards || !g.vehicle.turn_signals)
 		{
 			set_turn_signals(signal_state::hazzards, false);
 			hazzards = false;
@@ -154,7 +154,7 @@ namespace big
 
 		if (PAD::IS_CONTROL_JUST_RELEASED(0, (int)ControllerInputs::INPUT_VEH_MOVE_LEFT_ONLY))
 		{
-			if (g->vehicle.turn_signals)
+			if (g.vehicle.turn_signals)
 			{
 				script::get_current()->yield(1500ms);
 			}
@@ -163,14 +163,14 @@ namespace big
 
 		if (PAD::IS_CONTROL_JUST_RELEASED(0, (int)ControllerInputs::INPUT_VEH_MOVE_RIGHT_ONLY))
 		{
-			if (g->vehicle.turn_signals)
+			if (g.vehicle.turn_signals)
 			{
 				script::get_current()->yield(1500ms);
 			}
 			set_turn_signals(signal_state::right, false);
 		}
 
-		b_last_turn_signals = g->vehicle.turn_signals;
+		b_last_turn_signals = g.vehicle.turn_signals;
 
 	}
 }

--- a/src/backend/looped/vehicle/vehicle_god.cpp
+++ b/src/backend/looped/vehicle/vehicle_god.cpp
@@ -14,7 +14,7 @@ namespace big
 		}
 
 		if (
-			(g->vehicle.god_mode || g->vehicle.proof_collision) &&
+			(g.vehicle.god_mode || g.vehicle.proof_collision) &&
 			g_local_player->m_ped_task_flag & (int)ePedTask::TASK_DRIVING
 		) {
 			g_local_player->m_vehicle->m_deform_god = 0x8C;
@@ -24,7 +24,7 @@ namespace big
 			g_local_player->m_vehicle->m_deform_god = 0x9C;
 		}
 
-		uint32_t bits = g->vehicle.proof_mask;
+		uint32_t bits = g.vehicle.proof_mask;
 		uint32_t changed_bits = bits ^ last_bits;
 		uint32_t changed_or_enabled_bits = bits | changed_bits;
 

--- a/src/backend/looped/vehicle/vehicle_jump.cpp
+++ b/src/backend/looped/vehicle/vehicle_jump.cpp
@@ -6,7 +6,7 @@ namespace big
 {
 	void looped::vehicle_jump()
 	{
-		if (!g->vehicle.vehicle_jump) return;
+		if (!g.vehicle.vehicle_jump) return;
 
 		const auto vehicle = self::veh;
 

--- a/src/backend/looped/weapons/ammo_special_type.cpp
+++ b/src/backend/looped/weapons/ammo_special_type.cpp
@@ -18,7 +18,7 @@ namespace big
 			return;
 		}
 
-		if (g->weapons.ammo_special.toggle) {
+		if (g.weapons.ammo_special.toggle) {
 			CWeaponInfo* weapon_info = g_local_player->m_weapon_manager->m_weapon_info;
 
 			// check if the player changed their weapon
@@ -39,12 +39,12 @@ namespace big
 
 			// apply ammo type changes to the current weapon
 			eDamageType damage_type = eDamageType::None;
-			eExplosionTag explosion_tag = g->weapons.ammo_special.explosion_tag;
+			eExplosionTag explosion_tag = g.weapons.ammo_special.explosion_tag;
 			eAmmoSpecialType ammo_type = eAmmoSpecialType::None;
 
 			if (explosion_tag == eExplosionTag::DONTCARE) {
 				damage_type = modified_weapon_damage_type;
-				ammo_type = g->weapons.ammo_special.type;
+				ammo_type = g.weapons.ammo_special.type;
 			}
 			else {
 				damage_type = eDamageType::Explosive;

--- a/src/backend/looped/weapons/cage_gun.cpp
+++ b/src/backend/looped/weapons/cage_gun.cpp
@@ -7,7 +7,7 @@ namespace big
 {
 	void looped::weapons_cage_gun()
 	{
-		bool bCageGun = g->weapons.custom_weapon == CustomWeapon::CAGE_GUN;
+		bool bCageGun = g.weapons.custom_weapon == CustomWeapon::CAGE_GUN;
 
 		if (bCageGun)
 		{

--- a/src/backend/looped/weapons/custom_gun_disable_control_action.cpp
+++ b/src/backend/looped/weapons/custom_gun_disable_control_action.cpp
@@ -19,7 +19,7 @@ namespace big
 
 	void looped::custom_gun_disable_control_action()
 	{
-		bool is_custom_gun_selected = g->weapons.custom_weapon != CustomWeapon::NONE;
+		bool is_custom_gun_selected = g.weapons.custom_weapon != CustomWeapon::NONE;
 		if (is_custom_gun_selected)
 		{
 			for (const auto& control : attack_controls)

--- a/src/backend/looped/weapons/delete_gun.cpp
+++ b/src/backend/looped/weapons/delete_gun.cpp
@@ -8,7 +8,7 @@ namespace big
 {
 	void looped::weapons_delete_gun()
 	{
-		bool bCageGun = g->weapons.custom_weapon == CustomWeapon::DELETE_GUN;
+		bool bCageGun = g.weapons.custom_weapon == CustomWeapon::DELETE_GUN;
 
 		if (bCageGun)
 		{

--- a/src/backend/looped/weapons/force_crosshairs.cpp
+++ b/src/backend/looped/weapons/force_crosshairs.cpp
@@ -6,7 +6,7 @@ namespace big
 {
 	void looped::weapons_force_crosshairs()
 	{
-		if (g->weapons.force_crosshairs) {
+		if (g.weapons.force_crosshairs) {
 			HUD::SHOW_HUD_COMPONENT_THIS_FRAME(static_cast<int>(HudComponents::RETICLE));
 		}
 	}

--- a/src/backend/looped/weapons/gravity_gun.cpp
+++ b/src/backend/looped/weapons/gravity_gun.cpp
@@ -15,7 +15,7 @@ namespace big
 
 	void looped::weapons_gravity_gun()
 	{
-		bool is_gravity_gun_selected = g->weapons.custom_weapon == CustomWeapon::GRAVITY_GUN;
+		bool is_gravity_gun_selected = g.weapons.custom_weapon == CustomWeapon::GRAVITY_GUN;
 		constexpr double multiplier = 3.0;
 
 		auto is_zoomed_in = is_gravity_gun_selected && PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_AIM);

--- a/src/backend/looped/weapons/increase_damage.cpp
+++ b/src/backend/looped/weapons/increase_damage.cpp
@@ -5,10 +5,10 @@ namespace big
 {
 	void looped::weapons_increased_damage()
 	{
-		if (g->weapons.increased_damage != 1) {
+		if (g.weapons.increased_damage != 1) {
 			Hash weapon{}; 
 			WEAPON::GET_CURRENT_PED_WEAPON(self::ped, &weapon, 0);
-			WEAPON::SET_WEAPON_DAMAGE_MODIFIER(weapon, g->weapons.increased_damage);
+			WEAPON::SET_WEAPON_DAMAGE_MODIFIER(weapon, g.weapons.increased_damage);
 		}
 	}
 }

--- a/src/backend/looped/weapons/infinite_ammo.cpp
+++ b/src/backend/looped/weapons/infinite_ammo.cpp
@@ -7,13 +7,13 @@ namespace big
 
 	void looped::weapons_infinite_ammo()
 	{
-		bool bInfiniteAmmo = g->weapons.infinite_ammo;
+		bool bInfiniteAmmo = g.weapons.infinite_ammo;
 
 		if (bInfiniteAmmo || (!bInfiniteAmmo && bInfiniteAmmo != bLastInfiniteAmmo))
 		{
-			WEAPON::SET_PED_INFINITE_AMMO(self::ped, g->weapons.infinite_ammo, NULL);
+			WEAPON::SET_PED_INFINITE_AMMO(self::ped, g.weapons.infinite_ammo, NULL);
 
-			bLastInfiniteAmmo = g->weapons.infinite_ammo;
+			bLastInfiniteAmmo = g.weapons.infinite_ammo;
 		}
 	}
 }

--- a/src/backend/looped/weapons/infinite_mag.cpp
+++ b/src/backend/looped/weapons/infinite_mag.cpp
@@ -7,13 +7,13 @@ namespace big
 
 	void looped::weapons_infinite_mag()
 	{
-		bool bInfiniteMag = g->weapons.infinite_mag;
+		bool bInfiniteMag = g.weapons.infinite_mag;
 
 		if (bInfiniteMag || (!bInfiniteMag && bInfiniteMag != bLastInfiniteMag))
 		{
-			WEAPON::SET_PED_INFINITE_AMMO_CLIP(self::ped, g->weapons.infinite_mag);
+			WEAPON::SET_PED_INFINITE_AMMO_CLIP(self::ped, g.weapons.infinite_mag);
 
-			bLastInfiniteMag = g->weapons.infinite_mag;
+			bLastInfiniteMag = g.weapons.infinite_mag;
 		}
 	}
 }

--- a/src/backend/looped/weapons/no_recoil.cpp
+++ b/src/backend/looped/weapons/no_recoil.cpp
@@ -24,7 +24,7 @@ namespace big
 
 	float get_recoil_value(uint32_t hash)
 	{
-		return g->weapons.no_recoil
+		return g.weapons.no_recoil
 			? 0.f
 			: get_og_recoil_value(hash);
 	}

--- a/src/backend/looped/weapons/no_spread.cpp
+++ b/src/backend/looped/weapons/no_spread.cpp
@@ -24,7 +24,7 @@ namespace big
 
 	float get_spread_value(uint32_t hash)
 	{
-		return g->weapons.no_spread
+		return g.weapons.no_spread
 			? 0.f
 			: get_og_spread_value(hash);
 	}

--- a/src/backend/looped/weapons/rapid_fire.cpp
+++ b/src/backend/looped/weapons/rapid_fire.cpp
@@ -8,7 +8,7 @@ namespace big
 {
     void looped::weapons_rapid_fire()
     {
-        if (g->weapons.rapid_fire)
+        if (g.weapons.rapid_fire)
         {
             if(!HUD::IS_PAUSE_MENU_ACTIVE() && !g_gui->is_open() && !PED::IS_PED_DEAD_OR_DYING(self::ped, true))
             {

--- a/src/backend/looped/weapons/repair_gun.cpp
+++ b/src/backend/looped/weapons/repair_gun.cpp
@@ -7,7 +7,7 @@ namespace big
 {
 	void looped::weapons_repair_gun()
 	{
-		bool bRepairGun = g->weapons.custom_weapon == CustomWeapon::REPAIR_GUN;
+		bool bRepairGun = g.weapons.custom_weapon == CustomWeapon::REPAIR_GUN;
 
 		if (bRepairGun)
 		{

--- a/src/backend/looped/weapons/steal_vehicle_gun.cpp
+++ b/src/backend/looped/weapons/steal_vehicle_gun.cpp
@@ -9,7 +9,7 @@ namespace big
 
 	void looped::weapons_steal_vehicle_gun()
 	{
-		if (const bool bStealVehicleGun = g->weapons.custom_weapon == CustomWeapon::STEAL_VEHICLE_GUN; bStealVehicleGun)
+		if (const bool bStealVehicleGun = g.weapons.custom_weapon == CustomWeapon::STEAL_VEHICLE_GUN; bStealVehicleGun)
 		{
 			if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_AIM))
 			{

--- a/src/backend/looped/weapons/vehicle_gun.cpp
+++ b/src/backend/looped/weapons/vehicle_gun.cpp
@@ -10,7 +10,7 @@ namespace big
 
 	void looped::weapons_vehicle_gun()
 	{
-		const bool is_vehicle_gun_selected = g->weapons.custom_weapon == CustomWeapon::VEHICLE_GUN;
+		const bool is_vehicle_gun_selected = g.weapons.custom_weapon == CustomWeapon::VEHICLE_GUN;
 
 		const auto time_now = std::chrono::steady_clock::now();
 
@@ -35,7 +35,7 @@ namespace big
 			location.y += dist * sin(yaw) * cos(pitch);
 			location.z += dist * sin(pitch);
 			Vehicle veh = vehicle::spawn(
-				rage::joaat(g->weapons.vehicle_gun_model.data()),
+				rage::joaat(g.weapons.vehicle_gun_model.data()),
 				location,
 				ENTITY::GET_ENTITY_HEADING(self::ped)
 			);

--- a/src/backend/looped/weapons/vehicle_gun.cpp
+++ b/src/backend/looped/weapons/vehicle_gun.cpp
@@ -35,7 +35,7 @@ namespace big
 			location.y += dist * sin(yaw) * cos(pitch);
 			location.z += dist * sin(pitch);
 			Vehicle veh = vehicle::spawn(
-				rage::joaat((const char*)g->weapons.vehicle_gun_model),
+				rage::joaat(g->weapons.vehicle_gun_model.data()),
 				location,
 				ENTITY::GET_ENTITY_HEADING(self::ped)
 			);

--- a/src/backend/script_patches.hpp
+++ b/src/backend/script_patches.hpp
@@ -6,9 +6,9 @@ namespace big
 {
 	void register_script_patches()
 	{
-		g_script_patcher_service->add_patch({ RAGE_JOAAT("freemode"), "2D 01 08 00 ? 38 00 5D ? ? ? 2A 06", 5, {0x71, 0x2E, 0x01, 0x01}, &g->session.decloak_players });
-		g_script_patcher_service->add_patch({ RAGE_JOAAT("freemode"), "2D 01 04 00 ? 2C ? ? ? 5D ? ? ? 71 57 ? ? 2C", 5, { 0x2E, 0x01, 0x00 }, &g->protections.script_host_kick });
-		g_script_patcher_service->add_patch({ RAGE_JOAAT("freemode"), "2D 00 07 00 00 5D ? ? ? 56 ? ? 71", 5, { 0x2E, 0x00, 0x00 }, &g->tunables.no_idle_kick });
+		g_script_patcher_service->add_patch({ RAGE_JOAAT("freemode"), "2D 01 08 00 ? 38 00 5D ? ? ? 2A 06", 5, {0x71, 0x2E, 0x01, 0x01}, &g.session.decloak_players });
+		g_script_patcher_service->add_patch({ RAGE_JOAAT("freemode"), "2D 01 04 00 ? 2C ? ? ? 5D ? ? ? 71 57 ? ? 2C", 5, { 0x2E, 0x01, 0x00 }, &g.protections.script_host_kick });
+		g_script_patcher_service->add_patch({ RAGE_JOAAT("freemode"), "2D 00 07 00 00 5D ? ? ? 56 ? ? 71", 5, { 0x2E, 0x00, 0x00 }, &g.tunables.no_idle_kick });
 		g_script_patcher_service->add_patch({ RAGE_JOAAT("freemode"), "5D ? ? ? 76 57 ? ? 5D ? ? ? 76", 0, { 0x2E, 0x00, 0x00 }, nullptr }); // end session kick protection
 		g_script_patcher_service->add_patch({ RAGE_JOAAT("freemode"), "2D 01 09 00 00 5D ? ? ? 56 ? ? 2E", 5, { 0x2E, 0x01, 0x00 }, nullptr }); // disable death when undermap/spectating
 		g_script_patcher_service->add_patch({ RAGE_JOAAT("shop_controller"), "2D 01 04 00 00 2C ? ? ? 56 ? ? 71", 5, { 0x71, 0x2E, 0x01, 0x01 }, nullptr }); // despawn bypass

--- a/src/core/enums.hpp
+++ b/src/core/enums.hpp
@@ -8,6 +8,11 @@ namespace big
 		INSTANT_REFIL,
 		INFINITE_BOOST
 	};
+	NLOHMANN_JSON_SERIALIZE_ENUM(eBoostBehaviors, {
+		{ eBoostBehaviors::DEFAULT, "default" },
+		{ eBoostBehaviors::INSTANT_REFIL, "instant" },
+		{ eBoostBehaviors::INFINITE_BOOST, "infinite" }
+	})
 
 	enum class CustomWeapon
 	{
@@ -19,6 +24,15 @@ namespace big
 		REPAIR_GUN,
 		VEHICLE_GUN
 	};
+	NLOHMANN_JSON_SERIALIZE_ENUM(CustomWeapon, {
+		{ CustomWeapon::NONE, "none" },
+		{ CustomWeapon::CAGE_GUN, "cage" },
+		{ CustomWeapon::DELETE_GUN, "delete" },
+		{ CustomWeapon::GRAVITY_GUN, "gravity" },
+		{ CustomWeapon::STEAL_VEHICLE_GUN, "steal" },
+		{ CustomWeapon::REPAIR_GUN, "repair" },
+		{ CustomWeapon::VEHICLE_GUN, "vehicle" },
+	})
 
 	enum class ContextEntityType : uint8_t
 	{
@@ -271,6 +285,11 @@ namespace big
 		MIPH,
 		MPS
 	};
+	NLOHMANN_JSON_SERIALIZE_ENUM(SpeedUnit, {
+		{ SpeedUnit::KMPH, "kmph" },
+		{ SpeedUnit::MIPH, "miph" },
+		{ SpeedUnit::MPS, "mps" },
+	})
 
 	enum class RainbowPaintType
 	{
@@ -278,6 +297,11 @@ namespace big
 		Fade,
 		Spasm
 	};
+	NLOHMANN_JSON_SERIALIZE_ENUM(RainbowPaintType, {
+		{ RainbowPaintType::Off, "off" },
+		{ RainbowPaintType::Fade, "fade" },
+		{ RainbowPaintType::Spasm, "spasm" },
+	})
 
 	enum class AutoDriveDestination
 	{
@@ -287,12 +311,23 @@ namespace big
 		WANDER,
 		EMERGENCY_STOP
 	};
+	NLOHMANN_JSON_SERIALIZE_ENUM(AutoDriveDestination, {
+		{ AutoDriveDestination::STOPPED, "stopped" },
+		{ AutoDriveDestination::OBJECTITVE, "objective" },
+		{ AutoDriveDestination::WAYPOINT, "waypoint" },
+		{ AutoDriveDestination::WANDER, "wander" },
+		{ AutoDriveDestination::EMERGENCY_STOP, "emergency_stop" },
+	})
 
 	enum class AutoDriveStyle
 	{
 		LAW_ABIDING,
 		THE_ROAD_IS_YOURS
 	};
+	NLOHMANN_JSON_SERIALIZE_ENUM(AutoDriveStyle, {
+		{ AutoDriveStyle::LAW_ABIDING, "law_abiding" },
+		{ AutoDriveStyle::THE_ROAD_IS_YOURS, "the_road_is_yours" },
+	})
 
 	enum class eEntityProofs : uint32_t
 	{

--- a/src/core/globals.cpp
+++ b/src/core/globals.cpp
@@ -14,6 +14,13 @@ namespace big
                 attempt_save();
             }
         });
+
+        g = this;
+    }
+
+    menu_settings::~menu_settings()
+    {
+        g = nullptr;
     }
 
     void menu_settings::attempt_save()

--- a/src/core/globals.cpp
+++ b/src/core/globals.cpp
@@ -1,0 +1,114 @@
+#include "globals.hpp"
+
+namespace big
+{
+    menu_settings::menu_settings(file save_file)
+			: m_save_file(std::move(save_file))
+    {
+        g = this;
+    }
+
+    menu_settings::~menu_settings()
+    {
+        g = nullptr;
+    }
+
+    void menu_settings::attempt_save()
+    {
+        const nlohmann::json j = *this;
+
+        if (deep_compare(m_options, j, true))
+            save();
+    }
+
+    bool menu_settings::load()
+    {
+        m_default_options = *this;
+
+        std::ifstream file(m_save_file.get_path());
+
+        if (!file.is_open())
+        {
+            write_default_config();
+
+            file.open(m_save_file.get_path());
+        }
+
+        try
+        {
+            file >> m_options;
+
+            file.close();
+        }
+        catch (const std::exception&)
+        {
+            file.close();
+
+            LOG(WARNING) << "Detected corrupt settings, writing default config...";
+
+            write_default_config();
+
+            return load();
+        }
+
+        const bool should_save = deep_compare(m_options, m_default_options);
+        from_json(m_options, *this);
+
+        if (should_save)
+        {
+            LOG(INFO) << "Updating settings.";
+            save();
+        }
+
+        return true;
+    }
+
+    bool menu_settings::deep_compare(nlohmann::json& current_settings, const nlohmann::json& default_settings, bool compare_value)
+    {
+        bool should_save = false;
+
+        for (auto& e : default_settings.items())
+        {
+            const std::string& key = e.key();
+
+            if (current_settings.count(key) == 0 || (compare_value && current_settings[key] != e.value()))
+            {
+                current_settings[key] = e.value();
+
+                should_save = true;
+            }
+            else if (current_settings[key].is_object() && e.value().is_object())
+            {
+                if (deep_compare(current_settings[key], e.value(), compare_value))
+                    should_save = true;
+            }
+            else if (!current_settings[key].is_object() && e.value().is_object()) {
+                current_settings[key] = e.value();
+
+                should_save = true;
+            }
+        }
+
+        return should_save;
+    }
+
+    bool menu_settings::save()
+    {
+        std::ofstream file(m_save_file.get_path(), std::ios::out | std::ios::trunc);
+        nlohmann::json j = *this;
+        file << j.dump(4);
+        file.close();
+
+        return true;
+    }
+
+    bool menu_settings::write_default_config()
+    {
+        std::ofstream file(m_save_file.get_path(), std::ios::out | std::ios::trunc);
+        nlohmann::json j = *this;
+        file << j.dump(4);
+        file.close();
+
+        return true;
+    }
+}

--- a/src/core/globals.cpp
+++ b/src/core/globals.cpp
@@ -3,9 +3,9 @@
 
 namespace big
 {
-    void menu_settings::init(file save_file)
+    void menu_settings::init(const file& save_file)
     {
-        m_save_file = save_file;
+        m_save_file = std::make_unique<file>(save_file.get_path());
         load();
 
         g_thread_pool->push([this]
@@ -30,13 +30,13 @@ namespace big
     {
         m_default_options = *this;
 
-        std::ifstream file(m_save_file.get_path());
+        std::ifstream file(m_save_file->get_path());
 
-        if (!m_save_file.exists())
+        if (!m_save_file->exists())
         {
             write_default_config();
 
-            file.open(m_save_file.get_path());
+            file.open(m_save_file->get_path());
         }
 
         try
@@ -108,7 +108,7 @@ namespace big
 
     bool menu_settings::save()
     {
-        std::ofstream file(m_save_file.get_path(), std::ios::out | std::ios::trunc);
+        std::ofstream file(m_save_file->get_path(), std::ios::out | std::ios::trunc);
         nlohmann::json j = *this;
         file << j.dump(4);
         file.close();
@@ -118,7 +118,7 @@ namespace big
 
     bool menu_settings::write_default_config()
     {
-        std::ofstream file(m_save_file.get_path(), std::ios::out | std::ios::trunc);
+        std::ofstream file(m_save_file->get_path(), std::ios::out | std::ios::trunc);
         nlohmann::json j = *this;
         file << j.dump(4);
         file.close();

--- a/src/core/globals.cpp
+++ b/src/core/globals.cpp
@@ -52,7 +52,16 @@ namespace big
         }
 
         const bool should_save = deep_compare(m_options, m_default_options);
-        from_json(m_options, *this);
+        try
+        {
+            from_json(m_options, *this);
+        }
+        catch(const nlohmann::detail::type_error& e)
+        {
+            LOG(WARNING) << e.what();
+
+            return false;
+        }
 
         if (should_save)
         {

--- a/src/core/globals.cpp
+++ b/src/core/globals.cpp
@@ -3,19 +3,9 @@
 
 namespace big
 {
-    menu_settings::menu_settings(file save_file)
-        : m_save_file(save_file)
+    void menu_settings::init(file save_file)
     {
-        g = this;
-    }
-
-    menu_settings::~menu_settings()
-    {
-        g = nullptr;
-    }
-
-    void menu_settings::init()
-    {
+        m_save_file = save_file;
         load();
 
         g_thread_pool->push([this]

--- a/src/core/globals.cpp
+++ b/src/core/globals.cpp
@@ -27,7 +27,7 @@ namespace big
 
         std::ifstream file(m_save_file.get_path());
 
-        if (!file.is_open())
+        if (!m_save_file.exists())
         {
             write_default_config();
 

--- a/src/core/globals.cpp
+++ b/src/core/globals.cpp
@@ -4,8 +4,20 @@
 namespace big
 {
     menu_settings::menu_settings(file save_file)
-			: m_save_file(std::move(save_file))
+        : m_save_file(save_file)
     {
+        g = this;
+    }
+
+    menu_settings::~menu_settings()
+    {
+        g = nullptr;
+    }
+
+    void menu_settings::init()
+    {
+        load();
+
         g_thread_pool->push([this]
         {
             while (g_running)
@@ -14,13 +26,6 @@ namespace big
                 attempt_save();
             }
         });
-
-        g = this;
-    }
-
-    menu_settings::~menu_settings()
-    {
-        g = nullptr;
     }
 
     void menu_settings::attempt_save()

--- a/src/core/globals.cpp
+++ b/src/core/globals.cpp
@@ -1,16 +1,19 @@
 #include "globals.hpp"
+#include "thread_pool.hpp"
 
 namespace big
 {
     menu_settings::menu_settings(file save_file)
 			: m_save_file(std::move(save_file))
     {
-        g = this;
-    }
-
-    menu_settings::~menu_settings()
-    {
-        g = nullptr;
+        g_thread_pool->push([this]
+        {
+            while (g_running)
+            {
+                std::this_thread::sleep_for(100ms);
+                attempt_save();
+            }
+        });
     }
 
     void menu_settings::attempt_save()

--- a/src/core/globals.hpp
+++ b/src/core/globals.hpp
@@ -75,7 +75,7 @@ namespace big
 					NLOHMANN_DEFINE_TYPE_INTRUSIVE(script_event, logs, filter_player, player_id)
 				} script_event{};
 
-				NLOHMANN_DEFINE_TYPE_INTRUSIVE(logs, metric_logs, script_hook_logs)
+				NLOHMANN_DEFINE_TYPE_INTRUSIVE(logs, metric_logs, script_hook_logs, script_event)
 			} logs{};
 
 			NLOHMANN_DEFINE_TYPE_INTRUSIVE(debug, logs)
@@ -507,7 +507,7 @@ namespace big
 				eExplosionTag explosion_tag = eExplosionTag::DONTCARE;
 
 				NLOHMANN_JSON_SERIALIZE_ENUM(eAmmoSpecialType, {
-					{ eAmmoSpecialType::None, nullptr },
+					{ eAmmoSpecialType::None, "none" },
 					{ eAmmoSpecialType::ArmorPiercing, "armor_piercing" },
 					{ eAmmoSpecialType::Explosive, "explosive" },
 					{ eAmmoSpecialType::FMJ, "fmj" },
@@ -525,7 +525,7 @@ namespace big
 			float increased_damage = 1;
 			bool no_recoil = false;
 			bool no_spread = false;
-			char vehicle_gun_model[12] = "bus";
+			std::string vehicle_gun_model = "bus";
 			bool bypass_c4_limit = false;
 			bool rapid_fire = false;
 

--- a/src/core/globals.hpp
+++ b/src/core/globals.hpp
@@ -4,7 +4,7 @@
 #include <weapon/CWeaponInfo.hpp>
 #include "enums.hpp"
 #include "file_manager.hpp"
-#include "imgui.h"
+#include <imgui.h>
 #include <bitset>
 
 class CNetGamePlayer;
@@ -17,40 +17,89 @@ namespace rage
 
 namespace big
 {
-	class menu_settings;
-	inline menu_settings* g{};
+	class menu_settings
+	{
+	public:
+		menu_settings(file save_file);
+		~menu_settings();
 
-	class menu_settings {
-		nlohmann::json default_options;
-		nlohmann::json options;
+		void attempt_save();
+		bool load();
+
+	private:
+		bool deep_compare(nlohmann::json& current_settings, const nlohmann::json& default_settings, bool compare_value = false);
+		bool save();
+		bool write_default_config();
+
+	private:
+		file m_save_file;
+
+		nlohmann::json m_default_options;
+		nlohmann::json m_options;
+
+	public:
+		int friend_count = 0;
+		int player_count = 0;
+
+		CNetGamePlayer* m_syncing_player = nullptr;
+		std::unordered_map<std::uint64_t, std::uint64_t> m_spoofed_peer_ids;
+
+		int m_remote_controller_vehicle = -1;
+		int m_remote_controlled_vehicle = -1;
+
+		int m_mod_net_id = -1;
+		int m_test_net_id = -1;
+
+		rage::scrThread* m_hunt_the_beast_thread = nullptr;
+
+		rage::scrThread* m_dance_thread = nullptr;
+		rage::scrProgram* m_dance_program = nullptr;
+
+		rage::scrThread* m_mission_creator_thread = nullptr;
 
 		struct debug
 		{
-			struct
+			struct logs
 			{
 				bool metric_logs{};
 
 				bool script_hook_logs{};
 
-				struct
+				struct script_event
 				{
 					bool logs = false;
 
 					bool filter_player = true;
 					std::int8_t player_id = -1;
-				} script_event{};
-			} logs{};
-		};
 
+					NLOHMANN_DEFINE_TYPE_INTRUSIVE(script_event, logs, filter_player, player_id)
+				} script_event{};
+
+				NLOHMANN_DEFINE_TYPE_INTRUSIVE(logs, metric_logs, script_hook_logs)
+			} logs{};
+
+			NLOHMANN_DEFINE_TYPE_INTRUSIVE(debug, logs)
+		} debug{};
+
+		struct tunables
+		{
+			bool disable_phone = false;
+			bool no_idle_kick = false;
+
+			NLOHMANN_DEFINE_TYPE_INTRUSIVE(tunables, disable_phone, no_idle_kick)
+		} tunables{};
+		
 		struct notifications
 		{
 			struct pair
 			{
 				bool log = false;
 				bool notify = false;
+
+				NLOHMANN_DEFINE_TYPE_INTRUSIVE(pair, log, notify)
 			};
 
-			struct
+			struct received_event
 			{
 				pair clear_ped_task{};
 				pair kick_vote{};
@@ -58,9 +107,11 @@ namespace big
 				pair modder_detect{};
 				pair request_control_event{};
 				pair vehicle_temp_action{};
+
+				NLOHMANN_DEFINE_TYPE_INTRUSIVE(received_event, clear_ped_task, kick_vote, report_cash_spawn, modder_detect, request_control_event, vehicle_temp_action)
 			} received_event{};
 
-			struct
+			struct script_event_handler
 			{
 				pair bounty{};
 				pair ceo_ban{};
@@ -89,6 +140,12 @@ namespace big
 				pair teleport_to_warehouse{};
 				pair start_activity{};
 				pair null_function_kick{};
+
+				NLOHMANN_DEFINE_TYPE_INTRUSIVE(script_event_handler,
+					bounty, ceo_ban, ceo_kick, clear_wanted_level, crash, fake_deposit, force_mission, force_teleport,
+					gta_banner, mc_teleport, network_bail, personal_vehicle_destroyed, remote_off_radar, rotate_cam,
+					send_to_cutscene, send_to_location, sound_spam, spectate, switch_player_model, transaction_error,
+					tse_freeze, tse_sender_mismatch, vehicle_kick, teleport_to_warehouse, start_activity, null_function_kick)
 			} script_event_handler{};
 
 			pair gta_thread_kill{};
@@ -97,12 +154,14 @@ namespace big
 			pair network_player_mgr_init{};
 			pair network_player_mgr_shutdown{};
 
-			struct
+			struct player_join
 			{
 				bool above_map = true;
 				bool log = false;
 				bool notify = false;
-			} player_join;
+
+				NLOHMANN_DEFINE_TYPE_INTRUSIVE(player_join, above_map, log, notify)
+			} player_join{};
 			pair player_leave{};
 
 			pair reports{};
@@ -112,13 +171,21 @@ namespace big
 			pair mismatch_sync_type{};
 			pair out_of_allowed_range_sync_type{};
 			pair invalid_sync{};
-		};
 
-		struct player {
+			NLOHMANN_DEFINE_TYPE_INTRUSIVE(notifications,
+				received_event, script_event_handler, gta_thread_kill, gta_thread_start, network_player_mgr_init,
+				network_player_mgr_shutdown, player_join, player_leave, reports, send_net_info_to_lobby,
+				transaction_rate_limit, mismatch_sync_type, out_of_allowed_range_sync_type, invalid_sync)
+		} notifications{};
+		
+		struct player
+		{
 			int character_slot = 1;
 			int set_level = 130;
 			bool spectating = false;
-		};
+
+			NLOHMANN_DEFINE_TYPE_INTRUSIVE(player, character_slot, set_level, spectating)
+		} player{};
 
 		struct protections 
 		{
@@ -148,13 +215,21 @@ namespace big
 				bool vehicle_kick = true;
 				bool teleport_to_warehouse = true;
 				bool start_activity = true;
-			};
 
-			script_events script_events{};
+				NLOHMANN_DEFINE_TYPE_INTRUSIVE(script_events,
+					bounty, ceo_ban, ceo_kick, ceo_money, clear_wanted_level, crash, fake_deposit,
+					force_mission, force_teleport, gta_banner, mc_teleport, network_bail,
+					personal_vehicle_destroyed, remote_off_radar, rotate_cam, send_to_cutscene,
+					send_to_location, sound_spam, spectate, switch_player_model, transaction_error,
+					vehicle_kick, teleport_to_warehouse, start_activity)
+			} script_events{};
+
 			bool script_host_kick = true;
 			bool rid_join = false;
 			bool lessen_breakups = false; // disabled by default due to anticheat concerns
-		};
+
+			NLOHMANN_DEFINE_TYPE_INTRUSIVE(protections, script_events, script_host_kick, rid_join, lessen_breakups)
+		} protections{};
 
 		struct self 
 		{
@@ -185,7 +260,7 @@ namespace big
 			bool hide_radar = false;
 			bool hide_ammo = false;
 			int selected_hud_component = 1;
-			bool hud_components_states[(int)HudComponents::HUD_WEAPONS] = { false };
+			std::array<bool, 22> hud_components_states = { false };
 			bool force_show_hud_element = false;
 			bool force_show_hud = false;
 			bool mobile_radio = false;
@@ -193,21 +268,27 @@ namespace big
 			bool auto_tp = false;
 
 			// do not save below entries
-
 			bool dance_mode = false;
-		};
+
+			NLOHMANN_DEFINE_TYPE_INTRUSIVE(self,
+				clean_player, force_wanted_level, free_cam, invisibility, local_visibility, never_wanted, no_ragdoll,
+				noclip, off_radar, super_run, no_collision, unlimited_oxygen, no_water_collision, wanted_level, god_mode,
+				proof_bullet, proof_fire, proof_collision, proof_melee, proof_explosion, proof_steam, proof_drown, proof_water,
+				proof_mask, hide_radar, hide_ammo, selected_hud_component, hud_components_states, force_show_hud_element,
+				force_show_hud, mobile_radio, fast_respawn, auto_tp)
+		} self{};
 
 		struct session
 		{
 			int local_weather = 0;
 			bool override_time = {};
 			bool override_weather = false;
-			struct
+			struct custom_time
 			{
 				int hour{}, minute{}, second{};
+
+				NLOHMANN_DEFINE_TYPE_INTRUSIVE(custom_time, hour, minute, second)
 			} custom_time;
-			bool join_queued = false;
-			rage::rlSessionInfo info;
 			bool disable_chat_filter = false;
 			bool log_chat_messages = false;
 			bool log_text_messages = false;
@@ -239,13 +320,23 @@ namespace big
 			int send_to_warehouse_idx = 1;
 
 			// not to be saved
+			bool join_queued = false;
+			rage::rlSessionInfo info;
 			bool never_wanted_all = false;
 			bool off_radar_all = false;
 			bool semi_godmode_all = false;
 			bool wanted_level_all = false;
-		};
 
-		struct settings {
+			NLOHMANN_DEFINE_TYPE_INTRUSIVE(session,
+				local_weather, override_time, override_weather, custom_time, disable_chat_filter, log_chat_messages,
+				log_text_messages, decloak_players, force_session_host, force_script_host, player_magnet_enabled,
+				player_magnet_count, is_team, name_spoof_enabled, advertise_menu, spoofed_name, join_in_sctv_slots,
+				kick_chat_spammers, kick_host_when_forcing_host, explosion_karma, damage_karma, disable_traffic,
+				disable_peds, force_thunder, block_ceo_money, randomize_ceo_colors, send_to_apartment_idx, send_to_warehouse_idx)
+		} session{};
+
+		struct settings
+		{
 			struct hotkeys
 			{
 				bool editing_menu_toggle = false;
@@ -253,11 +344,14 @@ namespace big
 				int teleport_waypoint = 0;
 				int teleport_objective = 0;
 				int noclip = 0;
-			};
+
+				NLOHMANN_DEFINE_TYPE_INTRUSIVE(hotkeys, editing_menu_toggle, menu_toggle, teleport_waypoint, teleport_objective, noclip)
+			} hotkeys{};
 
 			bool dev_dlc = false;
-			hotkeys hotkeys{};
-		};
+			
+			NLOHMANN_DEFINE_TYPE_INTRUSIVE(settings, hotkeys, dev_dlc)
+		} settings{};
 
 		struct spawn_vehicle
 		{
@@ -265,7 +359,9 @@ namespace big
 			bool spawn_inside = false;
 			bool spawn_maxed = false;
 			std::string plate = "";
-		};
+
+			NLOHMANN_DEFINE_TYPE_INTRUSIVE(spawn_vehicle, preview_vehicle, spawn_inside, spawn_maxed, plate)
+		} spawn_vehicle{};
 
 		struct clone_pv
 		{
@@ -275,7 +371,16 @@ namespace big
 			bool spawn_maxed = false;
 			bool clone_plate = false;
 			std::string plate = "";
-		};
+
+			NLOHMANN_DEFINE_TYPE_INTRUSIVE(clone_pv, preview_vehicle, spawn_inside, spawn_clone, spawn_maxed, clone_plate, plate)
+		} clone_pv{};
+
+		struct spawn_ped
+		{
+			bool preview_ped = false;
+
+			NLOHMANN_DEFINE_TYPE_INTRUSIVE(spawn_ped, preview_ped)
+		} spawn_ped{};
 
 		struct spoofing
 		{
@@ -283,7 +388,7 @@ namespace big
 			std::string username = "";
 
 			bool spoof_ip = true;
-			int ip_address[4] = { 42, 42, 42, 42 };
+			std::array<int, 4> ip_address = { 42, 42, 42, 42 };
 
 			bool spoof_rockstar_id = false;
 			uint64_t rockstar_id = 0;
@@ -311,21 +416,26 @@ namespace big
 			// don't save
 			bool should_spoof_rockstar_id = false;
 			uint64_t applied_spoof_rockstar_id = 0;
-		};
 
-		struct tunables {
-			bool disable_phone = false;
-			bool no_idle_kick = false;
-		};
+			NLOHMANN_DEFINE_TYPE_INTRUSIVE(spoofing,
+				spoof_username, username, spoof_ip, ip_address, spoof_rockstar_id, rockstar_id, spoof_cheater,
+				spoof_hide_god, spoof_hide_spectate, spoof_rockstar_dev, spoof_rockstar_qa, spoof_crew_data,
+				crew_tag, rockstar_crew, square_crew_tag, spoof_session_region_type, session_region_type,
+				spoof_session_language, session_language, spoof_session_player_count, session_player_count)
+		} spoofing{};
 
-		struct vehicle {
-			struct speedo_meter {
+		struct vehicle
+		{
+			struct speedo_meter
+			{
 				float x = .9f;
 				float y = .72f;
 
 				bool enabled = false;
 				bool left_side = false;
-			};
+
+				NLOHMANN_DEFINE_TYPE_INTRUSIVE(speedo_meter, x, y, enabled, left_side)
+			} speedo_meter{};
 
 			struct fly
 			{
@@ -334,16 +444,21 @@ namespace big
 				bool no_collision = false;
 				bool stop_on_exit = false;
 				float speed = 1;
-			};
 
-			struct rainbow_paint {
+				NLOHMANN_DEFINE_TYPE_INTRUSIVE(fly, dont_stop, enabled, no_collision, stop_on_exit, speed)
+			} fly{};
+
+			struct rainbow_paint
+			{
 				RainbowPaintType type = RainbowPaintType::Off;
 				bool neon = false;
 				bool primary = false;
 				bool secondary = false;
 				bool smoke = false;
 				int speed = 0;
-			};
+
+				NLOHMANN_DEFINE_TYPE_INTRUSIVE(rainbow_paint, type, neon, primary, secondary, smoke, speed)
+			} rainbow_paint{};
 
 			SpeedUnit speed_unit = SpeedUnit::MIPH;
 
@@ -374,18 +489,34 @@ namespace big
 			bool no_water_collision = false;
 			bool disable_engine_auto_start = false;
 			bool change_engine_state_immediately = false;
-			speedo_meter speedo_meter{};
-			rainbow_paint rainbow_paint{};
-			fly fly{};
-		};
 
-		struct weapons {
+			NLOHMANN_DEFINE_TYPE_INTRUSIVE(vehicle,
+				speedo_meter, fly, rainbow_paint, speed_unit, god_mode,
+				proof_bullet, proof_fire, proof_collision, proof_melee, proof_explosion, proof_steam, proof_water, proof_mask,
+				auto_drive_destination, auto_drive_style, auto_drive_speed, auto_turn_signals, boost_behavior,
+				drive_on_water, horn_boost, instant_brake, is_targetable, seatbelt, turn_signals, vehicle_jump,
+				keep_vehicle_repaired, no_water_collision, disable_engine_auto_start, change_engine_state_immediately)
+		} vehicle{};
+
+		struct weapons
+		{
 			struct ammo_special
 			{
 				bool toggle = false;
 				eAmmoSpecialType type = eAmmoSpecialType::None;
 				eExplosionTag explosion_tag = eExplosionTag::DONTCARE;
-			} ammo_special;
+
+				NLOHMANN_JSON_SERIALIZE_ENUM(eAmmoSpecialType, {
+					{ eAmmoSpecialType::None, nullptr },
+					{ eAmmoSpecialType::ArmorPiercing, "armor_piercing" },
+					{ eAmmoSpecialType::Explosive, "explosive" },
+					{ eAmmoSpecialType::FMJ, "fmj" },
+					{ eAmmoSpecialType::HollowPoint, "hollow_point" },
+					{ eAmmoSpecialType::Incendiary, "incendiary" },
+					{ eAmmoSpecialType::Tracer, "tracer" },
+				})
+				NLOHMANN_DEFINE_TYPE_INTRUSIVE(ammo_special, toggle, type, explosion_tag)
+			} ammo_special{};
 
 			CustomWeapon custom_weapon = CustomWeapon::NONE;
 			bool force_crosshairs = false;
@@ -397,7 +528,11 @@ namespace big
 			char vehicle_gun_model[12] = "bus";
 			bool bypass_c4_limit = false;
 			bool rapid_fire = false;
-		};
+
+			NLOHMANN_DEFINE_TYPE_INTRUSIVE(weapons,
+				ammo_special, custom_weapon, force_crosshairs, infinite_ammo, infinite_mag, increased_damage, no_recoil,
+				no_spread, vehicle_gun_model, bypass_c4_limit, rapid_fire)
+		} weapons{};
 
 		struct window
 		{
@@ -410,7 +545,9 @@ namespace big
 			ImFont* font_icon = nullptr;
 
 			bool switched_view = true;
-		};
+
+			NLOHMANN_DEFINE_TYPE_INTRUSIVE(window, color, gui_scale, switched_view)
+		} window{};
 
 		struct context_menu
 		{
@@ -426,7 +563,10 @@ namespace big
 
 			bool bounding_box_enabled = true;
 			ImU32 bounding_box_color = 4278255360;
-		};
+
+			NLOHMANN_DEFINE_TYPE_INTRUSIVE(context_menu,
+				enabled, allowed_entity_types, selected_option_color, bounding_box_enabled, bounding_box_color)
+		} context_menu{};
 
 		struct esp
 		{
@@ -451,12 +591,12 @@ namespace big
 			ImU32 enemy_near_color = 4283794943;
 			ImU32 default_color = 4285713522;
 			ImU32 friend_color = 4293244509;
-		};
 
-		struct spawn_ped
-		{
-			bool preview_ped = false;
-		};
+			NLOHMANN_DEFINE_TYPE_INTRUSIVE(esp,
+				enabled, hide_self, global_render_distance, tracer_render_distance, box_render_distance, tracer, tracer_draw_position,
+				box, health, armor, god, distance, name, change_esp_color_from_dist, scale_health_from_dist, scale_armor_from_dist,
+				distance_threshold, enemy_color, enemy_near_color, default_color, friend_color)
+		} esp{};
 
 		struct session_browser
 		{
@@ -474,945 +614,17 @@ namespace big
 			int sort_direction = 0;
 
 			bool replace_game_matchmaking = false;
-		};
 
-	public:
-		int friend_count = 0;
-		int player_count = 0;
+			NLOHMANN_DEFINE_TYPE_INTRUSIVE(session_browser,
+				region_filter_enabled, region_filter, language_filter_enabled, language_filter, player_count_filter_enabled,
+				player_count_filter_minimum, player_count_filter_maximum, sort_method, sort_direction, replace_game_matchmaking)
+		} session_browser{};
 
-		CNetGamePlayer* m_syncing_player = nullptr;
-		std::unordered_map<std::uint64_t, std::uint64_t> m_spoofed_peer_ids;
 
-		int m_remote_controller_vehicle = -1;
-		int m_remote_controlled_vehicle = -1;
-
-		int m_mod_net_id = -1;
-		int m_test_net_id = -1;
-
-		rage::scrThread* m_hunt_the_beast_thread = nullptr;
-
-		rage::scrThread* m_dance_thread = nullptr;
-		rage::scrProgram* m_dance_program = nullptr;
-
-		rage::scrThread* m_mission_creator_thread = nullptr;
-
-		debug debug{};
-		tunables tunables{};
-		notifications notifications{};
-		player player{};
-		protections protections{};
-		self self{};
-		session session{};
-		settings settings{};
-		spawn_vehicle spawn_vehicle{};
-		clone_pv clone_pv{};
-		spawn_ped spawn_ped{};
-		spoofing spoofing{};
-		vehicle vehicle{};
-		weapons weapons{};
-		window window{};
-		context_menu context_menu{};
-		esp esp{};
-		session_browser session_browser{};
-
-		menu_settings(file save_file)
-			: m_save_file(std::move(save_file))
-		{
-			g = this;
-		}
-
-		~menu_settings()
-		{
-			g = nullptr;
-		}
-
-		void from_json(const nlohmann::json& j)
-		{
-			this->debug.logs.metric_logs = j["debug"]["logs"]["metric_logs"];
-			this->debug.logs.script_hook_logs = j["debug"]["logs"]["script_hook_logs"];
-
-			g->notifications.gta_thread_kill.log = j["notifications"]["gta_thread_kill"]["log"];
-			g->notifications.gta_thread_kill.notify = j["notifications"]["gta_thread_kill"]["notify"];
-			g->notifications.gta_thread_start.log = j["notifications"]["gta_thread_start"]["log"];
-			g->notifications.gta_thread_start.notify = j["notifications"]["gta_thread_start"]["notify"];
-
-			g->notifications.network_player_mgr_init.log = j["notifications"]["network_player_mgr_init"]["log"];
-			g->notifications.network_player_mgr_init.notify = j["notifications"]["network_player_mgr_init"]["notify"];
-			g->notifications.network_player_mgr_shutdown.log = j["notifications"]["network_player_mgr_shutdown"]["log"];
-			g->notifications.network_player_mgr_shutdown.notify = j["notifications"]["network_player_mgr_shutdown"]["notify"];
-
-			g->notifications.player_join.above_map = j["notifications"]["player_join"]["above_map"];
-			g->notifications.player_join.log = j["notifications"]["player_join"]["log"];
-			g->notifications.player_join.notify = j["notifications"]["player_join"]["notify"];
-
-			g->notifications.player_leave.log = j["notifications"]["player_leave"]["log"];
-			g->notifications.player_leave.notify = j["notifications"]["player_leave"]["notify"];
-
-			g->notifications.received_event.clear_ped_task.log = j["notifications"]["received_event"]["clear_ped_task"]["log"];
-			g->notifications.received_event.clear_ped_task.notify = j["notifications"]["received_event"]["clear_ped_task"]["notify"];
-			g->notifications.received_event.kick_vote.log = j["notifications"]["received_event"]["kick_vote"]["log"];
-			g->notifications.received_event.kick_vote.notify = j["notifications"]["received_event"]["kick_vote"]["notify"];
-			g->notifications.received_event.modder_detect.log = j["notifications"]["received_event"]["modder_detect"]["log"];
-			g->notifications.received_event.modder_detect.notify = j["notifications"]["received_event"]["modder_detect"]["notify"];
-			g->notifications.received_event.request_control_event.log = j["notifications"]["received_event"]["request_control_event"]["log"];
-			g->notifications.received_event.request_control_event.notify = j["notifications"]["received_event"]["request_control_event"]["notify"];
-			g->notifications.received_event.report_cash_spawn.log = j["notifications"]["received_event"]["report_cash_spawn"]["log"];
-			g->notifications.received_event.report_cash_spawn.notify = j["notifications"]["received_event"]["report_cash_spawn"]["notify"];
-			g->notifications.received_event.vehicle_temp_action.log = j["notifications"]["received_event"]["vehicle_temp_action"]["log"];
-			g->notifications.received_event.vehicle_temp_action.notify = j["notifications"]["received_event"]["vehicle_temp_action"]["notify"];
-
-			g->notifications.reports.log = j["notifications"]["reports"]["log"];
-			g->notifications.reports.notify = j["notifications"]["reports"]["notify"];
-
-			g->notifications.invalid_sync.notify = j["notifications"]["invalid_sync"]["notify"];
-			g->notifications.invalid_sync.log = j["notifications"]["invalid_sync"]["log"];
-
-			{
-				const auto& script_handler_j = j["notifications"]["script_event_handler"];
-				auto& script_handler = this->notifications.script_event_handler;
-
-				script_handler.bounty.log = script_handler_j["bounty"]["log"];
-				script_handler.bounty.notify = script_handler_j["bounty"]["notify"];
-				script_handler.ceo_ban.log = script_handler_j["ceo_ban"]["log"];
-				script_handler.ceo_ban.notify = script_handler_j["ceo_ban"]["notify"];
-				script_handler.ceo_kick.log = script_handler_j["ceo_kick"]["log"];
-				script_handler.ceo_kick.notify = script_handler_j["ceo_kick"]["notify"];
-				script_handler.ceo_money.log = script_handler_j["ceo_money"]["log"];
-				script_handler.ceo_money.notify = script_handler_j["ceo_money"]["notify"];
-				script_handler.clear_wanted_level.log = script_handler_j["clear_wanted_level"]["log"];
-				script_handler.clear_wanted_level.notify = script_handler_j["clear_wanted_level"]["notify"];
-				script_handler.crash.log = script_handler_j["crash"]["log"];
-				script_handler.crash.notify = script_handler_j["crash"]["notify"];
-				script_handler.fake_deposit.log = script_handler_j["fake_deposit"]["log"];
-				script_handler.fake_deposit.notify = script_handler_j["fake_deposit"]["notify"];
-				script_handler.force_mission.log = script_handler_j["force_mission"]["log"];
-				script_handler.force_mission.notify = script_handler_j["force_mission"]["notify"];
-				script_handler.force_teleport.log = script_handler_j["force_teleport"]["log"];
-				script_handler.force_teleport.notify = script_handler_j["force_teleport"]["notify"];
-				script_handler.gta_banner.log = script_handler_j["gta_banner"]["log"];
-				script_handler.gta_banner.notify = script_handler_j["gta_banner"]["notify"];
-				script_handler.mc_teleport.log = script_handler_j["mc_teleport"]["log"];
-				script_handler.mc_teleport.notify = script_handler_j["mc_teleport"]["notify"];
-				script_handler.network_bail.log = script_handler_j["network_bail"]["log"];
-				script_handler.network_bail.notify = script_handler_j["network_bail"]["notify"];
-				script_handler.personal_vehicle_destroyed.log = script_handler_j["personal_vehicle_destroyed"]["log"];
-				script_handler.personal_vehicle_destroyed.notify = script_handler_j["personal_vehicle_destroyed"]["notify"];
-				script_handler.remote_off_radar.log = script_handler_j["remote_off_radar"]["log"];
-				script_handler.remote_off_radar.notify = script_handler_j["remote_off_radar"]["notify"];
-				script_handler.rotate_cam.log = script_handler_j["rotate_cam"]["log"];
-				script_handler.rotate_cam.notify = script_handler_j["rotate_cam"]["notify"];
-				script_handler.send_to_cutscene.log = script_handler_j["send_to_cutscene"]["log"];
-				script_handler.send_to_cutscene.notify = script_handler_j["send_to_cutscene"]["notify"];
-				script_handler.send_to_location.log = script_handler_j["send_to_location"]["log"];
-				script_handler.send_to_location.notify = script_handler_j["send_to_location"]["notify"];
-				script_handler.sound_spam.log = script_handler_j["sound_spam"]["log"];
-				script_handler.sound_spam.notify = script_handler_j["sound_spam"]["notify"];
-				script_handler.spectate.log = script_handler_j["spectate"]["log"];
-				script_handler.spectate.notify = script_handler_j["spectate"]["notify"];
-				script_handler.switch_player_model.log = script_handler_j["switch_player_model"]["log"];
-				script_handler.switch_player_model.notify = script_handler_j["switch_player_model"]["notify"];
-				script_handler.transaction_error.log = script_handler_j["transaction_error"]["log"];
-				script_handler.transaction_error.notify = script_handler_j["transaction_error"]["notify"];
-				script_handler.tse_freeze.log = script_handler_j["tse_freeze"]["log"];
-				script_handler.tse_freeze.notify = script_handler_j["tse_freeze"]["notify"];
-				script_handler.tse_sender_mismatch.log = script_handler_j["tse_sender_mismatch"]["log"];
-				script_handler.tse_sender_mismatch.notify = script_handler_j["tse_sender_mismatch"]["notify"];
-				script_handler.vehicle_kick.log = script_handler_j["vehicle_kick"]["log"];
-				script_handler.vehicle_kick.notify = script_handler_j["vehicle_kick"]["notify"];
-				script_handler.teleport_to_warehouse.log = script_handler_j["teleport_to_warehouse"]["log"];
-				script_handler.teleport_to_warehouse.notify = script_handler_j["teleport_to_warehouse"]["notify"];
-				script_handler.start_activity.log = script_handler_j["start_activity"]["log"];
-				script_handler.start_activity.notify = script_handler_j["start_activity"]["notify"];
-				script_handler.null_function_kick.log = script_handler_j["null_function_kick"]["log"];
-				script_handler.null_function_kick.notify = script_handler_j["null_function_kick"]["notify"];
-			}
-
-			g->notifications.send_net_info_to_lobby.log = j["notifications"]["send_net_info_to_lobby"]["log"];
-			g->notifications.send_net_info_to_lobby.notify = j["notifications"]["send_net_info_to_lobby"]["notify"];
-
-			g->notifications.transaction_rate_limit.log = j["notifications"]["transaction_rate_limit"]["log"];
-			g->notifications.transaction_rate_limit.notify = j["notifications"]["transaction_rate_limit"]["notify"];
-
-			{
-				const auto& script_handler_j = j["protections"]["script_events"];
-				auto& script_handler = this->protections.script_events;
-
-				script_handler.bounty = script_handler_j["bounty"];
-				script_handler.ceo_ban = script_handler_j["ceo_ban"];
-				script_handler.ceo_kick = script_handler_j["ceo_kick"];
-				script_handler.ceo_money = script_handler_j["ceo_money"];
-				script_handler.clear_wanted_level = script_handler_j["clear_wanted_level"];
-				script_handler.crash = script_handler_j["crash"];
-				script_handler.fake_deposit = script_handler_j["fake_deposit"];
-				script_handler.force_mission = script_handler_j["force_mission"];
-				script_handler.force_teleport = script_handler_j["force_teleport"];
-				script_handler.gta_banner = script_handler_j["gta_banner"];
-				script_handler.mc_teleport = script_handler_j["mc_teleport"];
-				script_handler.network_bail = script_handler_j["network_bail"];
-				script_handler.personal_vehicle_destroyed = script_handler_j["personal_vehicle_destroyed"];
-				script_handler.remote_off_radar = script_handler_j["remote_off_radar"];
-				script_handler.rotate_cam = script_handler_j["rotate_cam"];
-				script_handler.send_to_cutscene = script_handler_j["send_to_cutscene"];
-				script_handler.send_to_location = script_handler_j["send_to_location"];
-				script_handler.sound_spam = script_handler_j["sound_spam"];
-				script_handler.spectate = script_handler_j["spectate"];
-				script_handler.switch_player_model = script_handler_j["switch_player_model"];
-				script_handler.transaction_error = script_handler_j["transaction_error"];
-				script_handler.vehicle_kick = script_handler_j["vehicle_kick"];
-				script_handler.teleport_to_warehouse = script_handler_j["teleport_to_warehouse"];
-				script_handler.start_activity = script_handler_j["start_activity"];
-			}
-
-			this->protections.script_host_kick = j["protections"]["script_host_kick"];
-			this->protections.rid_join = j["protections"]["rid_join"];
-			this->protections.lessen_breakups = j["protections"]["lessen_breakups"];
-
-			this->tunables.disable_phone = j["tunables"]["disable_phone"];
-			this->tunables.no_idle_kick = j["tunables"]["no_idle_kick"];
-
-			this->self.god_mode = j["self"]["god_mode"];
-			this->self.proof_bullet = j["self"]["proof_bullet"];
-			this->self.proof_fire = j["self"]["proof_fire"];
-			this->self.proof_collision = j["self"]["proof_collision"];
-			this->self.proof_melee = j["self"]["proof_melee"];
-			this->self.proof_explosion = j["self"]["proof_explosion"];
-			this->self.proof_steam = j["self"]["proof_steam"];
-			this->self.proof_drown = j["self"]["proof_drown"];
-			this->self.proof_water = j["self"]["proof_water"];
-			this->self.proof_mask = j["self"]["proof_mask"];
-			this->self.clean_player = j["self"]["clean_player"];
-			this->self.invisibility = j["self"]["invisibility"];
-			this->self.local_visibility = j["self"]["local_visibility"];
-			this->self.never_wanted = j["self"]["never_wanted"];
-			this->self.no_ragdoll = j["self"]["no_ragdoll"];
-			this->self.off_radar = j["self"]["off_radar"];
-			this->self.super_run = j["self"]["super_run"];
-			this->self.no_collision = j["self"]["no_collision"];
-			this->self.hide_radar = j["self"]["hide_radar"];
-			this->self.hide_ammo = j["self"]["hide_ammo"];
-			this->self.selected_hud_component = j["self"]["selected_hud_component"];
-			for (int i = 0; i < (int)HudComponents::HUD_WEAPONS; i++)
-				this->self.hud_components_states[i] = j["self"]["hud_components_states"].at(i);
-			this->self.force_show_hud_element = j["self"]["force_show_hud_element"];
-			this->self.force_show_hud = j["self"]["force_show_hud"];
-			this->self.unlimited_oxygen = j["self"]["unlimited_oxygen"];
-			this->self.no_water_collision = j["self"]["no_water_collision"];
-			this->self.mobile_radio = j["self"]["mobile_radio"];
-			this->self.fast_respawn = j["self"]["fast_respawn"];
-			this->self.auto_tp = j["self"]["auto_tp"];
-
-			this->session.log_chat_messages = j["session"]["log_chat_messages"];
-			this->session.log_text_messages = j["session"]["log_text_messages"];
-			this->session.disable_chat_filter = j["session"]["disable_chat_filter"];
-			this->session.decloak_players = j["session"]["decloak_players"];
-			this->session.force_session_host = j["session"]["force_session_host"];
-			this->session.force_script_host = j["session"]["force_script_host"];
-			this->session.player_magnet_enabled = j["session"]["player_magnet_enabled"];
-			this->session.player_magnet_count = j["session"]["player_magnet_count"];
-			this->session.is_team = j["session"]["is_team"];
-			this->session.name_spoof_enabled = j["session"]["name_spoof_enabled"];
-			this->session.advertise_menu = j["session"]["advertise_menu"];
-			this->session.spoofed_name = j["session"]["spoofed_name"];
-			this->session.join_in_sctv_slots = j["session"]["join_in_sctv_slots"];
-
-			this->session.kick_chat_spammers = j["session"]["kick_chat_spammers"];
-			this->session.kick_host_when_forcing_host = j["session"]["kick_host_when_forcing_host"];
-
-			this->session.explosion_karma = j["session"]["explosion_karma"];
-			this->session.damage_karma = j["session"]["damage_karma"];
-
-			this->session.disable_peds = j["session"]["disable_peds"];
-			this->session.disable_traffic = j["session"]["disable_traffic"];
-			this->session.force_thunder = j["session"]["force_thunder"];
-
-			this->session.block_ceo_money = j["session"]["block_ceo_money"];
-			this->session.randomize_ceo_colors = j["session"]["randomize_ceo_colors"];
-
-			this->session.send_to_apartment_idx = j["session"]["send_to_apartment_idx"];
-			this->session.send_to_warehouse_idx = j["session"]["send_to_warehouse_idx"];
-
-			this->settings.dev_dlc = j["settings"]["dev_dlc"];
-			this->settings.hotkeys.menu_toggle = j["settings"]["hotkeys"]["menu_toggle"];
-			this->settings.hotkeys.teleport_waypoint = j["settings"]["hotkeys"]["teleport_waypoint"];
-			this->settings.hotkeys.teleport_objective = j["settings"]["hotkeys"]["teleport_objective"];
-			this->settings.hotkeys.noclip = j["settings"]["hotkeys"]["noclip"];
-
-			this->spawn_vehicle.preview_vehicle = j["spawn_vehicle"]["preview_vehicle"];
-			this->spawn_vehicle.spawn_inside = j["spawn_vehicle"]["spawn_inside"];
-			this->spawn_vehicle.spawn_maxed = j["spawn_vehicle"]["spawn_maxed"];
-			this->spawn_vehicle.plate = j["spawn_vehicle"]["plate"];
-
-			this->clone_pv.preview_vehicle = j["clone_pv"]["preview_vehicle"];
-			this->clone_pv.spawn_inside = j["clone_pv"]["spawn_inside"];
-			this->clone_pv.spawn_clone = j["clone_pv"]["spawn_clone"];
-			this->clone_pv.spawn_maxed = j["clone_pv"]["spawn_maxed"];
-			this->clone_pv.clone_plate = j["clone_pv"]["clone_plate"];
-			this->clone_pv.plate = j["clone_pv"]["plate"];
-
-			this->spawn_ped.preview_ped = j["spawn_ped"]["preview_ped"];
-
-			this->spoofing.spoof_ip = j["spoofing"]["spoof_ip"];
-			this->spoofing.spoof_rockstar_id = j["spoofing"]["spoof_rockstar_id"];
-			this->spoofing.spoof_username = j["spoofing"]["spoof_username"];
-			this->spoofing.spoof_cheater = j["spoofing"]["spoof_cheater"];
-			this->spoofing.spoof_rockstar_dev = j["spoofing"]["spoof_rockstar_dev"];
-			this->spoofing.spoof_rockstar_qa = j["spoofing"]["spoof_rockstar_qa"];
-			this->spoofing.spoof_crew_data = j["spoofing"]["spoof_crew_data"];
-			this->spoofing.crew_tag = j["spoofing"]["crew_tag"];
-			this->spoofing.rockstar_crew = j["spoofing"]["rockstar_crew"];
-			this->spoofing.square_crew_tag = j["spoofing"]["square_crew_tag"];
-
-			for (int i = 0; i < 4; i++)
-				this->spoofing.ip_address[i] = j["spoofing"]["ip_address"].at(i);
-			this->spoofing.rockstar_id = j["spoofing"]["rockstar_id"];
-			this->spoofing.username = j["spoofing"]["username"];
-
-			this->spoofing.spoof_hide_god = j["spoofing"]["spoof_hide_god"];
-			this->spoofing.spoof_hide_spectate = j["spoofing"]["spoof_hide_spectate"];
-
-			this->spoofing.spoof_session_region_type = j["spoofing"]["spoof_session_region_type"];
-			this->spoofing.spoof_session_language = j["spoofing"]["spoof_session_language"];
-			this->spoofing.spoof_session_player_count = j["spoofing"]["spoof_session_player_count"];
-			this->spoofing.session_region_type = j["spoofing"]["session_region_type"];
-			this->spoofing.session_language = j["spoofing"]["session_language"];
-			this->spoofing.session_player_count = j["spoofing"]["session_player_count"];
-
-			this->vehicle.speed_unit = (SpeedUnit)j["vehicle"]["speed_unit"];
-			this->vehicle.god_mode = j["vehicle"]["god_mode"];
-			this->vehicle.proof_bullet = j["vehicle"]["proof_bullet"];
-			this->vehicle.proof_fire = j["vehicle"]["proof_fire"];
-			this->vehicle.proof_collision = j["vehicle"]["proof_collision"];
-			this->vehicle.proof_melee = j["vehicle"]["proof_melee"];
-			this->vehicle.proof_explosion = j["vehicle"]["proof_explosion"];
-			this->vehicle.proof_steam = j["vehicle"]["proof_steam"];
-			this->vehicle.proof_water = j["vehicle"]["proof_water"];
-			this->vehicle.proof_mask = j["vehicle"]["proof_mask"];
-			this->vehicle.boost_behavior = j["vehicle"]["boost_behavior"];
-			this->vehicle.auto_drive_style = j["vehicle"]["auto_drive_style"];
-			this->vehicle.auto_drive_speed = j["vehicle"]["auto_drive_speed"];
-			this->vehicle.auto_turn_signals = j["vehicle"]["auto_turn_signals"];
-			this->vehicle.drive_on_water = j["vehicle"]["drive_on_water"];
-			this->vehicle.horn_boost = j["vehicle"]["horn_boost"];
-			this->vehicle.vehicle_jump = j["vehicle"]["vehicle_jump"];
-			this->vehicle.keep_vehicle_repaired = j["vehicle"]["keep_vehicle_repaired"];
-			this->vehicle.instant_brake = j["vehicle"]["instant_brake"];
-			this->vehicle.is_targetable = j["vehicle"]["is_targetable"];
-			this->vehicle.seatbelt = j["vehicle"]["seatbelt"];
-			this->vehicle.turn_signals = j["vehicle"]["turn_signals"];
-			this->vehicle.no_water_collision = j["vehicle"]["no_water_collision"];
-			this->vehicle.disable_engine_auto_start = j["vehicle"]["disable_engine_auto_start"];
-			this->vehicle.change_engine_state_immediately = j["vehicle"]["change_engine_state_immediately"];
-
-			this->vehicle.speedo_meter.enabled = j["vehicle"]["speedo_meter"]["enabled"];
-			this->vehicle.speedo_meter.left_side = j["vehicle"]["speedo_meter"]["left_side"];
-			this->vehicle.speedo_meter.x = j["vehicle"]["speedo_meter"]["position_x"];
-			this->vehicle.speedo_meter.y = j["vehicle"]["speedo_meter"]["position_y"];
-
-			this->vehicle.rainbow_paint.type = j["vehicle"]["rainbow_paint"]["type"];
-			this->vehicle.rainbow_paint.speed = j["vehicle"]["rainbow_paint"]["speed"];
-			this->vehicle.rainbow_paint.neon = j["vehicle"]["rainbow_paint"]["neon"];
-			this->vehicle.rainbow_paint.primary = j["vehicle"]["rainbow_paint"]["primary"];
-			this->vehicle.rainbow_paint.secondary = j["vehicle"]["rainbow_paint"]["secondary"];
-			this->vehicle.rainbow_paint.smoke = j["vehicle"]["rainbow_paint"]["smoke"];
-
-			this->vehicle.fly.dont_stop = j["vehicle"]["fly"]["dont_stop"];
-			this->vehicle.fly.enabled = j["vehicle"]["fly"]["enabled"];
-			this->vehicle.fly.no_collision = j["vehicle"]["fly"]["no_collision"];
-			this->vehicle.fly.speed = j["vehicle"]["fly"]["speed"];
-			this->vehicle.fly.stop_on_exit = j["vehicle"]["fly"]["stop_on_exit"];
-
-			this->weapons.custom_weapon = (CustomWeapon)j["weapons"]["custom_weapon"];
-			this->weapons.force_crosshairs = j["weapons"]["force_crosshairs"];
-			this->weapons.infinite_ammo = j["weapons"]["infinite_ammo"];
-			this->weapons.increased_damage = j["weapons"]["increased_damage"];
-			this->weapons.infinite_mag = j["weapons"]["infinite_mag"];
-			this->weapons.no_recoil = j["weapons"]["no_recoil"];
-			this->weapons.no_spread = j["weapons"]["no_spread"];
-			this->weapons.bypass_c4_limit = j["weapons"]["bypass_c4_limit"];
-			this->weapons.rapid_fire = j["weapons"]["rapid_fire"];
-
-			this->weapons.ammo_special.type = (eAmmoSpecialType)j["weapons"]["ammo_special"]["type"];
-			this->weapons.ammo_special.toggle = j["weapons"]["ammo_special"]["toggle"];
-
-			this->window.color = j["window"]["color"];
-			this->window.gui_scale = j["window"]["gui_scale"];
-
-			this->context_menu.enabled = j["context_menu"]["enabled"];
-			this->context_menu.allowed_entity_types = j["context_menu"]["allowed_entity_types"];
-			this->context_menu.selected_option_color = j["context_menu"]["selected_option_color"];
-			this->context_menu.bounding_box_enabled = j["context_menu"]["bounding_box_enabled"];
-			this->context_menu.bounding_box_color = j["context_menu"]["bounding_box_color"];
-
-			this->esp.enabled = j["esp"]["enabled"];
-			this->esp.hide_self = j["esp"]["hide_self"];
-			this->esp.enemy_color = j["esp"]["enemy_color"];
-			this->esp.enemy_near_color = j["esp"]["enemy_near_color"];
-			this->esp.default_color = j["esp"]["default_color"];
-			this->esp.friend_color = j["esp"]["friend_color"];
-			this->esp.box = j["esp"]["box"];
-			this->esp.distance = j["esp"]["distance"];
-			this->esp.god = j["esp"]["god"];
-			this->esp.health = j["esp"]["health"];
-			this->esp.armor = j["esp"]["armor"];
-			this->esp.name = j["esp"]["name"];
-			this->esp.change_esp_color_from_dist = j["esp"]["change_esp_color_from_dist"];
-			this->esp.scale_health_from_dist = j["esp"]["scale_health_from_dist"];
-			this->esp.scale_armor_from_dist = j["esp"]["scale_armor_from_dist"];
-			for (int i = 0; i < 2; i++)
-				this->esp.global_render_distance[i] = j["esp"]["global_render_distance"].at(i);
-			for (int i = 0; i < 2; i++)
-				this->esp.tracer_render_distance[i] = j["esp"]["tracer_render_distance"].at(i);
-			for (int i = 0; i < 2; i++)
-				this->esp.box_render_distance[i] = j["esp"]["box_render_distance"].at(i);
-			this->esp.tracer = j["esp"]["tracer"];
-			for (int i = 0; i < 2; i++)
-				this->esp.tracer_draw_position[i] = j["esp"]["tracer_draw_position"].at(i);
-			for (int i = 0; i < 2; i++)
-				this->esp.distance_threshold[i] = j["esp"]["distance_threshold"].at(i);
-
-			this->session_browser.region_filter_enabled = j["session_browser"]["region_filter_enabled"];
-			this->session_browser.region_filter = j["session_browser"]["region_filter"];
-
-			this->session_browser.language_filter_enabled = j["session_browser"]["language_filter_enabled"];
-			this->session_browser.language_filter = j["session_browser"]["language_filter"];
-
-			this->session_browser.player_count_filter_enabled = j["session_browser"]["player_count_filter_enabled"];
-			this->session_browser.player_count_filter_minimum = j["session_browser"]["player_count_filter_minimum"];
-			this->session_browser.player_count_filter_maximum = j["session_browser"]["player_count_filter_maximum"];
-
-			this->session_browser.sort_method = j["session_browser"]["sort_method"];
-			this->session_browser.sort_direction = j["session_browser"]["sort_direction"];
-
-			this->session_browser.replace_game_matchmaking = j["session_browser"]["replace_game_matchmaking"];
-		}
-
-		nlohmann::json to_json()
-		{
-			constexpr auto return_notify_pair = [](const notifications::pair& notify_pair) -> auto
-			{
-				return nlohmann::json{
-					{ "log", notify_pair.log },
-					{ "notify", notify_pair.notify }
-				};
-			};
-
-			const auto& script_handler_notifications = this->notifications.script_event_handler;
-			const auto& script_handler_protections = this->protections.script_events;
-
-			return nlohmann::json{
-				{
-					"debug",
-					{
-						{
-							"logs",
-							{
-								{ "metric_logs", this->debug.logs.metric_logs },
-								{ "script_hook_logs", this->debug.logs.script_hook_logs }
-							}
-						}
-					}
-				},
-				{
-					"notifications", {
-						{ "gta_thread_kill", return_notify_pair(g->notifications.gta_thread_kill) },
-						{ "gta_thread_start", return_notify_pair(g->notifications.gta_thread_start) },
-						{ "network_player_mgr_init", return_notify_pair(g->notifications.network_player_mgr_init) },
-						{ "network_player_mgr_shutdown", return_notify_pair(g->notifications.network_player_mgr_shutdown) },
-						{ "player_join", {
-								{ "above_map", g->notifications.player_join.above_map },
-								{ "log", g->notifications.player_join.log },
-								{ "notify", g->notifications.player_join.notify }
-							}
-						},
-						{ "player_leave", return_notify_pair(g->notifications.player_leave) },
-						{
-							"received_event", {
-								{ "clear_ped_task", return_notify_pair(g->notifications.received_event.clear_ped_task) },
-								{ "kick_vote", return_notify_pair(g->notifications.received_event.kick_vote) },
-								{ "modder_detect", return_notify_pair(g->notifications.received_event.modder_detect) },
-								{ "report_cash_spawn", return_notify_pair(g->notifications.received_event.report_cash_spawn) },
-								{ "request_control_event", return_notify_pair(g->notifications.received_event.request_control_event) },
-								{ "vehicle_temp_action", return_notify_pair(g->notifications.received_event.vehicle_temp_action) }
-							}
-						},
-						{ "reports", return_notify_pair(g->notifications.reports) },
-						{ "script_event_handler", {
-								{ "bounty", return_notify_pair(script_handler_notifications.bounty) },
-								{ "ceo_ban", return_notify_pair(script_handler_notifications.ceo_ban) },
-								{ "ceo_kick", return_notify_pair(script_handler_notifications.ceo_kick) },
-								{ "ceo_money", return_notify_pair(script_handler_notifications.ceo_money) },
-								{ "clear_wanted_level", return_notify_pair(script_handler_notifications.clear_wanted_level) },
-								{ "crash", return_notify_pair(script_handler_notifications.crash) },
-								{ "fake_deposit", return_notify_pair(script_handler_notifications.fake_deposit) },
-								{ "force_mission", return_notify_pair(script_handler_notifications.force_mission) },
-								{ "force_teleport", return_notify_pair(script_handler_notifications.force_teleport) },
-								{ "gta_banner", return_notify_pair(script_handler_notifications.gta_banner) },
-								{ "mc_teleport", return_notify_pair(script_handler_notifications.mc_teleport) },
-								{ "network_bail", return_notify_pair(script_handler_notifications.network_bail) },
-								{ "personal_vehicle_destroyed", return_notify_pair(script_handler_notifications.personal_vehicle_destroyed) },
-								{ "remote_off_radar", return_notify_pair(script_handler_notifications.remote_off_radar) },
-								{ "rotate_cam", return_notify_pair(script_handler_notifications.rotate_cam) },
-								{ "send_to_cutscene", return_notify_pair(script_handler_notifications.send_to_cutscene) },
-								{ "send_to_location", return_notify_pair(script_handler_notifications.send_to_location) },
-								{ "sound_spam", return_notify_pair(script_handler_notifications.sound_spam) },
-								{ "spectate", return_notify_pair(script_handler_notifications.spectate) },
-								{ "switch_player_model", return_notify_pair(script_handler_notifications.switch_player_model) },
-								{ "transaction_error", return_notify_pair(script_handler_notifications.transaction_error) },
-								{ "tse_freeze", return_notify_pair(script_handler_notifications.tse_freeze) },
-								{ "tse_sender_mismatch", return_notify_pair(script_handler_notifications.tse_sender_mismatch) },
-								{ "vehicle_kick", return_notify_pair(script_handler_notifications.vehicle_kick) },
-								{ "teleport_to_warehouse", return_notify_pair(script_handler_notifications.teleport_to_warehouse) },
-								{ "start_activity", return_notify_pair(script_handler_notifications.start_activity) },
-								{ "null_function_kick", return_notify_pair(script_handler_notifications.null_function_kick) }
-							}
-						},
-						{ "send_net_info_to_lobby", return_notify_pair(g->notifications.send_net_info_to_lobby) },
-						{ "transaction_rate_limit", return_notify_pair(g->notifications.transaction_rate_limit) },
-						{ "mismatch_sync_type", return_notify_pair(g->notifications.mismatch_sync_type) },
-						{ "out_of_allowed_range_sync_type", return_notify_pair(g->notifications.out_of_allowed_range_sync_type) },
-						{ "invalid_sync", return_notify_pair(g->notifications.invalid_sync) }
-					}
-				},
-				{
-					"protections",
-					{
-						{
-							"script_events", {
-								{ "bounty", script_handler_protections.bounty },
-								{ "ceo_ban", script_handler_protections.ceo_ban },
-								{ "ceo_kick", script_handler_protections.ceo_kick },
-								{ "ceo_money", script_handler_protections.ceo_money },
-								{ "clear_wanted_level", script_handler_protections.clear_wanted_level },
-								{ "crash", script_handler_protections.crash },
-								{ "fake_deposit", script_handler_protections.fake_deposit },
-								{ "force_mission", script_handler_protections.force_mission },
-								{ "force_teleport", script_handler_protections.force_teleport },
-								{ "gta_banner", script_handler_protections.gta_banner },
-								{ "mc_teleport", script_handler_protections.mc_teleport },
-								{ "network_bail", script_handler_protections.network_bail },
-								{ "personal_vehicle_destroyed", script_handler_protections.personal_vehicle_destroyed },
-								{ "remote_off_radar", script_handler_protections.remote_off_radar },
-								{ "rotate_cam", script_handler_protections.rotate_cam },
-								{ "send_to_cutscene", script_handler_protections.send_to_cutscene },
-								{ "send_to_location", script_handler_protections.send_to_location },
-								{ "sound_spam", script_handler_protections.sound_spam },
-								{ "spectate", script_handler_protections.spectate },
-								{ "switch_player_model", script_handler_protections.switch_player_model },
-								{ "transaction_error", script_handler_protections.transaction_error },
-								{ "vehicle_kick", script_handler_protections.vehicle_kick },
-								{ "teleport_to_warehouse", script_handler_protections.teleport_to_warehouse },
-								{ "start_activity", script_handler_protections.start_activity }
-							}
-						},
-
-						{ "script_host_kick", g->protections.script_host_kick },
-						{ "rid_join", g->protections.rid_join },
-						{ "lessen_breakups", g->protections.lessen_breakups }
-					}
-				},
-				{
-					"tunables", {
-						{ "disable_phone", this->tunables.disable_phone },
-						{ "no_idle_kick", this->tunables.no_idle_kick }
-					}
-				},
-				{
-					"self", {
-						{ "god_mode", this->self.god_mode },
-						{ "proof_bullet", this->self.proof_bullet },
-						{ "proof_fire", this->self.proof_fire },
-						{ "proof_collision", this->self.proof_collision },
-						{ "proof_melee", this->self.proof_melee },
-						{ "proof_explosion", this->self.proof_explosion },
-						{ "proof_steam", this->self.proof_steam },
-						{ "proof_drown", this->self.proof_drown },
-						{ "proof_water", this->self.proof_water },
-						{ "proof_mask", this->self.proof_mask },
-						{ "clean_player", this->self.clean_player },
-						{ "invisibility", this->self.invisibility },
-						{ "local_visibility", this->self.local_visibility },
-						{ "never_wanted", this->self.never_wanted },
-						{ "no_ragdoll", this->self.no_ragdoll },
-						{ "off_radar", this->self.off_radar },
-						{ "super_run", this->self.super_run },
-						{ "no_collision", this->self.no_collision },
-						{ "hide_radar", this->self.hide_radar },
-						{ "hide_ammo", this->self.hide_ammo },
-						{ "selected_hud_component", this->self.selected_hud_component },
-						{ "hud_components_states", nlohmann::json::array({
-							this->self.hud_components_states[0],
-							this->self.hud_components_states[1],
-							this->self.hud_components_states[2],
-							this->self.hud_components_states[3],
-							this->self.hud_components_states[4],
-							this->self.hud_components_states[5],
-							this->self.hud_components_states[6],
-							this->self.hud_components_states[7],
-							this->self.hud_components_states[8],
-							this->self.hud_components_states[9],
-							this->self.hud_components_states[10],
-							this->self.hud_components_states[11],
-							this->self.hud_components_states[12],
-							this->self.hud_components_states[13],
-							this->self.hud_components_states[14],
-							this->self.hud_components_states[15],
-							this->self.hud_components_states[16],
-							this->self.hud_components_states[17],
-							this->self.hud_components_states[18],
-							this->self.hud_components_states[19],
-							this->self.hud_components_states[20],
-							this->self.hud_components_states[21] })
-						},
-						{ "force_show_hud_element", this->self.force_show_hud_element },
-						{ "force_show_hud", this->self.force_show_hud },
-						{ "unlimited_oxygen", this->self.unlimited_oxygen },
-						{ "no_water_collision", this->self.no_water_collision },
-						{ "mobile_radio", this->self.mobile_radio },
-						{ "fast_respawn", this->self.fast_respawn },
-						{ "auto_tp", this->self.auto_tp }
-					}
-				},
-				{
-					"session", {
-						{ "log_chat_messages", this->session.log_chat_messages },
-						{ "log_text_messages", this->session.log_text_messages },
-						{ "disable_chat_filter", this->session.disable_chat_filter },
-						{ "decloak_players", this->session.decloak_players },
-						{ "force_session_host", this->session.force_session_host },
-						{ "force_script_host", this->session.force_script_host },
-						{ "player_magnet_enabled", this->session.player_magnet_enabled },
-						{ "player_magnet_count", this->session.player_magnet_count },
-						{ "is_team", this->session.is_team },
-						{ "name_spoof_enabled", this->session.name_spoof_enabled },
-						{ "advertise_menu", this->session.advertise_menu },
-						{ "spoofed_name", this->session.spoofed_name },
-						{ "join_in_sctv_slots", this->session.join_in_sctv_slots },
-						{ "kick_chat_spammers", this->session.kick_chat_spammers },
-						{ "kick_host_when_forcing_host", this->session.kick_host_when_forcing_host },
-						{ "explosion_karma", this->session.explosion_karma },
-						{ "damage_karma", this->session.damage_karma },
-						{ "disable_peds", this->session.disable_peds },
-						{ "disable_traffic", this->session.disable_traffic },
-						{ "force_thunder", this->session.force_thunder },
-						{ "block_ceo_money", this->session.block_ceo_money },
-						{ "randomize_ceo_colors", this->session.randomize_ceo_colors },
-						{ "send_to_apartment_idx", this->session.send_to_apartment_idx },
-						{ "send_to_warehouse_idx", this->session.send_to_warehouse_idx }
-					}
-				},
-				{
-					"settings", {
-						{ "dev_dlc", this->settings.dev_dlc },
-						{ "hotkeys", {
-								{ "menu_toggle", this->settings.hotkeys.menu_toggle },
-								{ "teleport_waypoint", this->settings.hotkeys.teleport_waypoint },
-								{ "teleport_objective", this->settings.hotkeys.teleport_objective },
-								{ "noclip", this->settings.hotkeys.noclip }
-							}
-						}
-					}
-				},
-				{
-					"clone_pv", {
-						{ "preview_vehicle", this->clone_pv.preview_vehicle },
-						{ "spawn_inside", this->clone_pv.spawn_inside },
-						{ "spawn_clone", this->clone_pv.spawn_clone },
-						{ "spawn_maxed", this->clone_pv.spawn_maxed },
-						{ "clone_plate", this->clone_pv.clone_plate },
-						{ "plate", this->clone_pv.plate }
-					}
-				},
-				{
-					"spawn_vehicle", {
-						{ "preview_vehicle", this->spawn_vehicle.preview_vehicle },
-						{ "spawn_inside", this->spawn_vehicle.spawn_inside },
-						{ "spawn_maxed", this->spawn_vehicle.spawn_maxed},
-						{ "plate", this->spawn_vehicle.plate }
-					}
-				},
-				{
-					"spawn_ped", {
-						{ "preview_ped", this->spawn_ped.preview_ped },
-					}
-				},
-				{
-					"spoofing", {
-						{ "spoof_ip", this->spoofing.spoof_ip },
-						{ "spoof_rockstar_id", this->spoofing.spoof_rockstar_id },
-						{ "spoof_username", this->spoofing.spoof_username },
-						{ "ip_address", nlohmann::json::array({
-							this->spoofing.ip_address[0],
-							this->spoofing.ip_address[1],
-							this->spoofing.ip_address[2],
-							this->spoofing.ip_address[3] })
-						},
-						{ "rockstar_id", this->spoofing.rockstar_id },
-						{ "username", this->spoofing.username },
-						{ "spoof_cheater", this->spoofing.spoof_cheater },
-						{ "spoof_rockstar_dev", this->spoofing.spoof_rockstar_dev },
-						{ "spoof_rockstar_qa", this->spoofing.spoof_rockstar_qa },
-						{ "spoof_crew_data", this->spoofing.spoof_crew_data },
-						{ "crew_tag", this->spoofing.crew_tag },
-						{ "rockstar_crew", this->spoofing.rockstar_crew },
-						{ "square_crew_tag", this->spoofing.square_crew_tag },
-						{ "spoof_hide_god", this->spoofing.spoof_hide_god },
-						{ "spoof_hide_spectate", this->spoofing.spoof_hide_spectate },
-						{ "spoof_session_region_type", this->spoofing.spoof_session_region_type},
-						{ "spoof_session_language", this->spoofing.spoof_session_language },
-						{ "spoof_session_player_count", this->spoofing.spoof_session_player_count },
-						{ "session_region_type", this->spoofing.session_region_type },
-						{ "session_language", this->spoofing.session_language },
-						{ "session_player_count", this->spoofing.session_player_count }
-					}
-				},
-				{
-					"vehicle", {
-						{ "speed_unit", this->vehicle.speed_unit },
-						{ "god_mode", this->vehicle.god_mode },
-						{ "proof_bullet", this->vehicle.proof_bullet },
-						{ "proof_fire", this->vehicle.proof_fire },
-						{ "proof_collision", this->vehicle.proof_collision },
-						{ "proof_melee", this->vehicle.proof_melee },
-						{ "proof_explosion", this->vehicle.proof_explosion },
-						{ "proof_steam", this->vehicle.proof_steam },
-						{ "proof_water", this->vehicle.proof_water },
-						{ "proof_mask", this->vehicle.proof_mask },
-						{ "auto_drive_style", this->vehicle.auto_drive_style },
-						{ "auto_drive_speed", this->vehicle.auto_drive_speed },
-						{ "auto_turn_signals", this->vehicle.auto_turn_signals },
-						{ "boost_behavior", this->vehicle.boost_behavior },
-						{ "drive_on_water", this->vehicle.drive_on_water },
-						{ "horn_boost", this->vehicle.horn_boost },
-						{ "vehicle_jump", this->vehicle.vehicle_jump },
-						{ "keep_vehicle_repaired", this->vehicle.keep_vehicle_repaired },
-						{ "instant_brake", this->vehicle.instant_brake },
-						{ "is_targetable", this->vehicle.is_targetable },
-						{ "turn_signals", this->vehicle.turn_signals },
-						{ "seatbelt", this->vehicle.seatbelt },
-						{ "no_water_collision", this->vehicle.no_water_collision },
-						{ "disable_engine_auto_start", this->vehicle.disable_engine_auto_start },
-						{ "change_engine_state_immediately", this->vehicle.change_engine_state_immediately },
-						{
-							"speedo_meter",
-							{
-								{ "enabled", this->vehicle.speedo_meter.enabled },
-								{ "left_side", this->vehicle.speedo_meter.left_side },
-								{ "position_x", this->vehicle.speedo_meter.x },
-								{ "position_y", this->vehicle.speedo_meter.y },
-							}
-						},
-						{
-							"rainbow_paint",
-							{
-								{ "type", this->vehicle.rainbow_paint.type },
-								{ "speed", this->vehicle.rainbow_paint.speed },
-								{ "neon", this->vehicle.rainbow_paint.neon },
-								{ "primary", this->vehicle.rainbow_paint.primary },
-								{ "secondary", this->vehicle.rainbow_paint.secondary },
-								{ "smoke", this->vehicle.rainbow_paint.smoke }
-							}
-						},
-						{
-							"fly",
-							{
-								{ "no_collision", this->vehicle.fly.no_collision },
-								{ "dont_stop", this->vehicle.fly.dont_stop },
-								{ "enabled", this->vehicle.fly.enabled },
-								{ "stop_on_exit", this->vehicle.fly.stop_on_exit },
-								{ "speed", this->vehicle.fly.speed },
-							}
-						}
-					}
-				},
-				{
-					"weapons", {
-						{ "ammo_special", {
-							{ "toggle", this->weapons.ammo_special.toggle },
-							{ "type", (int)this->weapons.ammo_special.type },
-							}
-						},
-						{ "custom_weapon", (int)this->weapons.custom_weapon },
-						{ "force_crosshairs", this->weapons.force_crosshairs },
-						{ "increased_damage", this->weapons.increased_damage },
-						{ "infinite_ammo", this->weapons.infinite_ammo },
-						{ "infinite_mag", this->weapons.infinite_mag },
-						{ "no_recoil", this->weapons.no_recoil },
-						{ "no_spread", this->weapons.no_spread },
-						{ "bypass_c4_limit", this->weapons.bypass_c4_limit },
-						{ "rapid_fire", this->weapons.rapid_fire },
-					}
-				},
-				{
-					"window", {
-						{ "color", this->window.color },
-						{ "gui_scale", this->window.gui_scale }
-					}
-				},
-				{
-					"context_menu", {
-						{"enabled", this->context_menu.enabled},
-						{ "allowed_entity_types", this->context_menu.allowed_entity_types },
-						{ "selected_option_color", this->context_menu.selected_option_color },
-						{ "bounding_box_enabled", this->context_menu.bounding_box_enabled },
-						{ "bounding_box_color", this->context_menu.bounding_box_color },
-					}
-				},
-				{
-					"esp", {
-						{ "enabled", this->esp.enabled },
-						{ "hide_self", this->esp.hide_self },
-						{ "global_render_distance", nlohmann::json::array({
-							this->esp.global_render_distance[0],
-							this->esp.global_render_distance[1] })
-						},
-						{ "tracer_render_distance", nlohmann::json::array({
-							this->esp.tracer_render_distance[0],
-							this->esp.tracer_render_distance[1] })
-						},
-						{ "box_render_distance", nlohmann::json::array({
-							this->esp.box_render_distance[0],
-							this->esp.box_render_distance[1] })
-						},
-						{ "enemy_color", this->esp.enemy_color },
-						{ "enemy_near_color", this->esp.enemy_near_color },
-						{ "default_color", this->esp.default_color },
-						{ "friend_color", this->esp.friend_color },
-						{ "distance", this->esp.distance },
-						{ "box", this->esp.box },
-						{ "god", this->esp.god },
-						{ "health", this->esp.health },
-						{ "armor", this->esp.armor },
-						{ "name", this->esp.name },
-						{ "tracer", this->esp.tracer },
-						{ "change_esp_color_from_dist", this->esp.change_esp_color_from_dist },
-						{ "scale_health_from_dist", this->esp.scale_health_from_dist },
-						{ "scale_armor_from_dist", this->esp.scale_armor_from_dist },
-						{ "tracer_draw_position", nlohmann::json::array({
-							this->esp.tracer_draw_position[0],
-							this->esp.tracer_draw_position[1] })
-						},
-						{ "distance_threshold", nlohmann::json::array({
-							this->esp.distance_threshold[0],
-							this->esp.distance_threshold[1] })
-						}
-					}
-				},
-				{
-					"session_browser", {
-						{ "region_filter_enabled", this->session_browser.region_filter_enabled },
-						{ "region_filter", this->session_browser.region_filter },
-						{ "language_filter_enabled", this->session_browser.language_filter_enabled },
-						{ "language_filter", this->session_browser.language_filter },
-						{ "player_count_filter_enabled", this->session_browser.player_count_filter_enabled },
-						{ "player_count_filter_minimum", this->session_browser.player_count_filter_minimum },
-						{ "player_count_filter_maximum", this->session_browser.player_count_filter_maximum },
-						{ "sort_method", this->session_browser.sort_method },
-						{ "sort_direction", this->session_browser.sort_direction },
-						{ "replace_game_matchmaking", this->session_browser.replace_game_matchmaking }
-					}
-				},
-			};
-		}
-
-		void attempt_save()
-		{
-			const nlohmann::json& j = this->to_json();
-
-			if (deep_compare(this->options, j, true))
-				this->save();
-		}
-
-		bool load()
-		{
-			this->default_options = this->to_json();
-
-			std::ifstream file(m_save_file.get_path());
-
-			if (!file.is_open())
-			{
-				this->write_default_config();
-
-				file.open(m_save_file.get_path());
-			}
-
-			try
-			{
-				file >> this->options;
-
-				file.close();
-			}
-			catch (const std::exception&)
-			{
-				file.close();
-
-				LOG(WARNING) << "Detected corrupt settings, writing default config...";
-
-				this->write_default_config();
-
-				return this->load();
-			}
-
-			const bool should_save = this->deep_compare(this->options, this->default_options);
-
-			this->from_json(this->options);
-
-			if (should_save)
-			{
-				LOG(INFO) << "Updating settings.";
-				save();
-			}
-
-			return true;
-		}
-
-	private:
-		file m_save_file;
-
-		bool deep_compare(nlohmann::json& current_settings, const nlohmann::json& default_settings, bool compare_value = false)
-		{
-			bool should_save = false;
-
-			for (auto& e : default_settings.items())
-			{
-				const std::string& key = e.key();
-
-				if (current_settings.count(key) == 0 || (compare_value && current_settings[key] != e.value()))
-				{
-					current_settings[key] = e.value();
-
-					should_save = true;
-				}
-				else if (current_settings[key].is_object() && e.value().is_object())
-				{
-					if (deep_compare(current_settings[key], e.value(), compare_value))
-						should_save = true;
-				}
-				else if (!current_settings[key].is_object() && e.value().is_object()) {
-					current_settings[key] = e.value();
-
-					should_save = true;
-				}
-			}
-
-			return should_save;
-		}
-
-		bool save()
-		{
-			std::ofstream file(m_save_file.get_path(), std::ios::out | std::ios::trunc);
-			file << this->to_json().dump(4);
-			file.close();
-
-			return true;
-		}
-
-		bool write_default_config()
-		{
-			std::ofstream file(m_save_file.get_path(), std::ios::out | std::ios::trunc);
-			file << this->to_json().dump(4);
-			file.close();
-
-			return true;
-		}
+		NLOHMANN_DEFINE_TYPE_INTRUSIVE(menu_settings,
+			debug, tunables, notifications, player, protections, self, session, settings, spawn_vehicle, clone_pv,
+			spawn_ped, spoofing, vehicle, weapons, window, context_menu, esp, session_browser)
 	};
+
+	inline menu_settings* g{};
 }

--- a/src/core/globals.hpp
+++ b/src/core/globals.hpp
@@ -20,10 +20,7 @@ namespace big
 	class menu_settings
 	{
 	public:
-		menu_settings(file save_file);
-		~menu_settings();
-
-		void init();
+		void init(file save_file);
 
 		void attempt_save();
 		bool load();
@@ -34,7 +31,7 @@ namespace big
 		bool write_default_config();
 
 	private:
-		file m_save_file;
+		file m_save_file = "";
 
 		nlohmann::json m_default_options;
 		nlohmann::json m_options;
@@ -628,5 +625,5 @@ namespace big
 			spawn_ped, spoofing, vehicle, weapons, window, context_menu, esp, session_browser)
 	};
 
-	inline menu_settings* g{};
+	inline static auto g = menu_settings();
 }

--- a/src/core/globals.hpp
+++ b/src/core/globals.hpp
@@ -625,5 +625,5 @@ namespace big
 			spawn_ped, spoofing, vehicle, weapons, window, context_menu, esp, session_browser)
 	};
 
-	inline static auto g = menu_settings();
+	inline auto g = menu_settings();
 }

--- a/src/core/globals.hpp
+++ b/src/core/globals.hpp
@@ -23,6 +23,8 @@ namespace big
 		menu_settings(file save_file);
 		~menu_settings();
 
+		void init();
+
 		void attempt_save();
 		bool load();
 

--- a/src/core/globals.hpp
+++ b/src/core/globals.hpp
@@ -20,7 +20,7 @@ namespace big
 	class menu_settings
 	{
 	public:
-		void init(file save_file);
+		void init(const file& save_file);
 
 		void attempt_save();
 		bool load();
@@ -31,7 +31,7 @@ namespace big
 		bool write_default_config();
 
 	private:
-		file m_save_file = "";
+		std::unique_ptr<file> m_save_file;
 
 		nlohmann::json m_default_options;
 		nlohmann::json m_options;

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -76,8 +76,8 @@ namespace big
 		auto& colors = style.Colors;
 		colors[ImGuiCol_Text] = ImVec4(0.80f, 0.80f, 0.83f, 1.00f);
 		colors[ImGuiCol_TextDisabled] = ImVec4(0.24f, 0.23f, 0.29f, 1.00f);
-		colors[ImGuiCol_WindowBg] = ImGui::ColorConvertU32ToFloat4(g->window.color);
-		colors[ImGuiCol_ChildBg] = ImGui::ColorConvertU32ToFloat4(g->window.color);
+		colors[ImGuiCol_WindowBg] = ImGui::ColorConvertU32ToFloat4(g.window.color);
+		colors[ImGuiCol_ChildBg] = ImGui::ColorConvertU32ToFloat4(g.window.color);
 		colors[ImGuiCol_PopupBg] = ImVec4(0.07f, 0.07f, 0.09f, 1.00f);
 		colors[ImGuiCol_Border] = ImVec4(0.80f, 0.80f, 0.83f, 0.88f);
 		colors[ImGuiCol_BorderShadow] = ImVec4(0.92f, 0.91f, 0.88f, 0.00f);
@@ -115,7 +115,7 @@ namespace big
 	{
 		if (m_is_open)
 		{
-			ImGui::PushStyleColor(ImGuiCol_WindowBg, ImGui::ColorConvertU32ToFloat4(g->window.color));
+			ImGui::PushStyleColor(ImGuiCol_WindowBg, ImGui::ColorConvertU32ToFloat4(g.window.color));
 			view::root();
 			ImGui::PopStyleColor();
 		}
@@ -166,7 +166,7 @@ namespace big
 
 	void gui::wndproc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam)
 	{
-		if (msg == WM_KEYUP && wparam == g->settings.hotkeys.menu_toggle)
+		if (msg == WM_KEYUP && wparam == g.settings.hotkeys.menu_toggle)
 		{
 			//Persist and restore the cursor position between menu instances.
 			static POINT cursor_coords{};
@@ -179,9 +179,9 @@ namespace big
 				SetCursorPos(cursor_coords.x, cursor_coords.y);
 			}
 
-			toggle(g->settings.hotkeys.editing_menu_toggle || !m_is_open);
-			if (g->settings.hotkeys.editing_menu_toggle)
-				g->settings.hotkeys.editing_menu_toggle = false;
+			toggle(g.settings.hotkeys.editing_menu_toggle || !m_is_open);
+			if (g.settings.hotkeys.editing_menu_toggle)
+				g.settings.hotkeys.editing_menu_toggle = false;
 		}
 	}
 

--- a/src/gui/components/icon.cpp
+++ b/src/gui/components/icon.cpp
@@ -4,6 +4,6 @@
 namespace big
 {
 	void components::icon(const std::string_view text) {
-		components::custom_text(text.data(), g->window.font_icon);
+		components::custom_text(text.data(), g.window.font_icon);
 	}
 }

--- a/src/gui/components/small.cpp
+++ b/src/gui/components/small.cpp
@@ -4,6 +4,6 @@
 namespace big
 {
 	void components::small_text(const std::string_view text) {
-		components::custom_text(text.data(), g->window.font_small);
+		components::custom_text(text.data(), g.window.font_small);
 	}
 }

--- a/src/gui/components/sub_title.cpp
+++ b/src/gui/components/sub_title.cpp
@@ -4,6 +4,6 @@
 namespace big
 {
 	void components::sub_title(const std::string_view text) {
-		components::custom_text(text.data(), g->window.font_sub_title);
+		components::custom_text(text.data(), g.window.font_sub_title);
 	}
 }

--- a/src/gui/components/title.cpp
+++ b/src/gui/components/title.cpp
@@ -4,6 +4,6 @@
 namespace big
 {
 	void components::title(const std::string_view text) {
-		components::custom_text(text.data(), g->window.font_title);
+		components::custom_text(text.data(), g.window.font_title);
 	}
 }

--- a/src/hooks/misc/multiplayer_chat_filter.cpp
+++ b/src/hooks/misc/multiplayer_chat_filter.cpp
@@ -4,7 +4,7 @@ namespace big
 {
 	int hooks::multiplayer_chat_filter(__int64 chat_type, const char* input, const char** output)
 	{
-		if (g->session.disable_chat_filter)
+		if (g.session.disable_chat_filter)
 		{
 			return -1;
 		}

--- a/src/hooks/misc/send_chat_net_message.cpp
+++ b/src/hooks/misc/send_chat_net_message.cpp
@@ -18,8 +18,8 @@ namespace big
 			}
 		}
 
-		if (g->m_spoofed_peer_ids.contains(host_token))
-			msg->m_peer_id = g->m_spoofed_peer_ids[host_token];
+		if (g.m_spoofed_peer_ids.contains(host_token))
+			msg->m_peer_id = g.m_spoofed_peer_ids[host_token];
 
 		return g_hooking->get_original<hooks::send_chat_net_message>()(mgr, receiver_msg_id, msg, flags, unk);
 	}

--- a/src/hooks/misc/serialize_player_data_msg.cpp
+++ b/src/hooks/misc/serialize_player_data_msg.cpp
@@ -9,7 +9,7 @@ namespace big
 	{
 		int old_group = msg->m_matchmaking_group;
 
-		if (g->session.join_in_sctv_slots)
+		if (g.session.join_in_sctv_slots)
 			msg->m_matchmaking_group = 4;
 
 	    bool ret = g_hooking->get_original<hooks::serialize_player_data_msg>()(msg, buffer);

--- a/src/hooks/misc/sort_session_details.cpp
+++ b/src/hooks/misc/sort_session_details.cpp
@@ -7,9 +7,9 @@ namespace big
 	// false => e1 < e2
 	bool hooks::sort_session_details(SessionSortEntry* e1, SessionSortEntry* e2)
 	{
-		if (g->session.player_magnet_enabled)
+		if (g.session.player_magnet_enabled)
 		{
-			return std::abs((int)e1->m_session_detail->m_player_count - g->session.player_magnet_count) < std::abs((int)e2->m_session_detail->m_player_count - g->session.player_magnet_count);
+			return std::abs((int)e1->m_session_detail->m_player_count - g.session.player_magnet_count) < std::abs((int)e2->m_session_detail->m_player_count - g.session.player_magnet_count);
 		}
 		else
 		{

--- a/src/hooks/misc/start_matchmaking_find_sessions.cpp
+++ b/src/hooks/misc/start_matchmaking_find_sessions.cpp
@@ -9,14 +9,14 @@ namespace big
 	{
 		int discriminator = filter->m_param_values[0]; // this is guaranteed to work
 
-		if (g->session_browser.replace_game_matchmaking && filter->m_filter_type == 1)
+		if (g.session_browser.replace_game_matchmaking && filter->m_filter_type == 1)
 		{
 			*status = 1;
 			g_fiber_pool->queue_job([max_sessions, results, num_sessions_found, status, discriminator]
 			{
 				bool result = false;
 
-				if (g->session.join_in_sctv_slots)
+				if (g.session.join_in_sctv_slots)
 					result = g_matchmaking_service->matchmake();
 				else
 					result = g_matchmaking_service->matchmake(discriminator);

--- a/src/hooks/player_management/assign_physical_index.cpp
+++ b/src/hooks/player_management/assign_physical_index.cpp
@@ -15,17 +15,17 @@ namespace big
 
 		if (new_index == static_cast<uint8_t>(-1))
 		{
-			g->m_spoofed_peer_ids.erase(player->get_net_data()->m_host_token);
+			g.m_spoofed_peer_ids.erase(player->get_net_data()->m_host_token);
 			g_player_service->player_leave(player);
 
 			if (net_player_data)
 			{
-				if (g->notifications.player_leave.log)
+				if (g.notifications.player_leave.log)
 					LOG(INFO) << "Player left '" << net_player_data->m_name
 						<< "' freeing slot #" << (int)player->m_player_id
 						<< " with Rockstar ID: " << net_player_data->m_gamer_handle_2.m_rockstar_id;
 
-				if (g->notifications.player_leave.notify)
+				if (g.notifications.player_leave.notify)
 					g_notification_service->push("Player Left", std::format("{} freeing slot #{} with Rockstar ID: {}", net_player_data->m_name, player->m_player_id, net_player_data->m_gamer_handle_2.m_rockstar_id));
 			}
 
@@ -36,15 +36,15 @@ namespace big
 		g_player_service->player_join(player);
 		if (net_player_data)
 		{
-			if (g->notifications.player_join.above_map && *g_pointers->m_is_session_started) // prevent loading screen spam
+			if (g.notifications.player_join.above_map && *g_pointers->m_is_session_started) // prevent loading screen spam
 				notify::player_joined(player);
 
-			if (g->notifications.player_join.log)
+			if (g.notifications.player_join.log)
 				LOG(INFO) << "Player joined '" << net_player_data->m_name
 					<< "' allocating slot #" << (int)player->m_player_id
 					<< " with Rockstar ID: " << net_player_data->m_gamer_handle_2.m_rockstar_id;
 
-			if (g->notifications.player_join.notify)
+			if (g.notifications.player_join.notify)
 				g_notification_service->push("Player Joined", std::format("{} taking slot #{} with Rockstar ID: {}", net_player_data->m_name, player->m_player_id, net_player_data->m_gamer_handle_2.m_rockstar_id));
 
 			auto id = player->m_player_id;

--- a/src/hooks/player_management/network_player_mgr.cpp
+++ b/src/hooks/player_management/network_player_mgr.cpp
@@ -6,9 +6,9 @@ namespace big
 {
 	void hooks::network_player_mgr_init(CNetworkPlayerMgr* _this, std::uint64_t a2, std::uint32_t a3, std::uint32_t a4[4])
 	{
-		if (g->notifications.network_player_mgr_init.log)
+		if (g.notifications.network_player_mgr_init.log)
 			LOG(INFO) << "CNetworkPlayerMgr#init got called, we're probably entering a session.";
-		if (g->notifications.network_player_mgr_init.notify)
+		if (g.notifications.network_player_mgr_init.notify)
 			g_notification_service->push("Network Player Manager", "Entering session and initializing player data.");
 
 		g_hooking->get_original<hooks::network_player_mgr_init>()(_this, a2, a3, a4);
@@ -18,12 +18,12 @@ namespace big
 
 	void hooks::network_player_mgr_shutdown(CNetworkPlayerMgr* _this)
 	{
-		g->m_spoofed_peer_ids.clear();
+		g.m_spoofed_peer_ids.clear();
 		g_player_service->do_cleanup();
 
-		if (g->notifications.network_player_mgr_shutdown.log)
+		if (g.notifications.network_player_mgr_shutdown.log)
 			LOG(INFO) << "CNetworkPlayerMgr#shutdown got called, we're probably leaving our session.";
-		if (g->notifications.network_player_mgr_shutdown.notify)
+		if (g.notifications.network_player_mgr_shutdown.notify)
 			g_notification_service->push("Network Player Manager", "Leaving session and cleaning up player data.");
 
 		g_hooking->get_original<hooks::network_player_mgr_shutdown>()(_this);

--- a/src/hooks/protections/add_player_to_session.cpp
+++ b/src/hooks/protections/add_player_to_session.cpp
@@ -31,7 +31,7 @@ namespace big
 {
 	bool hooks::add_player_to_session(rage::netConnectionManager* mgr, int receiver_msg_id, int* out_command_hndl, RemoteGamerInfoMsg* msg, int flags, void* unk)
 	{
-		if (msg->m_gamer_info.m_gamer_handle_2.m_rockstar_id == g_local_player->m_player_info->m_net_player_data.m_gamer_handle_2.m_rockstar_id && gta_util::get_network()->m_game_session_ptr->is_host() && g->protections.lessen_breakups)
+		if (msg->m_gamer_info.m_gamer_handle_2.m_rockstar_id == g_local_player->m_player_info->m_net_player_data.m_gamer_handle_2.m_rockstar_id && gta_util::get_network()->m_game_session_ptr->is_host() && g.protections.lessen_breakups)
 		{
 			std::uint64_t host_token = -1;
 
@@ -46,7 +46,7 @@ namespace big
 			}
 
 			std::uint64_t peer_id = rand64bits();
-			g->m_spoofed_peer_ids.emplace(host_token, peer_id);
+			g.m_spoofed_peer_ids.emplace(host_token, peer_id);
 			msg->m_gamer_info.m_peer_id_2 = peer_id;
 		}
 

--- a/src/hooks/protections/can_apply_data.cpp
+++ b/src/hooks/protections/can_apply_data.cpp
@@ -202,7 +202,7 @@ namespace big
 
 	bool hooks::can_apply_data(rage::netSyncTree* tree, rage::netObject* object)
 	{
-		if (tree->m_child_node_count && check_node(tree->m_sync_node, g->m_syncing_player, object))
+		if (tree->m_child_node_count && check_node(tree->m_sync_node, g.m_syncing_player, object))
 		{
 			return false;
 		}

--- a/src/hooks/protections/increment_stat_event.cpp
+++ b/src/hooks/protections/increment_stat_event.cpp
@@ -20,10 +20,10 @@ namespace big
 		case RAGE_JOAAT("MPPLY_VC_HATE"):
 			const auto report = std::format("From: {}", sender->get_name());
 
-			if (g->notifications.reports.log)
+			if (g.notifications.reports.log)
 				LOG(INFO) << "Blocked report; " << report;
 
-			if (g->notifications.reports.notify)
+			if (g.notifications.reports.notify)
 				g_notification_service->push_warning("BLOCKED REPORT", report);
 
 			return true;

--- a/src/hooks/protections/receive_net_message.cpp
+++ b/src/hooks/protections/receive_net_message.cpp
@@ -80,16 +80,16 @@ namespace big
 
 					if (spam::is_text_spam(message))
 					{
-						if (g->session.log_chat_messages)
+						if (g.session.log_chat_messages)
 							spam::log_chat(message, player, true);
 						player->is_spammer = true;
-						if (g->session.kick_chat_spammers)
+						if (g.session.kick_chat_spammers)
 							kick::breakup_kick(player);
 						return true;
 					}
 					else
 					{
-						if (g->session.log_chat_messages)
+						if (g.session.log_chat_messages)
 							spam::log_chat(message, player, false);
 					}
 					break;
@@ -213,7 +213,7 @@ namespace big
 					CGameScriptId script;
 					script_id_deserialize(script, buffer);
 
-					if (script.m_hash == RAGE_JOAAT("freemode") && g->session.force_script_host)
+					if (script.m_hash == RAGE_JOAAT("freemode") && g.session.force_script_host)
 						return true;
 					
 					break;

--- a/src/hooks/protections/received_clone_create.cpp
+++ b/src/hooks/protections/received_clone_create.cpp
@@ -11,7 +11,7 @@ namespace big
 			return true;
 		}
 
-		g->m_syncing_player = src;
+		g.m_syncing_player = src;
 		return g_hooking->get_original<hooks::received_clone_create>()(mgr, src, dst, object_type, object_id, object_flag, buffer, timestamp);
 	}
 }

--- a/src/hooks/protections/received_clone_sync.cpp
+++ b/src/hooks/protections/received_clone_sync.cpp
@@ -17,7 +17,7 @@ namespace big
 			return eAckCode::ACKCODE_FAIL;
 		}
 
-		g->m_syncing_player = src;
+		g.m_syncing_player = src;
 		return g_hooking->get_original<received_clone_sync>()(mgr, src, dst, object_type, object_id, buffer, unk, timestamp);
 	}
 }

--- a/src/hooks/protections/received_event.cpp
+++ b/src/hooks/protections/received_event.cpp
@@ -181,7 +181,7 @@ namespace big
 		if (damageType == 3 && (damageFlags & (1 << 1)) == 0)
 			hitGlobalId = g_local_player ? g_local_player->m_net_object->m_object_id : 0;
 
-		if (g->session.damage_karma && g_local_player && g_local_player->m_net_object && (g_local_player->m_net_object->m_object_id == hitGlobalId || math::distance_between_vectors(localPos, *g_local_player->m_navigation->get_position()) < 1.5f))
+		if (g.session.damage_karma && g_local_player && g_local_player->m_net_object && (g_local_player->m_net_object->m_object_id == hitGlobalId || math::distance_between_vectors(localPos, *g_local_player->m_navigation->get_position()) < 1.5f))
 		{
 			int id = player->m_player_id;
 			g_fiber_pool->queue_job([id, hitComponent, overrideDefaultDamage, weaponType, weaponDamage, tyreIndex, suspensionIndex, damageFlags, actionResultName, actionResultId, f104, hitEntityWeapon, hitWeaponAmmoAttachment, silenced, hasImpactDir, impactDir, localPos]
@@ -314,7 +314,7 @@ namespace big
 			return;
 		}
 
-		if (g->session.explosion_karma && g_local_player && math::distance_between_vectors({ posX, posY, posZ }, *g_local_player->m_navigation->get_position()) < 3.0f)
+		if (g.session.explosion_karma && g_local_player && math::distance_between_vectors({ posX, posY, posZ }, *g_local_player->m_navigation->get_position()) < 3.0f)
 		{
 			int id = player->m_player_id;
 			g_fiber_pool->queue_job([id, explosionType, damageScale, cameraShake, isAudible, isInvisible]
@@ -355,9 +355,9 @@ namespace big
 			std::uint32_t player_bitfield = buffer->Read<uint32_t>(32);
 			if (player_bitfield & (1 << target_player->m_player_id))
 			{
-				if (g->notifications.received_event.kick_vote.log)
+				if (g.notifications.received_event.kick_vote.log)
 					LOG(INFO) << "RECEIVED_EVENT_HANDLER : " << source_player->get_name() << " is voting to kick us.";
-				if (g->notifications.received_event.kick_vote.notify)
+				if (g.notifications.received_event.kick_vote.notify)
 					g_notification_service->push_warning("Kick Vote", std::format("{} is voting to kick us.", source_player->get_name()));
 			}
 			buffer->Seek(0);
@@ -421,9 +421,9 @@ namespace big
 			{
 				g_pointers->m_send_event_ack(event_manager, source_player, target_player, event_index, event_handled_bitset);
 
-				if (g->notifications.received_event.clear_ped_task.log)
+				if (g.notifications.received_event.clear_ped_task.log)
 					LOG(INFO) << "RECEIVED_EVENT_HANDLER : " << source_player->get_name() << " sent CLEAR_PED_TASKS event.";
-				if (g->notifications.received_event.clear_ped_task.notify)
+				if (g.notifications.received_event.clear_ped_task.notify)
 					g_notification_service->push_warning("Protections", std::format("{} tried to freeze player.", source_player->get_name()));
 
 				return;
@@ -440,9 +440,9 @@ namespace big
 			{
 				g_pointers->m_send_event_ack(event_manager, source_player, target_player, event_index, event_handled_bitset);
 
-				if (g->notifications.received_event.clear_ped_task.log)
+				if (g.notifications.received_event.clear_ped_task.log)
 					LOG(INFO) << "RECEIVED_EVENT_HANDLER : " << source_player->get_name() << " sent RAGDOLL_REQUEST event.";
-				if (g->notifications.received_event.clear_ped_task.notify)
+				if (g.notifications.received_event.clear_ped_task.notify)
 					g_notification_service->push_warning("Protections", std::format("{} tried to ragdoll player.", source_player->get_name()));
 
 				return;
@@ -463,9 +463,9 @@ namespace big
 
 			if (money >= 2000)
 			{
-				if (g->notifications.received_event.report_cash_spawn.log)
+				if (g.notifications.received_event.report_cash_spawn.log)
 					LOG(INFO) << "RECEIVED_EVENT_HANDLER : " << source_player->get_name() << " sent REPORT_CASH_SPAWN event.";
-				if (g->notifications.received_event.report_cash_spawn.notify)
+				if (g.notifications.received_event.report_cash_spawn.notify)
 					g_notification_service->push_warning("Protections", std::format("{} is spawning cash.", source_player->get_name()));
 			}
 
@@ -474,9 +474,9 @@ namespace big
 		// player sending this event is a modder
 		case eNetworkEvents::REPORT_MYSELF_EVENT:
 		{
-			if (g->notifications.received_event.modder_detect.log)
+			if (g.notifications.received_event.modder_detect.log)
 				LOG(INFO) << "RECEIVED_EVENT_HANDLER : " << source_player->get_name() << " sent modder event.";
-			if (g->notifications.received_event.modder_detect.notify)
+			if (g.notifications.received_event.modder_detect.notify)
 				g_notification_service->push_warning("Protections", std::format("{} sent out a modder event.", source_player->get_name()));
 
 			if (auto plyr = g_player_service->get_by_id(source_player->m_player_id))
@@ -491,9 +491,9 @@ namespace big
 			{
 				g_pointers->m_send_event_ack(event_manager, source_player, target_player, event_index, event_handled_bitset);
 
-				if (g->notifications.received_event.request_control_event.log)
+				if (g.notifications.received_event.request_control_event.log)
 					LOG(INFO) << "RECEIVED_EVENT_HANDLER : " << source_player->get_name() << " requested control of player vehicle.";
-				if (g->notifications.received_event.request_control_event.notify)
+				if (g.notifications.received_event.request_control_event.notify)
 					g_notification_service->push_warning("Protections", std::format("Denied player control request from {}", source_player->get_name()));
 
 				return;
@@ -610,7 +610,7 @@ namespace big
 			}
 
 			buffer->Seek(0);
-			g->m_syncing_player = source_player;
+			g.m_syncing_player = source_player;
 			break;
 		}
 		case eNetworkEvents::NETWORK_PLAY_SOUND_EVENT:

--- a/src/hooks/protections/script_event_handler.cpp
+++ b/src/hooks/protections/script_event_handler.cpp
@@ -24,7 +24,7 @@ namespace big
 		const auto hash = static_cast<eRemoteEvent>(args[0]);
 		const auto player_name = player->get_name();
 
-		const auto& notify = g->notifications.script_event_handler;
+		const auto& notify = g.notifications.script_event_handler;
 
 		// detect pasted menus setting args[1] to something other than PLAYER_ID()
 		if (*(int*)&args[1] != player->m_player_id && player->m_player_id != -1)
@@ -37,7 +37,7 @@ namespace big
 		switch (hash)
 		{
 		case eRemoteEvent::Bounty:
-			if (g->protections.script_events.bounty)
+			if (g.protections.script_events.bounty)
 			{
 				format_string(player_name, "Bounty", notify.bounty.log, notify.bounty.notify);
 
@@ -45,7 +45,7 @@ namespace big
 			}
 			break;
 		case eRemoteEvent::CeoBan:
-			if (g->protections.script_events.ceo_ban)
+			if (g.protections.script_events.ceo_ban)
 			{
 				format_string(player_name, "Ceo Ban", notify.ceo_ban.log, notify.ceo_ban.notify);
 
@@ -53,7 +53,7 @@ namespace big
 			}
 			break;
 		case eRemoteEvent::CeoKick:
-			if (g->protections.script_events.ceo_kick)
+			if (g.protections.script_events.ceo_kick)
 			{
 				format_string(player_name, "Ceo Kick", notify.ceo_kick.log, notify.ceo_kick.notify);
 
@@ -61,7 +61,7 @@ namespace big
 			}
 			break;
 		case eRemoteEvent::CeoMoney:
-			if (g->protections.script_events.ceo_money)
+			if (g.protections.script_events.ceo_money)
 			{
 				format_string(player_name, "Ceo Money", notify.ceo_money.log, notify.ceo_money.notify);
 
@@ -69,7 +69,7 @@ namespace big
 			}
 			break;
 		case eRemoteEvent::ClearWantedLevel:
-			if (g->protections.script_events.clear_wanted_level)
+			if (g.protections.script_events.clear_wanted_level)
 			{
 				format_string(player_name, "Clear Wanted Level", notify.clear_wanted_level.log, notify.clear_wanted_level.notify);
 
@@ -78,7 +78,7 @@ namespace big
 			break;
 		case eRemoteEvent::Crash:
 		case eRemoteEvent::Crash2:
-			if (g->protections.script_events.crash)
+			if (g.protections.script_events.crash)
 			{
 				format_string(player_name, "TSE Crash", notify.crash.log, notify.crash.notify);
 
@@ -91,7 +91,7 @@ namespace big
 			case eRemoteEvent::NotificationMoneyBanked:
 			case eRemoteEvent::NotificationMoneyRemoved:
 			case eRemoteEvent::NotificationMoneyStolen:
-				if (g->protections.script_events.fake_deposit)
+				if (g.protections.script_events.fake_deposit)
 				{
 					format_string(player_name, "Fake Deposit", notify.fake_deposit.log, notify.fake_deposit.notify);
 
@@ -101,7 +101,7 @@ namespace big
 			}
 			break;
 		case eRemoteEvent::ForceMission:
-			if (g->protections.script_events.force_mission)
+			if (g.protections.script_events.force_mission)
 			{
 				format_string(player_name, "Force Mission", notify.force_mission.log, notify.force_mission.notify);
 
@@ -109,7 +109,7 @@ namespace big
 			}
 			break;
 		case eRemoteEvent::GiveCollectible:
-			if (g->protections.script_events.switch_player_model)
+			if (g.protections.script_events.switch_player_model)
 			{
 				if (args[2] == 8)
 				{
@@ -120,7 +120,7 @@ namespace big
 			}
 			break;
 		case eRemoteEvent::GtaBanner:
-			if (g->protections.script_events.gta_banner)
+			if (g.protections.script_events.gta_banner)
 			{
 				format_string(player_name, "GTA Banner", notify.gta_banner.log, notify.gta_banner.notify);
 
@@ -128,13 +128,13 @@ namespace big
 			}
 			break;
 		case eRemoteEvent::MCTeleport:
-			if (g->protections.script_events.mc_teleport && args[3] <= 32)
+			if (g.protections.script_events.mc_teleport && args[3] <= 32)
 			{
 				format_string(player_name, "Remote Teleport", notify.mc_teleport.log, notify.mc_teleport.notify);
 
 				return true;
 			}
-			else if (g->protections.script_events.crash && args[3] > 32)
+			else if (g.protections.script_events.crash && args[3] > 32)
 			{
 				format_string(player_name, "TSE Crash", notify.crash.log, notify.crash.notify);
 
@@ -142,7 +142,7 @@ namespace big
 			}
 			break;
 		case eRemoteEvent::PersonalVehicleDestroyed:
-			if (g->protections.script_events.personal_vehicle_destroyed)
+			if (g.protections.script_events.personal_vehicle_destroyed)
 			{
 				format_string(player_name, "Personal Vehicle Destroyed", notify.personal_vehicle_destroyed.log, notify.personal_vehicle_destroyed.notify);
 
@@ -150,7 +150,7 @@ namespace big
 			}
 			break;
 		case eRemoteEvent::RemoteOffradar:
-			if (g->protections.script_events.remote_off_radar)
+			if (g.protections.script_events.remote_off_radar)
 			{
 				format_string(player_name, "Off Radar", notify.remote_off_radar.log, notify.remote_off_radar.notify);
 
@@ -158,7 +158,7 @@ namespace big
 			}
 			break;
 		case eRemoteEvent::TSECommand:
-			if (g->protections.script_events.rotate_cam && static_cast<eRemoteEvent>(args[2]) == eRemoteEvent::TSECommandRotateCam)
+			if (g.protections.script_events.rotate_cam && static_cast<eRemoteEvent>(args[2]) == eRemoteEvent::TSECommandRotateCam)
 			{
 				format_string(player_name, "Rotate Cam", notify.rotate_cam.log, notify.rotate_cam.notify);
 
@@ -166,7 +166,7 @@ namespace big
 			}
 			break;
 		case eRemoteEvent::SendToCayoPerico:
-			if (g->protections.script_events.send_to_location)
+			if (g.protections.script_events.send_to_location)
 			{
 				format_string(player_name, "Send to Cayo Perico", notify.send_to_location.log, notify.send_to_location.notify);
 
@@ -174,7 +174,7 @@ namespace big
 			}
 			break;
 		case eRemoteEvent::SendToCutscene:
-			if (g->protections.script_events.send_to_cutscene)
+			if (g.protections.script_events.send_to_cutscene)
 			{
 				format_string(player_name, "Send to Cutscene", notify.send_to_cutscene.log, notify.send_to_cutscene.notify);
 
@@ -191,7 +191,7 @@ namespace big
 				{
 					known_location = true;
 
-					if (g->protections.script_events.send_to_location)
+					if (g.protections.script_events.send_to_location)
 					{
 						format_string(player_name, "Send to Beach", notify.send_to_location.log, notify.send_to_location.notify);
 
@@ -202,7 +202,7 @@ namespace big
 				{
 					known_location = true;
 
-					if (g->protections.script_events.send_to_location)
+					if (g.protections.script_events.send_to_location)
 					{
 						format_string(player_name, "Send to Cayo Perico", notify.send_to_location.log, notify.send_to_location.notify);
 
@@ -220,7 +220,7 @@ namespace big
 			break;
 		}
 		case eRemoteEvent::SoundSpam:
-			if (g->protections.script_events.sound_spam)
+			if (g.protections.script_events.sound_spam)
 			{
 				format_string(player_name, "Sound Spamn", notify.sound_spam.log, notify.sound_spam.notify);
 
@@ -228,7 +228,7 @@ namespace big
 			}
 			break;
 		case eRemoteEvent::Spectate:
-			if (g->protections.script_events.spectate)
+			if (g.protections.script_events.spectate)
 			{
 				format_string(player_name, "Spectate", notify.spectate.log, notify.spectate.notify);
 
@@ -236,7 +236,7 @@ namespace big
 			}
 			break;
 		case eRemoteEvent::Teleport:
-			if (g->protections.script_events.force_teleport)
+			if (g.protections.script_events.force_teleport)
 			{
 				format_string(player_name, "Apartment Invite", notify.force_teleport.log, notify.force_teleport.notify);
 
@@ -244,7 +244,7 @@ namespace big
 			}
 			break;
 		case eRemoteEvent::TransactionError:
-			if (g->protections.script_events.transaction_error)
+			if (g.protections.script_events.transaction_error)
 			{
 				format_string(player_name, "Transaction Error", notify.transaction_error.log, notify.transaction_error.notify);
 
@@ -252,7 +252,7 @@ namespace big
 			}
 			break;
 		case eRemoteEvent::VehicleKick:
-			if (g->protections.script_events.vehicle_kick)
+			if (g.protections.script_events.vehicle_kick)
 			{
 				format_string(player_name, "Vehicle Kick", notify.vehicle_kick.log, notify.vehicle_kick.notify);
 
@@ -260,7 +260,7 @@ namespace big
 			}
 			break;
 		case eRemoteEvent::ForceMission2:
-			if (g->protections.script_events.force_mission)
+			if (g.protections.script_events.force_mission)
 			{
 				format_string(player_name, "Force Mission", notify.force_mission.log, notify.force_mission.notify);
 
@@ -268,7 +268,7 @@ namespace big
 			}
 			break;
 		case eRemoteEvent::NetworkBail:
-			if (g->protections.script_events.network_bail)
+			if (g.protections.script_events.network_bail)
 			{
 				if (auto plyr = g_player_service->get_by_id(player->m_player_id))
 					session::add_infraction(plyr, Infraction::TRIED_KICK_PLAYER);
@@ -277,7 +277,7 @@ namespace big
 			}
 			break;
 		case eRemoteEvent::TeleportToWarehouse:
-			if (g->protections.script_events.teleport_to_warehouse)
+			if (g.protections.script_events.teleport_to_warehouse)
 			{
 				format_string(player_name, "Teleport To Warehouse", notify.teleport_to_warehouse.log, notify.teleport_to_warehouse.notify);
 
@@ -287,7 +287,7 @@ namespace big
 		case eRemoteEvent::StartActivity:
 		{
 			eActivityType activity = static_cast<eActivityType>(args[2]);
-			if (g->protections.script_events.start_activity)
+			if (g.protections.script_events.start_activity)
 			{
 				if (activity == eActivityType::Survival || activity == eActivityType::Mission || activity == eActivityType::Deathmatch || activity == eActivityType::BaseJump || activity == eActivityType::Race)
 				{
@@ -321,7 +321,7 @@ namespace big
 				}
 				// there are MANY more
 			}
-			else if (g->protections.script_events.crash && activity == eActivityType::Tennis)
+			else if (g.protections.script_events.crash && activity == eActivityType::Tennis)
 			{
 				format_string(player_name, "TSE Crash (Start Tennis)", notify.crash.log, notify.crash.notify);
 
@@ -343,7 +343,7 @@ namespace big
 			break;
 		}
 
-		if (g->debug.logs.script_event.logs && (!g->debug.logs.script_event.filter_player || g->debug.logs.script_event.player_id == player->m_player_id))
+		if (g.debug.logs.script_event.logs && (!g.debug.logs.script_event.filter_player || g.debug.logs.script_event.player_id == player->m_player_id))
 		{
 			std::string script_args = "{ ";
 			for (std::size_t i = 0; i < scripted_game_event->m_args_size; i++)

--- a/src/hooks/protections/serialize_dynamic_entity_game_state_data_node.cpp
+++ b/src/hooks/protections/serialize_dynamic_entity_game_state_data_node.cpp
@@ -43,7 +43,7 @@ namespace big
 
 			if (node->m_decor_count > 11)
 			{
-				notify::crash_blocked(g->m_syncing_player, "out of bounds decorator count");
+				notify::crash_blocked(g.m_syncing_player, "out of bounds decorator count");
 				return;
 			}
 

--- a/src/hooks/protections/serialize_ped_inventory_data_node.cpp
+++ b/src/hooks/protections/serialize_ped_inventory_data_node.cpp
@@ -16,7 +16,7 @@ namespace big
 		data->SerializeDwordAlt(&node->m_num_items, 7);
 		if (node->m_num_items > 105)
 		{
-			notify::crash_blocked(g->m_syncing_player, "out of bounds inventory item count");
+			notify::crash_blocked(g.m_syncing_player, "out of bounds inventory item count");
 			return;
 		}
 
@@ -31,7 +31,7 @@ namespace big
 		data->SerializeBool(&node->m_ammo_all_infinite);
 		if (node->m_num_ammos > 65)
 		{
-			notify::crash_blocked(g->m_syncing_player, "out of bounds inventory ammo count");
+			notify::crash_blocked(g.m_syncing_player, "out of bounds inventory ammo count");
 			return;
 		}
 

--- a/src/hooks/protections/serialize_take_off_ped_variation_task.cpp
+++ b/src/hooks/protections/serialize_take_off_ped_variation_task.cpp
@@ -12,7 +12,7 @@ namespace big
 			info->m_prop_hash != RAGE_JOAAT("p_parachute_s")
 			)
 		{
-			notify::crash_blocked(g->m_syncing_player, "invalid parachute");
+			notify::crash_blocked(g.m_syncing_player, "invalid parachute");
 			info->m_prop_hash = 0;
 		}
 	}

--- a/src/hooks/protections/serialize_vehicle_gadget_data_node.cpp
+++ b/src/hooks/protections/serialize_vehicle_gadget_data_node.cpp
@@ -29,7 +29,7 @@ namespace big
 
 		if (node->m_gadget_count > 2)
 		{
-			notify::crash_blocked(g->m_syncing_player, "out of bounds vehicle gadget count");
+			notify::crash_blocked(g.m_syncing_player, "out of bounds vehicle gadget count");
 			return;
 		}
 

--- a/src/hooks/protections/update_presence_attribute.cpp
+++ b/src/hooks/protections/update_presence_attribute.cpp
@@ -5,7 +5,7 @@ namespace big
 	bool hooks::update_presence_attribute_int(void* presence_data, int profile_index, char* attr, std::uint64_t value)
 	{
 		auto hash = rage::joaat(attr);
-		if (g->protections.rid_join &&
+		if (g.protections.rid_join &&
 			(hash == RAGE_JOAAT("gstok") || hash == RAGE_JOAAT("gsid") || hash == RAGE_JOAAT("gstype") || hash == RAGE_JOAAT("gshost") || hash == RAGE_JOAAT("gsjoin")))
 		{
 			return true;
@@ -17,7 +17,7 @@ namespace big
 	bool hooks::update_presence_attribute_string(void* presence_data, int profile_index, char* attr, char* value)
 	{
 		auto hash = rage::joaat(attr);
-		if (g->protections.rid_join && hash == RAGE_JOAAT("gsinfo"))
+		if (g.protections.rid_join && hash == RAGE_JOAAT("gsinfo"))
 		{
 			return true;
 		}

--- a/src/hooks/script/gta_thread_kill.cpp
+++ b/src/hooks/script/gta_thread_kill.cpp
@@ -7,19 +7,19 @@ namespace big
 	{
 		const auto result = g_hooking->get_original<gta_thread_kill>()(thread);
 
-		if (g->notifications.gta_thread_kill.log)
+		if (g.notifications.gta_thread_kill.log)
 			LOG(INFO) << "Script Thread '" << thread->m_name << "' terminated.";
-		if (g->notifications.gta_thread_kill.notify)
+		if (g.notifications.gta_thread_kill.notify)
 			g_notification_service->push("Script Thread Termination", std::format("Script Thread '{}' terminated.", thread->m_name));
 
-		if (thread == g->m_hunt_the_beast_thread)
-			g->m_hunt_the_beast_thread = nullptr;
+		if (thread == g.m_hunt_the_beast_thread)
+			g.m_hunt_the_beast_thread = nullptr;
 
-		if (thread == g->m_dance_thread)
-			g->m_dance_thread = nullptr;
+		if (thread == g.m_dance_thread)
+			g.m_dance_thread = nullptr;
 
-		if (thread == g->m_mission_creator_thread)
-			g->m_mission_creator_thread = nullptr;
+		if (thread == g.m_mission_creator_thread)
+			g.m_mission_creator_thread = nullptr;
 
 		return result;
 	}

--- a/src/hooks/script/gta_thread_start.cpp
+++ b/src/hooks/script/gta_thread_start.cpp
@@ -9,9 +9,9 @@ namespace big
 
 		if (const char* name = new_thread->m_name; strlen(name) > 0)
 		{
-			if (g->notifications.gta_thread_kill.log)
+			if (g.notifications.gta_thread_kill.log)
 				LOG(INFO) << "Script Thread '" << name << "' started.";
-			if (g->notifications.gta_thread_kill.notify)
+			if (g.notifications.gta_thread_kill.notify)
 				g_notification_service->push("Script Thread Startup", std::format("Script Thread '{}' started.", name));
 		}
 

--- a/src/hooks/spoofing/read_bitbuffer_gamer_handle.cpp
+++ b/src/hooks/spoofing/read_bitbuffer_gamer_handle.cpp
@@ -7,7 +7,7 @@ namespace big
 	bool hooks::read_bitbuffer_gamer_handle(rage::datBitBuffer* buffer, rage::rlGamerHandle* handle)
 	{
 		bool result = g_hooking->get_original<hooks::read_bitbuffer_gamer_handle>()(buffer, handle);
-		if (g->spoofing.should_spoof_rockstar_id && handle->m_rockstar_id == g->spoofing.applied_spoof_rockstar_id)
+		if (g.spoofing.should_spoof_rockstar_id && handle->m_rockstar_id == g.spoofing.applied_spoof_rockstar_id)
 			handle->m_rockstar_id = g_pointers->m_profile_gamer_info->m_gamer_handle_2.m_rockstar_id;
 		return result;
 	}

--- a/src/hooks/spoofing/send_net_info_to_lobby.cpp
+++ b/src/hooks/spoofing/send_net_info_to_lobby.cpp
@@ -19,39 +19,39 @@ namespace big
 		// check so we're 100% sure we modify data only for ourselves
 		if (is_local_player)
 		{
-			if (g->spoofing.spoof_username)
-				memcpy(player->m_name, g->spoofing.username.c_str(), sizeof(player->m_name));
+			if (g.spoofing.spoof_username)
+				memcpy(player->m_name, g.spoofing.username.c_str(), sizeof(player->m_name));
 
-			if (g->spoofing.spoof_ip)
+			if (g.spoofing.spoof_ip)
 			{
-				player->m_external_ip.m_field1 = g->spoofing.ip_address[0];
-				player->m_external_ip.m_field2 = g->spoofing.ip_address[1];
-				player->m_external_ip.m_field3 = g->spoofing.ip_address[2];
-				player->m_external_ip.m_field4 = g->spoofing.ip_address[3];
+				player->m_external_ip.m_field1 = g.spoofing.ip_address[0];
+				player->m_external_ip.m_field2 = g.spoofing.ip_address[1];
+				player->m_external_ip.m_field3 = g.spoofing.ip_address[2];
+				player->m_external_ip.m_field4 = g.spoofing.ip_address[3];
 			}
 
-			if (g->spoofing.should_spoof_rockstar_id)
+			if (g.spoofing.should_spoof_rockstar_id)
 			{
-				player->m_gamer_handle.m_rockstar_id = g->spoofing.applied_spoof_rockstar_id;
-				player->m_gamer_handle_2.m_rockstar_id = g->spoofing.applied_spoof_rockstar_id;
+				player->m_gamer_handle.m_rockstar_id = g.spoofing.applied_spoof_rockstar_id;
+				player->m_gamer_handle_2.m_rockstar_id = g.spoofing.applied_spoof_rockstar_id;
 			}
 
-			if (g->notifications.send_net_info_to_lobby.log)
+			if (g.notifications.send_net_info_to_lobby.log)
 				LOG(INFO) << "Sending spoofed values to session host";
-			if (g->notifications.send_net_info_to_lobby.notify)
+			if (g.notifications.send_net_info_to_lobby.notify)
 				g_notification_service->push("Player Info Spoofing", "Sent spoofed values to lobby host.");
 		}
 		else
 		{
-			if (g->session.name_spoof_enabled)
+			if (g.session.name_spoof_enabled)
 			{
-				if (g->session.advertise_menu)
+				if (g.session.advertise_menu)
 				{
 					memcpy(player->m_name, advertisments[rand() % advertisments.size()], sizeof(player->m_name));
 				}
 				else
 				{
-					memcpy(player->m_name, g->session.spoofed_name.c_str(), sizeof(player->m_name));
+					memcpy(player->m_name, g.session.spoofed_name.c_str(), sizeof(player->m_name));
 				}
 			}
 		}

--- a/src/hooks/spoofing/send_session_matchmaking_attributes.cpp
+++ b/src/hooks/spoofing/send_session_matchmaking_attributes.cpp
@@ -5,14 +5,14 @@ namespace big
 {
 	bool hooks::send_session_matchmaking_attributes(void* a1, rage::rlSessionInfo* info, std::uint64_t session_id, bool use_session_id, MatchmakingAttributes* attributes)
 	{
-		if (g->spoofing.spoof_session_region_type)
-			attributes->m_param_values[4] = g->spoofing.session_region_type;
+		if (g.spoofing.spoof_session_region_type)
+			attributes->m_param_values[4] = g.spoofing.session_region_type;
 
-		if (g->spoofing.spoof_session_language)
-			attributes->m_param_values[3] = g->spoofing.session_language;
+		if (g.spoofing.spoof_session_language)
+			attributes->m_param_values[3] = g.spoofing.session_language;
 
-		if (g->spoofing.spoof_session_player_count)
-			attributes->m_param_values[7] = g->spoofing.session_player_count;
+		if (g.spoofing.spoof_session_player_count)
+			attributes->m_param_values[7] = g.spoofing.session_player_count;
 
 		return g_hooking->get_original<hooks::send_session_matchmaking_attributes>()(a1, info, session_id, use_session_id, attributes);
 	}

--- a/src/hooks/spoofing/write_bitbuffer_gamer_handle.cpp
+++ b/src/hooks/spoofing/write_bitbuffer_gamer_handle.cpp
@@ -8,9 +8,9 @@ namespace big
 	{
 		bool restore = false;
 
-		if (g->spoofing.should_spoof_rockstar_id && handle->m_rockstar_id == g_pointers->m_profile_gamer_info->m_gamer_handle_2.m_rockstar_id)
+		if (g.spoofing.should_spoof_rockstar_id && handle->m_rockstar_id == g_pointers->m_profile_gamer_info->m_gamer_handle_2.m_rockstar_id)
 		{
-			handle->m_rockstar_id = g->spoofing.applied_spoof_rockstar_id;
+			handle->m_rockstar_id = g.spoofing.applied_spoof_rockstar_id;
 			restore = true;
 		}
 

--- a/src/hooks/spoofing/write_player_game_state_data_node.cpp
+++ b/src/hooks/spoofing/write_player_game_state_data_node.cpp
@@ -7,7 +7,7 @@ namespace big
 	{
 		auto ret = g_hooking->get_original<write_player_game_state_data_node>()(player, node);
 
-		if (g->spoofing.spoof_hide_god)
+		if (g.spoofing.spoof_hide_god)
 		{
 			node->m_is_invincible = false;
 			node->m_bullet_proof = false;
@@ -19,7 +19,7 @@ namespace big
 			node->m_water_proof = false;
 		}
 
-		if (g->spoofing.spoof_hide_spectate)
+		if (g.spoofing.spoof_hide_spectate)
 		{
 			node->m_is_spectating = false;
 			node->m_spectating_net_id = 0;

--- a/src/hooks/spoofing/write_player_gamer_data_node.cpp
+++ b/src/hooks/spoofing/write_player_gamer_data_node.cpp
@@ -7,7 +7,7 @@ namespace big
 	{
 		g_hooking->get_original<write_player_gamer_data_node>()(player, node);
 
-		if (g->spoofing.spoof_crew_data)
+		if (g.spoofing.spoof_crew_data)
 		{
 			node->m_clan_data.m_clan_member_id = 1;
 			node->m_clan_data.m_clan_id = 41564112;
@@ -16,23 +16,23 @@ namespace big
 			node->m_clan_data.m_clan_member_count = 15;
 			node->m_clan_data.m_clan_created_time = 420;
 
-			strcpy(node->m_clan_data.m_clan_tag, g->spoofing.crew_tag.c_str());
-			node->m_clan_data.m_is_system_clan = g->spoofing.rockstar_crew;
-			node->m_clan_data.m_is_clan_open = g->spoofing.square_crew_tag;
+			strcpy(node->m_clan_data.m_clan_tag, g.spoofing.crew_tag.c_str());
+			node->m_clan_data.m_is_system_clan = g.spoofing.rockstar_crew;
+			node->m_clan_data.m_is_clan_open = g.spoofing.square_crew_tag;
 
-			if (g->spoofing.rockstar_crew)
+			if (g.spoofing.rockstar_crew)
 			{
 				strcpy(node->m_clan_data.m_clan_name, "Rockstar");
 			}
 		}
 
-		node->m_is_cheater = g->spoofing.spoof_cheater;
+		node->m_is_cheater = g.spoofing.spoof_cheater;
 
 		// spoof r* dev and qa only when spoofing rid because every player in the session will send metrics if you join with that enabled
-		if (g->spoofing.spoof_rockstar_id)
+		if (g.spoofing.spoof_rockstar_id)
 		{
-			node->m_is_rockstar_dev = g->spoofing.spoof_rockstar_dev;
-			node->m_is_rockstar_qa = g->spoofing.spoof_rockstar_qa;
+			node->m_is_rockstar_dev = g.spoofing.spoof_rockstar_dev;
+			node->m_is_rockstar_qa = g.spoofing.spoof_rockstar_qa;
 		}
 	}
 }

--- a/src/hooks/toxic/broadcast_net_array.cpp
+++ b/src/hooks/toxic/broadcast_net_array.cpp
@@ -18,13 +18,13 @@ namespace big
 		bool need_to_use_end_session_kick = g_player_service->m_player_to_use_end_session_kick &&
 			target->m_player_id == g_player_service->m_player_to_use_end_session_kick->get()->id() && _this->m_array == scr_globals::gsbd.as<void*>();
 
-		bool need_to_modify_wanted_level = g->session.wanted_level_all && (_this->m_array >= scr_globals::globalplayer_bd.as<uint8_t*>() && 
+		bool need_to_modify_wanted_level = g.session.wanted_level_all && (_this->m_array >= scr_globals::globalplayer_bd.as<uint8_t*>() && 
 			_this->m_array <= scr_globals::globalplayer_bd.at(31, scr_globals::size::globalplayer_bd).as<uint8_t*>());
 
-		bool need_to_turn_player_into_beast = g->m_hunt_the_beast_thread && g->m_hunt_the_beast_thread->m_stack && g->m_hunt_the_beast_thread->m_net_component &&
-			_this->m_array == script_local(g->m_hunt_the_beast_thread->m_stack, scr_locals::am_hunt_the_beast::broadcast_idx).as<void*>();
+		bool need_to_turn_player_into_beast = g.m_hunt_the_beast_thread && g.m_hunt_the_beast_thread->m_stack && g.m_hunt_the_beast_thread->m_net_component &&
+			_this->m_array == script_local(g.m_hunt_the_beast_thread->m_stack, scr_locals::am_hunt_the_beast::broadcast_idx).as<void*>();
 
-		bool need_to_randomize_replay_protection = g->session.block_ceo_money && _this->m_array == scr_globals::gsbd_fm_events.as<void*>();
+		bool need_to_randomize_replay_protection = g.session.block_ceo_money && _this->m_array == scr_globals::gsbd_fm_events.as<void*>();
 
 		if (need_to_use_end_session_kick)
 		{
@@ -41,13 +41,13 @@ namespace big
 
 		if (need_to_turn_player_into_beast)
 		{
-			orig_player = *script_local(g->m_hunt_the_beast_thread->m_stack, scr_locals::am_hunt_the_beast::broadcast_idx).at(1).at(7).as<Player*>();
-			orig_participant = *script_local(g->m_hunt_the_beast_thread->m_stack, scr_locals::am_hunt_the_beast::broadcast_idx).at(1).at(6).as<int*>();
+			orig_player = *script_local(g.m_hunt_the_beast_thread->m_stack, scr_locals::am_hunt_the_beast::broadcast_idx).at(1).at(7).as<Player*>();
+			orig_participant = *script_local(g.m_hunt_the_beast_thread->m_stack, scr_locals::am_hunt_the_beast::broadcast_idx).at(1).at(6).as<int*>();
 
-			*script_local(g->m_hunt_the_beast_thread->m_stack, scr_locals::am_hunt_the_beast::broadcast_idx).at(1).at(6).as<int*>() = g->m_hunt_the_beast_thread->m_net_component->get_participant_index(target); // participant idx
-			*script_local(g->m_hunt_the_beast_thread->m_stack, scr_locals::am_hunt_the_beast::broadcast_idx).at(1).at(7).as<Player*>() = target->m_player_id; // beast player idx
-			*script_local(g->m_hunt_the_beast_thread->m_stack, scr_locals::am_hunt_the_beast::broadcast_idx).at(1).at(2).as<int*>() = INT_MAX; // stopwatch time
-			*script_local(g->m_hunt_the_beast_thread->m_stack, scr_locals::am_hunt_the_beast::broadcast_idx).at(83).as<int*>() = 0; // transformed bitset
+			*script_local(g.m_hunt_the_beast_thread->m_stack, scr_locals::am_hunt_the_beast::broadcast_idx).at(1).at(6).as<int*>() = g.m_hunt_the_beast_thread->m_net_component->get_participant_index(target); // participant idx
+			*script_local(g.m_hunt_the_beast_thread->m_stack, scr_locals::am_hunt_the_beast::broadcast_idx).at(1).at(7).as<Player*>() = target->m_player_id; // beast player idx
+			*script_local(g.m_hunt_the_beast_thread->m_stack, scr_locals::am_hunt_the_beast::broadcast_idx).at(1).at(2).as<int*>() = INT_MAX; // stopwatch time
+			*script_local(g.m_hunt_the_beast_thread->m_stack, scr_locals::am_hunt_the_beast::broadcast_idx).at(83).as<int*>() = 0; // transformed bitset
 
 			g_pointers->m_broadcast_patch->apply();
 		}
@@ -74,8 +74,8 @@ namespace big
 
 		if (need_to_turn_player_into_beast)
 		{
-			*script_local(g->m_hunt_the_beast_thread->m_stack, scr_locals::am_hunt_the_beast::broadcast_idx).at(1).at(7).as<Player*>() = orig_player;
-			*script_local(g->m_hunt_the_beast_thread->m_stack, scr_locals::am_hunt_the_beast::broadcast_idx).at(1).at(6).as<int*>() = orig_participant;
+			*script_local(g.m_hunt_the_beast_thread->m_stack, scr_locals::am_hunt_the_beast::broadcast_idx).at(1).at(7).as<Player*>() = orig_player;
+			*script_local(g.m_hunt_the_beast_thread->m_stack, scr_locals::am_hunt_the_beast::broadcast_idx).at(1).at(6).as<int*>() = orig_participant;
 			g_pointers->m_broadcast_patch->restore();
 		}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,8 +46,6 @@ BOOL APIENTRY DllMain(HMODULE hmod, DWORD reason, PVOID)
 			base_dir /= "BigBaseV2";
 			auto file_manager_instance = std::make_unique<file_manager>(base_dir);
 
-			auto globals_instance = std::make_unique<menu_settings>(file_manager_instance->get_project_file("./settings.json"));
-
 			auto logger_instance = std::make_unique<logger>(
 				"YimMenu",
 				file_manager_instance->get_project_file("./cout.log")
@@ -63,7 +61,8 @@ BOOL APIENTRY DllMain(HMODULE hmod, DWORD reason, PVOID)
 				auto thread_pool_instance = std::make_unique<thread_pool>();
 				LOG(INFO) << "Thread pool initialized.";
 
-				globals_instance->init();
+				g.init(
+					file_manager_instance->get_project_file("./settings.json"));
 				LOG(INFO) << "Settings Loaded.";
 
 				auto pointers_instance = std::make_unique<pointers>();
@@ -195,8 +194,6 @@ BOOL APIENTRY DllMain(HMODULE hmod, DWORD reason, PVOID)
 			LOG(INFO) << "Farewell!";
 			logger_instance->destroy();
 			logger_instance.reset();
-
-			globals_instance.reset();
 
 			file_manager_instance.reset();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,9 +46,7 @@ BOOL APIENTRY DllMain(HMODULE hmod, DWORD reason, PVOID)
 			base_dir /= "BigBaseV2";
 			auto file_manager_instance = std::make_unique<file_manager>(base_dir);
 
-			auto globals_instance = std::make_unique<menu_settings>(
-				file_manager_instance->get_project_file("./settings.json")
-			);
+			auto globals_instance = std::make_unique<menu_settings>(file_manager_instance->get_project_file("./settings.json"));
 
 			auto logger_instance = std::make_unique<logger>(
 				"YimMenu",
@@ -62,7 +60,10 @@ BOOL APIENTRY DllMain(HMODULE hmod, DWORD reason, PVOID)
 				LOG(INFO) << "Yim's Menu Initializing";
 				LOGF(INFO, "Git Info\n\tBranch:\t%s\n\tHash:\t%s\n\tDate:\t%s", version::GIT_BRANCH, version::GIT_SHA1, version::GIT_DATE);
 
-				g->load();
+				auto thread_pool_instance = std::make_unique<thread_pool>();
+				LOG(INFO) << "Thread pool initialized.";
+
+				globals_instance->init();
 				LOG(INFO) << "Settings Loaded.";
 
 				auto pointers_instance = std::make_unique<pointers>();
@@ -77,9 +78,6 @@ BOOL APIENTRY DllMain(HMODULE hmod, DWORD reason, PVOID)
 
 				auto hooking_instance = std::make_unique<hooking>();
 				LOG(INFO) << "Hooking initialized.";
-
-				auto thread_pool_instance = std::make_unique<thread_pool>();
-				LOG(INFO) << "Thread pool initialized.";
 
 				auto context_menu_service_instance = std::make_unique<context_menu_service>();
 				auto custom_text_service_instance = std::make_unique<custom_text_service>();
@@ -141,8 +139,6 @@ BOOL APIENTRY DllMain(HMODULE hmod, DWORD reason, PVOID)
 				thread_pool_instance->destroy();
 				LOG(INFO) << "Destroyed thread pool.";
 
-				thread_pool_instance.reset();
-				LOG(INFO) << "Thread pool uninitialized.";
 
 				hotkey_service_instance.reset();
 				LOG(INFO) << "Hotkey Service reset.";
@@ -187,6 +183,9 @@ BOOL APIENTRY DllMain(HMODULE hmod, DWORD reason, PVOID)
 
 				pointers_instance.reset();
 				LOG(INFO) << "Pointers uninitialized.";
+				
+				thread_pool_instance.reset();
+				LOG(INFO) << "Thread pool uninitialized.";
 			}
 			catch (std::exception const& ex)
 			{

--- a/src/native_hooks/all_scripts.hpp
+++ b/src/native_hooks/all_scripts.hpp
@@ -16,7 +16,7 @@ namespace big
             
             bool return_value = DLC::IS_DLC_PRESENT(hash);
             if (hash == 0x96F02EE6)
-                return_value = return_value || g->settings.dev_dlc;
+                return_value = return_value || g.settings.dev_dlc;
 
             src->set_return_value(return_value);
         }

--- a/src/native_hooks/carmod_shop.hpp
+++ b/src/native_hooks/carmod_shop.hpp
@@ -68,7 +68,7 @@ namespace big
 
 		inline void SET_ENTITY_COORDS(rage::scrNativeCallContext* src)
 		{
-			if (!g->vehicle.ls_customs)
+			if (!g.vehicle.ls_customs)
 			{
 				ENTITY::SET_ENTITY_COORDS(
 					src->get_arg<Entity>(0),
@@ -85,7 +85,7 @@ namespace big
 
 		inline void SET_ENTITY_HEADING(rage::scrNativeCallContext* src)
 		{
-			if (!g->vehicle.ls_customs)
+			if (!g.vehicle.ls_customs)
 			{
 				ENTITY::SET_ENTITY_HEADING(
 					src->get_arg<Entity>(0),
@@ -96,7 +96,7 @@ namespace big
 
 		inline void SET_VEHICLE_LIGHTS(rage::scrNativeCallContext* src)
 		{
-			if (!g->vehicle.ls_customs)
+			if (!g.vehicle.ls_customs)
 			{
 				VEHICLE::SET_VEHICLE_LIGHTS(
 					src->get_arg<Vehicle>(0),

--- a/src/native_hooks/freemode.hpp
+++ b/src/native_hooks/freemode.hpp
@@ -12,7 +12,7 @@ namespace big
 		inline void IS_PLAYER_PLAYING(rage::scrNativeCallContext* src)
 		{
 			// block undead OTR
-			if (g->session.decloak_players && src->get_arg<Player>(0) != self::id)
+			if (g.session.decloak_players && src->get_arg<Player>(0) != self::id)
 				src->set_return_value<BOOL>(TRUE);
 			else
 				src->set_return_value<BOOL>(PLAYER::IS_PLAYER_PLAYING(src->get_arg<Player>(0)));
@@ -24,7 +24,7 @@ namespace big
 			auto toggle = src->get_arg<bool>(1);
 			auto outfit = src->get_arg<bool>(2);
 
-			if (g->self.invisibility && entity == self::ped && toggle)
+			if (g.self.invisibility && entity == self::ped && toggle)
 				return;
 			else
 				ENTITY::SET_ENTITY_VISIBLE(entity, toggle, outfit);
@@ -32,19 +32,19 @@ namespace big
 
 		void SET_BIGMAP_ACTIVE(rage::scrNativeCallContext* src)
 		{
-			if (!g->m_mission_creator_thread)
+			if (!g.m_mission_creator_thread)
 				HUD::SET_BIGMAP_ACTIVE(src->get_arg<BOOL>(0), src->get_arg<BOOL>(1));
 		};
 
 		void SET_BLIP_DISPLAY(rage::scrNativeCallContext* src)
 		{
-			if ((!g->m_mission_creator_thread) || src->get_arg<Blip>(0) != HUD::GET_MAIN_PLAYER_BLIP_ID())
+			if ((!g.m_mission_creator_thread) || src->get_arg<Blip>(0) != HUD::GET_MAIN_PLAYER_BLIP_ID())
 				HUD::SET_BLIP_DISPLAY(src->get_arg<Blip>(0), src->get_arg<BOOL>(1));
 		};
 
 		void NETWORK_HAS_RECEIVED_HOST_BROADCAST_DATA(rage::scrNativeCallContext* src)
 		{
-			if (SCRIPT::GET_HASH_OF_THIS_SCRIPT_NAME() == RAGE_JOAAT("freemode") && g->session.force_script_host)
+			if (SCRIPT::GET_HASH_OF_THIS_SCRIPT_NAME() == RAGE_JOAAT("freemode") && g.session.force_script_host)
 			{
 				g_fiber_pool->queue_job([]
 				{

--- a/src/native_hooks/network_session_host.hpp
+++ b/src/native_hooks/network_session_host.hpp
@@ -9,10 +9,10 @@ namespace big
     {
         inline void NETWORK_SESSION_HOST(rage::scrNativeCallContext* src)
         {
-			if (g->session.join_queued)
+			if (g.session.join_queued)
 			{
-				g_pointers->m_join_session_by_info(*g_pointers->m_network, &g->session.info, 1, 1 | 2 | 4, nullptr, 0);
-				g->session.join_queued = false;
+				g_pointers->m_join_session_by_info(*g_pointers->m_network, &g.session.info, 1, 1 | 2 | 4, nullptr, 0);
+				g.session.join_queued = false;
 				src->set_return_value<BOOL>(TRUE);
 			}
 			else

--- a/src/native_hooks/shop_controller.hpp
+++ b/src/native_hooks/shop_controller.hpp
@@ -10,9 +10,9 @@ namespace big
 		{
 			if (auto entry_line = src->get_arg<const char*>(1); !strcmp(entry_line, "CTALERT_F_2"))
 			{
-				if (g->notifications.transaction_rate_limit.log)
+				if (g.notifications.transaction_rate_limit.log)
 					LOG(WARNING) << "Received transaction rate limit";
-				if (g->notifications.transaction_rate_limit.notify)
+				if (g.notifications.transaction_rate_limit.notify)
 					g_notification_service->push_warning("Transaction Rate Limit", "You're receiving transaction rate limits, whatever you're doing do it less.");
 
 				*script_global(4536673).as<int*>() = 0;

--- a/src/pointers.cpp
+++ b/src/pointers.cpp
@@ -768,7 +768,7 @@ namespace big
 		{
 			m_bypass_max_count_of_active_sticky_bombs = memory::byte_patch::make(pat.add(4).as<uint8_t*>(), { 99 }).get();
 
-			if (g->weapons.bypass_c4_limit)
+			if (g.weapons.bypass_c4_limit)
 				m_bypass_max_count_of_active_sticky_bombs->apply();
 		}
 

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -66,7 +66,7 @@ namespace big
 			fnt_cfg.FontDataOwnedByAtlas = false;
 			strcpy(fnt_cfg.Name, "Fnt28px");
 
-			g->window.font_title = io.Fonts->AddFontFromMemoryTTF(const_cast<std::uint8_t*>(font_storopia), sizeof(font_storopia), 28.f, &fnt_cfg);
+			g.window.font_title = io.Fonts->AddFontFromMemoryTTF(const_cast<std::uint8_t*>(font_storopia), sizeof(font_storopia), 28.f, &fnt_cfg);
 			fnt_cfg.MergeMode = true;
 			io.Fonts->AddFontFromMemoryTTF(font_data.get(), font_data_size, 28.f, &fnt_cfg, ImGui::GetIO().Fonts->GetGlyphRangesChineseSimplifiedCommon());
 			io.Fonts->AddFontFromMemoryTTF(font_data.get(), font_data_size, 28.f, &fnt_cfg, ImGui::GetIO().Fonts->GetGlyphRangesCyrillic());
@@ -78,7 +78,7 @@ namespace big
 			fnt_cfg.FontDataOwnedByAtlas = false;
 			strcpy(fnt_cfg.Name, "Fnt24px");
 
-			g->window.font_sub_title = io.Fonts->AddFontFromMemoryTTF(const_cast<std::uint8_t*>(font_storopia), sizeof(font_storopia), 24.f, &fnt_cfg);
+			g.window.font_sub_title = io.Fonts->AddFontFromMemoryTTF(const_cast<std::uint8_t*>(font_storopia), sizeof(font_storopia), 24.f, &fnt_cfg);
 			fnt_cfg.MergeMode = true;
 			io.Fonts->AddFontFromMemoryTTF(font_data.get(), font_data_size, 24.f, &fnt_cfg, ImGui::GetIO().Fonts->GetGlyphRangesChineseSimplifiedCommon());
 			io.Fonts->AddFontFromMemoryTTF(font_data.get(), font_data_size, 24.f, &fnt_cfg, ImGui::GetIO().Fonts->GetGlyphRangesCyrillic());
@@ -90,7 +90,7 @@ namespace big
 			fnt_cfg.FontDataOwnedByAtlas = false;
 			strcpy(fnt_cfg.Name, "Fnt18px");
 
-			g->window.font_small = io.Fonts->AddFontFromMemoryTTF(const_cast<std::uint8_t*>(font_storopia), sizeof(font_storopia), 18.f, &fnt_cfg);
+			g.window.font_small = io.Fonts->AddFontFromMemoryTTF(const_cast<std::uint8_t*>(font_storopia), sizeof(font_storopia), 18.f, &fnt_cfg);
 			fnt_cfg.MergeMode = true;
 			io.Fonts->AddFontFromMemoryTTF(font_data.get(), font_data_size, 18.f, &fnt_cfg, ImGui::GetIO().Fonts->GetGlyphRangesChineseSimplifiedCommon());
 			io.Fonts->AddFontFromMemoryTTF(font_data.get(), font_data_size, 18.f, &fnt_cfg, ImGui::GetIO().Fonts->GetGlyphRangesCyrillic());
@@ -101,10 +101,10 @@ namespace big
 			ImFontConfig font_icons_cfg{};
 			font_icons_cfg.FontDataOwnedByAtlas = false;
 			std::strcpy(font_icons_cfg.Name, "Icons");
-			g->window.font_icon = io.Fonts->AddFontFromMemoryTTF(const_cast<std::uint8_t*>(font_icons), sizeof(font_icons), 24.f, &font_icons_cfg);
+			g.window.font_icon = io.Fonts->AddFontFromMemoryTTF(const_cast<std::uint8_t*>(font_icons), sizeof(font_icons), 24.f, &font_icons_cfg);
 		}
 
-		rescale(g->window.gui_scale);
+		rescale(g.window.gui_scale);
 
 		g_renderer = this;
 	}

--- a/src/services/context_menu/context_menu_service.cpp
+++ b/src/services/context_menu/context_menu_service.cpp
@@ -131,7 +131,7 @@ namespace big
 			{
 			case eModelType::Object:
 			{
-				if (!misc::has_bits_set(&g->context_menu.allowed_entity_types, static_cast<uint8_t>(ContextEntityType::OBJECT)))
+				if (!misc::has_bits_set(&g.context_menu.allowed_entity_types, static_cast<uint8_t>(ContextEntityType::OBJECT)))
 				{
 					break;
 				}
@@ -144,7 +144,7 @@ namespace big
 					if (ped->m_ped_task_flag & static_cast<uint8_t>(ePedTask::TASK_DRIVING) &&
 						ped->m_vehicle)
 					{
-						if (!misc::has_bits_set(&g->context_menu.allowed_entity_types, static_cast<uint8_t>(ContextEntityType::VEHICLE)))
+						if (!misc::has_bits_set(&g.context_menu.allowed_entity_types, static_cast<uint8_t>(ContextEntityType::VEHICLE)))
 						{
 							break;
 						}
@@ -154,7 +154,7 @@ namespace big
 					}
 					if (ped->m_player_info)
 					{
-						if (!misc::has_bits_set(&g->context_menu.allowed_entity_types, static_cast<uint8_t>(ContextEntityType::PLAYER)))
+						if (!misc::has_bits_set(&g.context_menu.allowed_entity_types, static_cast<uint8_t>(ContextEntityType::PLAYER)))
 						{
 							break;
 						}
@@ -163,7 +163,7 @@ namespace big
 					}
 				}
 
-				if (!misc::has_bits_set(&g->context_menu.allowed_entity_types, static_cast<uint8_t>(ContextEntityType::PED)))
+				if (!misc::has_bits_set(&g.context_menu.allowed_entity_types, static_cast<uint8_t>(ContextEntityType::PED)))
 				{
 					break;
 				}
@@ -172,7 +172,7 @@ namespace big
 			}
 			case eModelType::Vehicle:
 			{
-				if (!misc::has_bits_set(&g->context_menu.allowed_entity_types, static_cast<uint8_t>(ContextEntityType::VEHICLE)))
+				if (!misc::has_bits_set(&g.context_menu.allowed_entity_types, static_cast<uint8_t>(ContextEntityType::VEHICLE)))
 				{
 					break;
 				}
@@ -292,7 +292,7 @@ namespace big
 	{
 		while (g_running)
 		{
-			if (!g->context_menu.enabled)
+			if (!g.context_menu.enabled)
 			{
 				g_context_menu_service->enabled = false;
 

--- a/src/services/custom_text/custom_text_callbacks.cpp
+++ b/src/services/custom_text/custom_text_callbacks.cpp
@@ -4,7 +4,7 @@ namespace big
 {
 	const char* respawn_label_callback(const char* label)
 	{
-		if (g->self.god_mode)
+		if (g.self.god_mode)
 			return "~r~Dying with god mode, how?";
 
 		return nullptr;

--- a/src/services/hotkey/hotkey_functions.cpp
+++ b/src/services/hotkey/hotkey_functions.cpp
@@ -6,9 +6,9 @@ namespace big::hotkey_funcs
 {
     void toggle_noclip()
     {
-        const auto state = !g->self.noclip;
+        const auto state = !g.self.noclip;
         g_notification_service->push("Noclip", std::format("Noclip has been {}.", state ? "enabled" : "disabled"));
 
-        g->self.noclip = state;
+        g.self.noclip = state;
     }
 }

--- a/src/services/hotkey/hotkey_service.cpp
+++ b/src/services/hotkey/hotkey_service.cpp
@@ -11,9 +11,9 @@ namespace big
 {
     hotkey_service::hotkey_service()
     {
-        register_hotkey("waypoint", g->settings.hotkeys.teleport_waypoint, teleport::to_waypoint);
-        register_hotkey("objective", g->settings.hotkeys.teleport_objective, teleport::to_objective);
-        register_hotkey("noclip", g->settings.hotkeys.noclip, hotkey_funcs::toggle_noclip);
+        register_hotkey("waypoint", g.settings.hotkeys.teleport_waypoint, teleport::to_waypoint);
+        register_hotkey("objective", g.settings.hotkeys.teleport_objective, teleport::to_objective);
+        register_hotkey("noclip", g.settings.hotkeys.noclip, hotkey_funcs::toggle_noclip);
 
         g_renderer->add_wndproc_callback([this](HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam)
         {

--- a/src/services/matchmaking/matchmaking_service.cpp
+++ b/src/services/matchmaking/matchmaking_service.cpp
@@ -28,9 +28,9 @@ namespace big
 		component.m_game_mode = 0;
 		component.m_num_parameters = 0;
 
-		if (g->session_browser.region_filter_enabled)
+		if (g.session_browser.region_filter_enabled)
 		{
-			component.SetParameter("MMATTR_REGION", 0, g->session_browser.region_filter);
+			component.SetParameter("MMATTR_REGION", 0, g.session_browser.region_filter);
 		}
 
 		if (constraint)
@@ -57,23 +57,23 @@ namespace big
 					if (constraint && m_found_sessions[i].attributes.player_count >= 30)
 						m_found_sessions[i].is_valid = false;
 
-					if (g->session_browser.language_filter_enabled && m_found_sessions[i].attributes.language != g->session_browser.language_filter)
+					if (g.session_browser.language_filter_enabled && m_found_sessions[i].attributes.language != g.session_browser.language_filter)
 						m_found_sessions[i].is_valid = false;
 
-					if (g->session_browser.player_count_filter_enabled && (m_found_sessions[i].attributes.player_count < g->session_browser.player_count_filter_minimum ||
-						m_found_sessions[i].attributes.player_count > g->session_browser.player_count_filter_maximum))
+					if (g.session_browser.player_count_filter_enabled && (m_found_sessions[i].attributes.player_count < g.session_browser.player_count_filter_minimum ||
+						m_found_sessions[i].attributes.player_count > g.session_browser.player_count_filter_maximum))
 					{
 						m_found_sessions[i].is_valid = false;
 					}
 				}
 
-				if (g->session_browser.sort_method != 0)
+				if (g.session_browser.sort_method != 0)
 				{
 					std::qsort(m_found_sessions, m_num_sessions_found, sizeof(session), [](const void* a1, const void* a2) -> int
 					{
 						std::strong_ordering result;
 
-						if (g->session_browser.sort_method == 1)
+						if (g.session_browser.sort_method == 1)
 						{
 							result = (((session*)(a1))->attributes.player_count <=> ((session*)(a2))->attributes.player_count);
 						}
@@ -82,10 +82,10 @@ namespace big
 							return 0;
 
 						if (result > 0)
-							return g->session_browser.sort_direction ? -1 : 1;
+							return g.session_browser.sort_direction ? -1 : 1;
 
 						if (result < 0)
-							return g->session_browser.sort_direction ? 1 : -1;
+							return g.session_browser.sort_direction ? 1 : -1;
 
 
 						std::unreachable();

--- a/src/services/notifications/notification_service.cpp
+++ b/src/services/notifications/notification_service.cpp
@@ -5,7 +5,7 @@ namespace big
 {
 	notification_service::notification_service()
 	{
-		push("Welcome", std::format("Loaded YimMenu. Press {} to open", ImGui::key_names[g->settings.hotkeys.menu_toggle]));
+		push("Welcome", std::format("Loaded YimMenu. Press {} to open", ImGui::key_names[g.settings.hotkeys.menu_toggle]));
 
 		g_notification_service = this;
 	}

--- a/src/util/local_player.hpp
+++ b/src/util/local_player.hpp
@@ -13,8 +13,8 @@ namespace big::local_player
 
 	inline std::string get_mp_prefix()
 	{
-		get_active_character_slot(&g->player.character_slot);
-		return "MP" + std::to_string(g->player.character_slot) + "_";
+		get_active_character_slot(&g.player.character_slot);
+		return "MP" + std::to_string(g.player.character_slot) + "_";
 	}
 
 	inline void set_player_level(int level)

--- a/src/util/mobile.hpp
+++ b/src/util/mobile.hpp
@@ -106,7 +106,7 @@ namespace big::mobile
 			if (*scr_globals::mechanic_global.at(979).as<int*>() != -1)
 				return g_notification_service->push_warning("Vehicle", "Mechanic is not ready to deliver a vehicle right now.");
 
-			if (g->clone_pv.spawn_inside && self::veh)
+			if (g.clone_pv.spawn_inside && self::veh)
 				TASK::CLEAR_PED_TASKS_IMMEDIATELY(PLAYER::PLAYER_PED_ID());
 
 			// despawn current veh
@@ -129,7 +129,7 @@ namespace big::mobile
 			// blocking call till vehicle is delivered
 			notify::busy_spinner("Delivering vehicle...", scr_globals::mechanic_global.at(979).as<int*>(), -1);
 
-			if (g->clone_pv.spawn_inside)
+			if (g.clone_pv.spawn_inside)
 			{
 				big::vehicle::bring(get_personal_vehicle(), self::pos, true);
 			}

--- a/src/util/scripts.hpp
+++ b/src/util/scripts.hpp
@@ -200,7 +200,7 @@ incorrect:
 			return arr[0] + (arr[1] << 8) + (arr[2] << 16);
 		};
 
-		if (g->m_mission_creator_thread ||
+		if (g.m_mission_creator_thread ||
 			SCRIPT::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH(RAGE_JOAAT("creator")) != 0 ||
 			SCRIPT::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH(RAGE_JOAAT("maintransition")) != 0 ||
 			STREAMING::IS_PLAYER_SWITCH_IN_PROGRESS() ||
@@ -228,7 +228,7 @@ incorrect:
 
 		if (SYSTEM::START_NEW_SCRIPT_WITH_NAME_HASH(hash, 54000))
 		{
-			g->m_mission_creator_thread = gta_util::find_script_thread(hash);
+			g.m_mission_creator_thread = gta_util::find_script_thread(hash);
 		}
 
 		if (auto program = gta_util::find_script_program(hash))

--- a/src/util/session.hpp
+++ b/src/util/session.hpp
@@ -40,9 +40,9 @@ namespace big::session
 	{
 		MISC::CLEAR_OVERRIDE_WEATHER();
 
-		MISC::SET_OVERRIDE_WEATHER(weathers[g->session.local_weather]);
+		MISC::SET_OVERRIDE_WEATHER(weathers[g.session.local_weather]);
 
-		*script_global(262145).at(4752).as<bool*>() = g->session.local_weather == 13;
+		*script_global(262145).at(4752).as<bool*>() = g.session.local_weather == 13;
 	}
 
 	inline void set_fm_event_index(int index)
@@ -65,12 +65,12 @@ namespace big::session
 
 	inline void join_session(const rage::rlSessionInfo& info)
 	{
-		g->session.join_queued = true;
-		g->session.info = info;
+		g.session.join_queued = true;
+		g.session.info = info;
 		session::join_type({ eSessionType::NEW_PUBLIC });
 		if (SCRIPT::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH(RAGE_JOAAT("maintransition")) == 0)
 		{
-			g->session.join_queued = false;
+			g.session.join_queued = false;
 			g_notification_service->push_error("RID Joiner", "Unable to launch maintransition");
 		}
 		return;

--- a/src/util/toxic.hpp
+++ b/src/util/toxic.hpp
@@ -298,7 +298,7 @@ namespace big::toxic
 
 		thread->m_net_component->block_host_migration(true);
 		thread->m_context.m_state = rage::eThreadState::unk_3;
-		g->m_hunt_the_beast_thread = thread;
+		g.m_hunt_the_beast_thread = thread;
 
 		for (int i = 0; i < 15; i++)
 		{

--- a/src/util/vehicle.hpp
+++ b/src/util/vehicle.hpp
@@ -665,7 +665,7 @@ namespace big::vehicle
 			return false;
 		}
 
-		if (g->m_remote_controlled_vehicle == veh)
+		if (g.m_remote_controlled_vehicle == veh)
 		{
 			return false;
 		}
@@ -700,8 +700,8 @@ namespace big::vehicle
 		ENTITY::SET_ENTITY_VELOCITY(spawned, velocity.x, velocity.y, velocity.z);
 		VEHICLE::COPY_VEHICLE_DAMAGES(veh, spawned);
 
-		g->m_remote_controller_vehicle = spawned;
-		g->m_remote_controlled_vehicle = veh;
+		g.m_remote_controller_vehicle = spawned;
+		g.m_remote_controlled_vehicle = veh;
 		return true;
 	}
 }

--- a/src/views/core/view_notifications.cpp
+++ b/src/views/core/view_notifications.cpp
@@ -40,10 +40,10 @@ namespace big
 			}
 		}
 
-		dl->AddRectFilled({ (float)*g_pointers->m_resolution_x - 360.f, 10.f + start_pos }, { (float)*g_pointers->m_resolution_x - 10.f, start_pos + 45.f + total_size }, g->window.color);
+		dl->AddRectFilled({ (float)*g_pointers->m_resolution_x - 360.f, 10.f + start_pos }, { (float)*g_pointers->m_resolution_x - 10.f, start_pos + 45.f + total_size }, g.window.color);
 		dl->AddRectFilledMultiColor({ (float)*g_pointers->m_resolution_x - 360.f, 10.f + start_pos }, { (float)*g_pointers->m_resolution_x - 255.f, start_pos + 45.f + total_size }, fadeBegin, fadeEnd, fadeEnd, fadeBegin);
 
-		dl->AddText(g->window.font_sub_title, 22.f, { (float)*g_pointers->m_resolution_x - 350.f, 15.f + start_pos }, textCol, title.c_str());
+		dl->AddText(g.window.font_sub_title, 22.f, { (float)*g_pointers->m_resolution_x - 350.f, 15.f + start_pos }, textCol, title.c_str());
 		int i = 0;
 		for (std::string txt : split_points)
 		{
@@ -68,8 +68,8 @@ namespace big
 			prev_pos = draw_notification(prev_pos, draw_list, n.title, n.message, g_notification_service->notification_colors.at(n.type));
 		}
 
-		/*ImGui::SetNextWindowSize({ (float)g->window.x * 0.2f, (float)g->window.y });
-		ImGui::SetNextWindowPos({ (float)g->window.x - (float)g->window.x * 0.2f, 0 });
+		/*ImGui::SetNextWindowSize({ (float)g.window.x * 0.2f, (float)g.window.y });
+		ImGui::SetNextWindowPos({ (float)g.window.x - (float)g.window.x * 0.2f, 0 });
 		if (ImGui::Begin("notifications", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoMouseInputs | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoBringToFrontOnFocus))
 		{
 			std::vector<notification> notifications = g_notification_service->get();

--- a/src/views/debug/views_debug_logs.cpp
+++ b/src/views/debug/views_debug_logs.cpp
@@ -8,25 +8,25 @@ namespace big
 	{
 		if (ImGui::BeginTabItem("Logs"))
 		{
-			ImGui::Checkbox("Log Metrics", &g->debug.logs.metric_logs);
+			ImGui::Checkbox("Log Metrics", &g.debug.logs.metric_logs);
 
-			ImGui::Checkbox("Native Script Hooks", &g->debug.logs.script_hook_logs);
+			ImGui::Checkbox("Native Script Hooks", &g.debug.logs.script_hook_logs);
 
 			if (ImGui::TreeNode("Script Event Logging"))
 			{
-				ImGui::Checkbox("Enable Script Event Logging", &g->debug.logs.script_event.logs);
+				ImGui::Checkbox("Enable Script Event Logging", &g.debug.logs.script_event.logs);
 				ImGui::Separator();
 
-				ImGui::Checkbox("Filter by Player", &g->debug.logs.script_event.filter_player);
+				ImGui::Checkbox("Filter by Player", &g.debug.logs.script_event.filter_player);
 
-				if (g->debug.logs.script_event.filter_player)
+				if (g.debug.logs.script_event.filter_player)
 				{
 					ImGui::ListBoxHeader("##filter_player");
 					for (const auto& [_, player] : g_player_service->players())
 					{
-						if (components::selectable(player->get_name(), g->debug.logs.script_event.player_id == player->id()))
+						if (components::selectable(player->get_name(), g.debug.logs.script_event.player_id == player->id()))
 						{
-							g->debug.logs.script_event.player_id = player->id();
+							g.debug.logs.script_event.player_id = player->id();
 						}
 					}
 					ImGui::EndListBox();

--- a/src/views/esp/view_esp.cpp
+++ b/src/views/esp/view_esp.cpp
@@ -22,7 +22,7 @@ namespace big
 			!plyr->get_ped() ||
 			!plyr->get_ped()->m_navigation)
 			return;
-		if (g->esp.hide_self && plyr->is_valid() && plyr->id() == g_player_service->get_self()->id())
+		if (g.esp.hide_self && plyr->is_valid() && plyr->id() == g_player_service->get_self()->id())
 			return;
 
 		auto& player_pos = *plyr->get_ped()->m_navigation->get_position();
@@ -30,9 +30,9 @@ namespace big
 		float screen_x, screen_y;
 
 		const float distance = math::calculate_distance_from_game_cam(player_pos);
-		const float multplr = distance > g->esp.global_render_distance[1] ? -1.f : 6.17757f / distance;
+		const float multplr = distance > g.esp.global_render_distance[1] ? -1.f : 6.17757f / distance;
 
-		if (multplr == -1.f || g->esp.global_render_distance[0] > distance) return;
+		if (multplr == -1.f || g.esp.global_render_distance[0] > distance) return;
 
 		uint32_t ped_damage_bits = plyr->get_ped()->m_damage_bits;
 
@@ -43,34 +43,34 @@ namespace big
 
 			std::string name_str;
 			ImVec2 name_pos = { esp_x - (62.5f * multplr), esp_y - (175.f * multplr) - 20.f };
-			ImU32 esp_color = g->esp.default_color;
+			ImU32 esp_color = g.esp.default_color;
 
 			if (plyr->is_friend())
 			{
-				esp_color = g->esp.friend_color;
+				esp_color = g.esp.friend_color;
 			}
-			else if (g->esp.change_esp_color_from_dist) {
-				if (distance <= g->esp.distance_threshold[0])
-					esp_color = g->esp.enemy_color;
-				else if (distance >= g->esp.distance_threshold[0] && distance < g->esp.distance_threshold[1])
-					esp_color = g->esp.enemy_near_color;
+			else if (g.esp.change_esp_color_from_dist) {
+				if (distance <= g.esp.distance_threshold[0])
+					esp_color = g.esp.enemy_color;
+				else if (distance >= g.esp.distance_threshold[0] && distance < g.esp.distance_threshold[1])
+					esp_color = g.esp.enemy_near_color;
 			}
 
 			const auto armor_perc = plyr->get_ped()->m_armor / 50.f;
 			const auto health_perc = plyr->get_ped()->m_health / (plyr->get_ped()->m_maxhealth + 0.001f);
 
-			if (distance < g->esp.tracer_render_distance[1] && distance > g->esp.tracer_render_distance[0] && g->esp.tracer)
-				draw_list->AddLine({ (float)*g_pointers->m_resolution_x * g->esp.tracer_draw_position[0], (float)*g_pointers->m_resolution_y * g->esp.tracer_draw_position[1] }, { esp_x, esp_y }, esp_color);
+			if (distance < g.esp.tracer_render_distance[1] && distance > g.esp.tracer_render_distance[0] && g.esp.tracer)
+				draw_list->AddLine({ (float)*g_pointers->m_resolution_x * g.esp.tracer_draw_position[0], (float)*g_pointers->m_resolution_y * g.esp.tracer_draw_position[1] }, { esp_x, esp_y }, esp_color);
 
-			if (distance < g->esp.box_render_distance[1] && distance > g->esp.box_render_distance[0] && g->esp.box)
+			if (distance < g.esp.box_render_distance[1] && distance > g.esp.box_render_distance[0] && g.esp.box)
 				draw_list->AddRect({ esp_x - (62.5f * multplr), esp_y - (175.f * multplr) }, { esp_x - (62.5f * multplr) + (125.f * multplr), esp_y - (175.f * multplr) + (350.f * multplr) }, esp_color);
 
-			if (g->esp.name)
+			if (g.esp.name)
 				name_str = plyr->get_name();
 
-			if (g->esp.distance)
+			if (g.esp.distance)
 			{
-				if (g->esp.name)
+				if (g.esp.name)
 					name_str += " | ";
 				name_str += std::to_string((int)distance);
 				name_str += "m";
@@ -78,7 +78,7 @@ namespace big
 
 			draw_list->AddText(name_pos, esp_color, name_str.c_str());
 
-			if (g->esp.god) {
+			if (g.esp.god) {
 				std::string mode_str = "";
 
 				if (ped_damage_bits & (uint32_t)eEntityProofs::GOD)
@@ -105,8 +105,8 @@ namespace big
 
 			if (!(ped_damage_bits & (uint32_t)eEntityProofs::GOD))
 			{
-				if (g->esp.health) {
-					if (g->esp.scale_health_from_dist) {
+				if (g.esp.health) {
+					if (g.esp.scale_health_from_dist) {
 						draw_list->AddLine({ esp_x - (62.5f * multplr), esp_y + (175.f * multplr) + 5.f }, { esp_x - (62.5f * multplr) + (125.f * multplr), esp_y + (175.f * multplr) + 5.f }, health_perc == 0.f ? death_bg : health_perc < 0.25f ? health_red_bg : health_perc < 0.65f ? health_yellow_bg : health_green_bg, 4);
 						draw_list->AddLine({ esp_x - (62.5f * multplr), esp_y + (175.f * multplr) + 5.f }, { esp_x - (62.5f * multplr) + (125.f * multplr) * health_perc, esp_y + (175.f * multplr) + 5.f }, health_perc < 0.25f ? health_red : health_perc < 0.65f ? health_yellow : health_green, 4);
 					}
@@ -115,10 +115,10 @@ namespace big
 						draw_list->AddLine({ esp_x - (62.5f * multplr), esp_y + (175.f * multplr) + 5.f }, { esp_x - (62.5f * multplr) + (100.f * health_perc), esp_y + (175.f * multplr) + 5.f }, health_perc < 0.25f ? health_red : health_perc < 0.65f ? health_yellow : health_green, 4);
 					}
 				}
-				if (g->esp.armor && plyr->get_ped()->m_armor > 0) {
+				if (g.esp.armor && plyr->get_ped()->m_armor > 0) {
 					float offset = 5.f;
-					offset = g->esp.health ? 10.f : 5.f;
-					if (g->esp.scale_armor_from_dist) {
+					offset = g.esp.health ? 10.f : 5.f;
+					if (g.esp.scale_armor_from_dist) {
 						draw_list->AddLine({ esp_x - (62.5f * multplr), esp_y + (175.f * multplr) + offset }, { esp_x - (62.5f * multplr) + (125.f * multplr), esp_y + (175.f * multplr) + offset }, armor_blue_bg, 4);
 						draw_list->AddLine({ esp_x - (62.5f * multplr), esp_y + (175.f * multplr) + offset }, { esp_x - (62.5f * multplr) + (125.f * multplr) * armor_perc, esp_y + (175.f * multplr) + offset }, armor_blue, 4);
 					}
@@ -132,7 +132,7 @@ namespace big
 	}
 
 	void esp::draw() {
-		if (!g->esp.enabled) return;
+		if (!g.esp.enabled) return;
 
 		if (const auto draw_list = ImGui::GetBackgroundDrawList(); draw_list)
 		{

--- a/src/views/network/view_session.cpp
+++ b/src/views/network/view_session.cpp
@@ -70,53 +70,53 @@ namespace big
 			ImGui::EndListBox();
 		}
 
-		ImGui::Checkbox("Join in SCTV slots", &g->session.join_in_sctv_slots);
+		ImGui::Checkbox("Join in SCTV slots", &g.session.join_in_sctv_slots);
 		if (ImGui::IsItemHovered())
 			ImGui::SetTooltip("Allows you to join full and solo sessions but can be detected by other modders");
 
 		components::sub_title("Player Magnet");
-		ImGui::Checkbox("Enabled", &g->session.player_magnet_enabled);
-		if (g->session.player_magnet_enabled)
+		ImGui::Checkbox("Enabled", &g.session.player_magnet_enabled);
+		if (g.session.player_magnet_enabled)
 		{
-			ImGui::InputInt("Player Count", &g->session.player_magnet_count);
+			ImGui::InputInt("Player Count", &g.session.player_magnet_count);
 		}
 
 		components::sub_title("Chat");
-		ImGui::Checkbox("Auto-kick Chat Spammers", &g->session.kick_chat_spammers);
-		ImGui::Checkbox("Disable Filter", &g->session.disable_chat_filter);
-		ImGui::Checkbox("Log Chat Messages", &g->session.log_chat_messages);
-		ImGui::Checkbox("Log Text Messages", &g->session.log_text_messages);
+		ImGui::Checkbox("Auto-kick Chat Spammers", &g.session.kick_chat_spammers);
+		ImGui::Checkbox("Disable Filter", &g.session.disable_chat_filter);
+		ImGui::Checkbox("Log Chat Messages", &g.session.log_chat_messages);
+		ImGui::Checkbox("Log Text Messages", &g.session.log_text_messages);
 		static char msg[256];
 		ImGui::InputText("##message", msg, sizeof(msg));
 		ImGui::SameLine();
-		ImGui::Checkbox("Is Team", &g->session.is_team);
+		ImGui::Checkbox("Is Team", &g.session.is_team);
 		ImGui::SameLine();
 		components::button("Send", []
 		{
             if(const auto net_game_player = gta_util::get_network_player_mgr()->m_local_net_player; net_game_player)
 			{
-                if(g_pointers->m_send_chat_message(*g_pointers->m_send_chat_ptr, net_game_player->get_net_data(), msg, g->session.is_team))
-					notify::draw_chat(msg, net_game_player->get_name(), g->session.is_team);
+                if(g_pointers->m_send_chat_message(*g_pointers->m_send_chat_ptr, net_game_player->get_net_data(), msg, g.session.is_team))
+					notify::draw_chat(msg, net_game_player->get_name(), g.session.is_team);
 			}
 		});
 
 		components::sub_title("Decloak");
-		components::script_patch_checkbox("Reveal OTR Players", &g->session.decloak_players);
+		components::script_patch_checkbox("Reveal OTR Players", &g.session.decloak_players);
 
 		components::sub_title("Force Host");
-		ImGui::Checkbox("Force Session Host", &g->session.force_session_host);
+		ImGui::Checkbox("Force Session Host", &g.session.force_session_host);
 		if (ImGui::IsItemHovered())
 			ImGui::SetTooltip("Join another session to apply changes. The original host of the session must leave or be kicked. This feature is easily detectable by other mod menus, use with caution");
 		ImGui::SameLine();
-		if (g->session.force_session_host)
+		if (g.session.force_session_host)
 		{
 			ImGui::SameLine();
-			ImGui::Checkbox("Kick Host During Join", &g->session.kick_host_when_forcing_host);
+			ImGui::Checkbox("Kick Host During Join", &g.session.kick_host_when_forcing_host);
 		}
 
-		if (ImGui::Checkbox("Force Script Host", &g->session.force_script_host))
+		if (ImGui::Checkbox("Force Script Host", &g.session.force_script_host))
 		{
-			if (g->session.force_script_host)
+			if (g.session.force_script_host)
 				g_fiber_pool->queue_job([]
 			{
 				scripts::force_host(RAGE_JOAAT("freemode"));
@@ -126,40 +126,40 @@ namespace big
 		}
 
 		components::sub_title("Remote Name Spoofing");
-		ImGui::Checkbox("Spoof Other Players' Names", &g->session.name_spoof_enabled);
+		ImGui::Checkbox("Spoof Other Players' Names", &g.session.name_spoof_enabled);
 		if (ImGui::IsItemHovered())
 			ImGui::SetTooltip("Requires session host. Spoofed names will not visible locally nor to the player that had their name spoofed. Requires players to join after becoming host");
 
-		if (g->session.name_spoof_enabled)
+		if (g.session.name_spoof_enabled)
 		{
-			ImGui::Checkbox("Advertise YimMenu", &g->session.advertise_menu);
+			ImGui::Checkbox("Advertise YimMenu", &g.session.advertise_menu);
 			if (ImGui::IsItemHovered())
 				ImGui::SetTooltip("Advertise YimMenu by spoofing player names to differently colored variants of 'YimMenu'. You will not be able to customize the name with this option enabled");
 
-			if (!g->session.advertise_menu)
+			if (!g.session.advertise_menu)
 			{
 				constexpr size_t name_size = RTL_FIELD_SIZE(rage::rlGamerInfo, m_name);
 				static char name[name_size];
-				strcpy_s(name, sizeof(name), g->session.spoofed_name.c_str());
+				strcpy_s(name, sizeof(name), g.session.spoofed_name.c_str());
 
 				ImGui::Text("Name: ");
 				ImGui::InputText("##username_input", name, sizeof(name));
 
-				if (name != g->session.spoofed_name)
-					g->session.spoofed_name = std::string(name);
+				if (name != g.session.spoofed_name)
+					g.session.spoofed_name = std::string(name);
 			}
 		}
 
 		components::sub_title("All Players");
-		ImGui::Checkbox("Off The Radar", &g->session.off_radar_all);
+		ImGui::Checkbox("Off The Radar", &g.session.off_radar_all);
 		ImGui::SameLine();
-		ImGui::Checkbox("Never Wanted", &g->session.never_wanted_all);
+		ImGui::Checkbox("Never Wanted", &g.session.never_wanted_all);
 		ImGui::SameLine();
-		ImGui::Checkbox("Semi Godmode", &g->session.semi_godmode_all);
+		ImGui::Checkbox("Semi Godmode", &g.session.semi_godmode_all);
 
-		ImGui::Checkbox("Explosion Karma", &g->session.explosion_karma);
+		ImGui::Checkbox("Explosion Karma", &g.session.explosion_karma);
 		ImGui::SameLine();
-		ImGui::Checkbox("Damage Karma", &g->session.damage_karma);
+		ImGui::Checkbox("Damage Karma", &g.session.damage_karma);
 
 		static int global_wanted_level = 0;
 
@@ -169,7 +169,7 @@ namespace big
 		}
 
 		ImGui::SameLine();
-		if (ImGui::Checkbox("Force", &g->session.wanted_level_all))
+		if (ImGui::Checkbox("Force", &g.session.wanted_level_all))
 		{
 			*scr_globals::globalplayer_bd.at(self::id, scr_globals::size::globalplayer_bd).at(212).as<Player*>() = __rdtsc() + 32;
 			*scr_globals::globalplayer_bd.at(self::id, scr_globals::size::globalplayer_bd).at(213).as<int*>() = global_wanted_level;
@@ -197,16 +197,16 @@ namespace big
 
 		components::small_text("Teleports");
 
-		if (ImGui::BeginCombo("##apartment", apartment_names[g->session.send_to_apartment_idx]))
+		if (ImGui::BeginCombo("##apartment", apartment_names[g.session.send_to_apartment_idx]))
 		{
 			for (int i = 1; i < apartment_names.size(); i++)
 			{
-				if (ImGui::Selectable(apartment_names[i], i == g->session.send_to_apartment_idx))
+				if (ImGui::Selectable(apartment_names[i], i == g.session.send_to_apartment_idx))
 				{
-					g->session.send_to_apartment_idx = i;
+					g.session.send_to_apartment_idx = i;
 				}
 
-				if (i == g->session.send_to_apartment_idx)
+				if (i == g.session.send_to_apartment_idx)
 				{
 					ImGui::SetItemDefaultFocus();
 				}
@@ -217,18 +217,18 @@ namespace big
 
 		ImGui::SameLine();
 
-		components::button("TP All To Apartment", [] { g_player_service->iterate([](auto& plyr) { toxic::send_player_to_apartment(plyr.second, g->session.send_to_apartment_idx); }); });
+		components::button("TP All To Apartment", [] { g_player_service->iterate([](auto& plyr) { toxic::send_player_to_apartment(plyr.second, g.session.send_to_apartment_idx); }); });
 
-		if (ImGui::BeginCombo("##warehouse", warehouse_names[g->session.send_to_warehouse_idx]))
+		if (ImGui::BeginCombo("##warehouse", warehouse_names[g.session.send_to_warehouse_idx]))
 		{
 			for (int i = 1; i < warehouse_names.size(); i++)
 			{
-				if (ImGui::Selectable(warehouse_names[i], i == g->session.send_to_warehouse_idx))
+				if (ImGui::Selectable(warehouse_names[i], i == g.session.send_to_warehouse_idx))
 				{
-					g->session.send_to_warehouse_idx = i;
+					g.session.send_to_warehouse_idx = i;
 				}
 
-				if (i == g->session.send_to_warehouse_idx)
+				if (i == g.session.send_to_warehouse_idx)
 				{
 					ImGui::SetItemDefaultFocus();
 				}
@@ -239,7 +239,7 @@ namespace big
 
 		ImGui::SameLine();
 
-		components::button("TP All To Warehouse", [] { g_player_service->iterate([](auto& plyr) { toxic::send_player_to_warehouse(plyr.second, g->session.send_to_warehouse_idx); }); });
+		components::button("TP All To Warehouse", [] { g_player_service->iterate([](auto& plyr) { toxic::send_player_to_warehouse(plyr.second, g.session.send_to_warehouse_idx); }); });
 
 		components::button("TP All To Darts", [] { g_player_service->iterate([](auto& plyr) { toxic::start_activity(plyr.second, eActivityType::Darts); }); });
 		ImGui::SameLine();
@@ -313,17 +313,17 @@ namespace big
 		components::button("Camhedz", [] { scripts::start_launcher_script(218); });
 		ImGui::EndGroup();
 
-		ImGui::Checkbox("Disable Pedestrians", &g->session.disable_peds);
+		ImGui::Checkbox("Disable Pedestrians", &g.session.disable_peds);
 		ImGui::SameLine();
-		ImGui::Checkbox("Disable Traffic", &g->session.disable_traffic);
+		ImGui::Checkbox("Disable Traffic", &g.session.disable_traffic);
 		ImGui::SameLine();
-		ImGui::Checkbox("Force Thunder", &g->session.force_thunder);
+		ImGui::Checkbox("Force Thunder", &g.session.force_thunder);
 
 		components::sub_title("Script Host Features");
-		ImGui::Checkbox("Disable CEO Money", &g->session.block_ceo_money);
+		ImGui::Checkbox("Disable CEO Money", &g.session.block_ceo_money);
 		if (ImGui::IsItemHovered())
 			ImGui::SetTooltip("Blocks CEO money drops across the entire session. This can also break other stuff, use with caution");
 		ImGui::SameLine();
-		ImGui::Checkbox("Randomize CEO Colors", &g->session.randomize_ceo_colors);
+		ImGui::Checkbox("Randomize CEO Colors", &g.session.randomize_ceo_colors);
 	}
 }

--- a/src/views/network/view_session_browser.cpp
+++ b/src/views/network/view_session_browser.cpp
@@ -87,22 +87,22 @@ namespace big
 
 		if (ImGui::TreeNode("Filters"))
 		{
-			ImGui::Checkbox("Region", &g->session_browser.region_filter_enabled);
+			ImGui::Checkbox("Region", &g.session_browser.region_filter_enabled);
 
 			if (ImGui::IsItemHovered())
 				ImGui::SetTooltip("It is highly recommended to keep this filter enabled");
 
-			if (g->session_browser.region_filter_enabled)
+			if (g.session_browser.region_filter_enabled)
 			{
 				ImGui::SameLine();
 
-				if (ImGui::BeginCombo("###region_select", regions[g->session_browser.region_filter].name))
+				if (ImGui::BeginCombo("###region_select", regions[g.session_browser.region_filter].name))
 				{
 					for (const auto& region : regions)
 					{
-						if (ImGui::Selectable(region.name, g->session_browser.region_filter == region.id))
+						if (ImGui::Selectable(region.name, g.session_browser.region_filter == region.id))
 						{
-							g->session_browser.region_filter = region.id;
+							g.session_browser.region_filter = region.id;
 						}
 					}
 					ImGui::EndCombo();
@@ -110,34 +110,34 @@ namespace big
 
 			}
 
-			ImGui::Checkbox("Language", &g->session_browser.language_filter_enabled);
+			ImGui::Checkbox("Language", &g.session_browser.language_filter_enabled);
 
 			if (ImGui::IsItemHovered())
 				ImGui::SetTooltip("Setting a correct region filter for the language will help tremendously");
 
-			if (g->session_browser.language_filter_enabled)
+			if (g.session_browser.language_filter_enabled)
 			{
 				ImGui::SameLine();
 
-				if (ImGui::BeginCombo("###language_select", languages[g->session_browser.language_filter].name))
+				if (ImGui::BeginCombo("###language_select", languages[g.session_browser.language_filter].name))
 				{
 					for (const auto& language : languages)
 					{
-						if (ImGui::Selectable(language.name, g->session_browser.language_filter == language.id))
+						if (ImGui::Selectable(language.name, g.session_browser.language_filter == language.id))
 						{
-							g->session_browser.language_filter = language.id;
+							g.session_browser.language_filter = language.id;
 						};
 					}
 					ImGui::EndCombo();
 				}
 			}
 
-			ImGui::Checkbox("Players", &g->session_browser.player_count_filter_enabled);
+			ImGui::Checkbox("Players", &g.session_browser.player_count_filter_enabled);
 
-			if (g->session_browser.player_count_filter_enabled)
+			if (g.session_browser.player_count_filter_enabled)
 			{
-				ImGui::InputInt("Minimum", &g->session_browser.player_count_filter_minimum);
-				ImGui::InputInt("Maximum", &g->session_browser.player_count_filter_maximum);
+				ImGui::InputInt("Minimum", &g.session_browser.player_count_filter_minimum);
+				ImGui::InputInt("Maximum", &g.session_browser.player_count_filter_maximum);
 			}
 
 			ImGui::TreePop();
@@ -145,13 +145,13 @@ namespace big
 
 		if (ImGui::TreeNode("Sorting"))
 		{
-			ImGui::Combo("Sort By", &g->session_browser.sort_method, "Off\0Player Count");
-			if (g->session_browser.sort_method != 0)
-				ImGui::Combo("Direction", &g->session_browser.sort_direction, "Ascending\0Descending");
+			ImGui::Combo("Sort By", &g.session_browser.sort_method, "Off\0Player Count");
+			if (g.session_browser.sort_method != 0)
+				ImGui::Combo("Direction", &g.session_browser.sort_direction, "Ascending\0Descending");
 			ImGui::TreePop();
 		}
 
-		if (ImGui::Checkbox("Replace Game Matchmaking", &g->session_browser.replace_game_matchmaking));
+		if (ImGui::Checkbox("Replace Game Matchmaking", &g.session_browser.replace_game_matchmaking));
 
 		if (ImGui::IsItemHovered())
 			ImGui::SetTooltip("This will replace the default game matchmaking with a custom one that will use the filters and sorting set here");

--- a/src/views/network/view_spoofing.cpp
+++ b/src/views/network/view_spoofing.cpp
@@ -40,7 +40,7 @@ namespace big
 		ImGui::Checkbox("Spoof IP", &g->spoofing.spoof_ip);
 
 		ImGui::Text("IP Address:");
-		ImGui::DragInt4("##ip_fields", g->spoofing.ip_address, 0, 255);
+		ImGui::DragInt4("##ip_fields", g->spoofing.ip_address.data(), 0, 255);
 
 		ImGui::Separator();
 

--- a/src/views/network/view_spoofing.cpp
+++ b/src/views/network/view_spoofing.cpp
@@ -17,17 +17,17 @@ namespace big
 			PAD::DISABLE_ALL_CONTROL_ACTIONS(0);
 		});
 
-		ImGui::Checkbox("Spoof Username", &g->spoofing.spoof_username);
+		ImGui::Checkbox("Spoof Username", &g.spoofing.spoof_username);
 
 		constexpr size_t name_size = RTL_FIELD_SIZE(rage::rlGamerInfo, m_name);
 		static char name[name_size];
-		strcpy_s(name, sizeof(name), g->spoofing.username.c_str());
+		strcpy_s(name, sizeof(name), g.spoofing.username.c_str());
 
 		ImGui::Text("Username:");
 		ImGui::InputText("##username_input", name, sizeof(name));
 
-		if (name != g->spoofing.username)
-			g->spoofing.username = std::string(name);
+		if (name != g.spoofing.username)
+			g.spoofing.username = std::string(name);
 
 		ImGui::Separator();
 
@@ -37,10 +37,10 @@ namespace big
 			PAD::DISABLE_ALL_CONTROL_ACTIONS(0);
 		});
 
-		ImGui::Checkbox("Spoof IP", &g->spoofing.spoof_ip);
+		ImGui::Checkbox("Spoof IP", &g.spoofing.spoof_ip);
 
 		ImGui::Text("IP Address:");
-		ImGui::DragInt4("##ip_fields", g->spoofing.ip_address.data(), 0, 255);
+		ImGui::DragInt4("##ip_fields", g.spoofing.ip_address.data(), 0, 255);
 
 		ImGui::Separator();
 
@@ -50,14 +50,14 @@ namespace big
 			PAD::DISABLE_ALL_CONTROL_ACTIONS(0);
 		});
 
-		ImGui::Checkbox("Spoof Rockstar ID", &g->spoofing.spoof_rockstar_id);
+		ImGui::Checkbox("Spoof Rockstar ID", &g.spoofing.spoof_rockstar_id);
 
 		ImGui::Text("Rockstar ID:");
-		ImGui::InputScalar("##rockstar_id_input", ImGuiDataType_U64, &g->spoofing.rockstar_id);
+		ImGui::InputScalar("##rockstar_id_input", ImGuiDataType_U64, &g.spoofing.rockstar_id);
 
 		components::sub_title("Hide Features");
-		ImGui::Checkbox("Hide God Mode", &g->spoofing.spoof_hide_god);
-		ImGui::Checkbox("Hide Spectate", &g->spoofing.spoof_hide_spectate);
+		ImGui::Checkbox("Hide God Mode", &g.spoofing.spoof_hide_god);
+		ImGui::Checkbox("Hide Spectate", &g.spoofing.spoof_hide_spectate);
 
 		components::sub_title("Crew");
 
@@ -65,70 +65,70 @@ namespace big
 			PAD::DISABLE_ALL_CONTROL_ACTIONS(0);
 		});
 
-		ImGui::Checkbox("Spoof Crew", &g->spoofing.spoof_crew_data);
+		ImGui::Checkbox("Spoof Crew", &g.spoofing.spoof_crew_data);
 
 		constexpr size_t crew_tag_size = RTL_FIELD_SIZE(ClanData, m_clan_tag);
 		static char crew_tag[crew_tag_size];
-		strcpy_s(crew_tag, sizeof(crew_tag), g->spoofing.crew_tag.c_str());
+		strcpy_s(crew_tag, sizeof(crew_tag), g.spoofing.crew_tag.c_str());
 
 		ImGui::Text("Crew Tag:");
 		ImGui::InputText("##crew_tag_input", crew_tag, sizeof(crew_tag));
 
-		if (crew_tag != g->spoofing.crew_tag)
-			g->spoofing.crew_tag = std::string(crew_tag);
+		if (crew_tag != g.spoofing.crew_tag)
+			g.spoofing.crew_tag = std::string(crew_tag);
 
-		ImGui::Checkbox("Is Rockstar Crew", &g->spoofing.rockstar_crew);
+		ImGui::Checkbox("Is Rockstar Crew", &g.spoofing.rockstar_crew);
 
-		ImGui::Checkbox("Square Crew Tag", &g->spoofing.square_crew_tag);
+		ImGui::Checkbox("Square Crew Tag", &g.spoofing.square_crew_tag);
 
 		components::sub_title("Extra - Only work when Spoofed RID");
 
-		ImGui::Checkbox("Is Cheater", &g->spoofing.spoof_cheater);
-		ImGui::Checkbox("Is Rockstar Dev", &g->spoofing.spoof_rockstar_dev);
-		ImGui::Checkbox("Is Rockstar QA", &g->spoofing.spoof_rockstar_qa);
+		ImGui::Checkbox("Is Cheater", &g.spoofing.spoof_cheater);
+		ImGui::Checkbox("Is Rockstar Dev", &g.spoofing.spoof_rockstar_dev);
+		ImGui::Checkbox("Is Rockstar QA", &g.spoofing.spoof_rockstar_qa);
 
 		components::sub_title("Session Attributes");
 		components::small_text("Only works when session host");
 
-		ImGui::Checkbox("Region", &g->spoofing.spoof_session_region_type);
-		if (g->spoofing.spoof_session_region_type)
+		ImGui::Checkbox("Region", &g.spoofing.spoof_session_region_type);
+		if (g.spoofing.spoof_session_region_type)
 		{
 			ImGui::SameLine();
-			if (ImGui::BeginCombo("###region_select", regions[g->spoofing.session_region_type].name))
+			if (ImGui::BeginCombo("###region_select", regions[g.spoofing.session_region_type].name))
 			{
 				for (const auto& region : regions)
 				{
-					if (ImGui::Selectable(region.name, g->spoofing.session_region_type == region.id))
+					if (ImGui::Selectable(region.name, g.spoofing.session_region_type == region.id))
 					{
-						g->spoofing.session_region_type = region.id;
+						g.spoofing.session_region_type = region.id;
 					}
 				}
 				ImGui::EndCombo();
 			}
 		}
-		ImGui::Checkbox("Language", &g->spoofing.spoof_session_language);
-		if (g->spoofing.spoof_session_language)
+		ImGui::Checkbox("Language", &g.spoofing.spoof_session_language);
+		if (g.spoofing.spoof_session_language)
 		{
 			ImGui::SameLine();
 
-			if (ImGui::BeginCombo("###language_select", languages[g->spoofing.session_language].name))
+			if (ImGui::BeginCombo("###language_select", languages[g.spoofing.session_language].name))
 			{
 				for (const auto& language : languages)
 				{
-					if (ImGui::Selectable(language.name, g->spoofing.session_language == language.id))
+					if (ImGui::Selectable(language.name, g.spoofing.session_language == language.id))
 					{
-						g->spoofing.session_language = language.id;
+						g.spoofing.session_language = language.id;
 					};
 				}
 				ImGui::EndCombo();
 			}
 		}
 
-		ImGui::Checkbox("Player Count", &g->spoofing.spoof_session_player_count);
-		if (g->spoofing.spoof_session_player_count)
+		ImGui::Checkbox("Player Count", &g.spoofing.spoof_session_player_count);
+		if (g.spoofing.spoof_session_player_count)
 		{
 			ImGui::SameLine();
-			ImGui::InputInt("###player_count", &g->spoofing.session_player_count);
+			ImGui::InputInt("###player_count", &g.spoofing.session_player_count);
 		}
 	}
 }

--- a/src/views/players/player/player_toxic.cpp
+++ b/src/views/players/player/player_toxic.cpp
@@ -31,16 +31,16 @@ namespace big
 
 			components::small_text("Teleports");
 
-			if (ImGui::BeginCombo("##apartment", apartment_names[g->session.send_to_apartment_idx]))
+			if (ImGui::BeginCombo("##apartment", apartment_names[g.session.send_to_apartment_idx]))
 			{
 				for (int i = 1; i < apartment_names.size(); i++)
 				{
-					if (ImGui::Selectable(apartment_names[i], i == g->session.send_to_apartment_idx))
+					if (ImGui::Selectable(apartment_names[i], i == g.session.send_to_apartment_idx))
 					{
-						g->session.send_to_apartment_idx = i;
+						g.session.send_to_apartment_idx = i;
 					}
 
-					if (i == g->session.send_to_apartment_idx)
+					if (i == g.session.send_to_apartment_idx)
 					{
 						ImGui::SetItemDefaultFocus();
 					}
@@ -51,18 +51,18 @@ namespace big
 
 			ImGui::SameLine();
 
-			components::button("TP To Apartment", [] { toxic::send_player_to_apartment(g_player_service->get_selected(), g->session.send_to_apartment_idx); });
+			components::button("TP To Apartment", [] { toxic::send_player_to_apartment(g_player_service->get_selected(), g.session.send_to_apartment_idx); });
 
-			if (ImGui::BeginCombo("##warehouse", warehouse_names[g->session.send_to_warehouse_idx]))
+			if (ImGui::BeginCombo("##warehouse", warehouse_names[g.session.send_to_warehouse_idx]))
 			{
 				for (int i = 1; i < warehouse_names.size(); i++)
 				{
-					if (ImGui::Selectable(warehouse_names[i], i == g->session.send_to_warehouse_idx))
+					if (ImGui::Selectable(warehouse_names[i], i == g.session.send_to_warehouse_idx))
 					{
-						g->session.send_to_warehouse_idx = i;
+						g.session.send_to_warehouse_idx = i;
 					}
 
-					if (i == g->session.send_to_warehouse_idx)
+					if (i == g.session.send_to_warehouse_idx)
 					{
 						ImGui::SetItemDefaultFocus();
 					}
@@ -73,7 +73,7 @@ namespace big
 
 			ImGui::SameLine();
 
-			components::button("TP To Warehouse", [] { toxic::send_player_to_warehouse(g_player_service->get_selected(), g->session.send_to_warehouse_idx); });
+			components::button("TP To Warehouse", [] { toxic::send_player_to_warehouse(g_player_service->get_selected(), g.session.send_to_warehouse_idx); });
 
 			components::button("TP To Darts", [] { toxic::start_activity(g_player_service->get_selected(), eActivityType::Darts); });
 			ImGui::SameLine();

--- a/src/views/players/player/player_troll.cpp
+++ b/src/views/players/player/player_troll.cpp
@@ -32,7 +32,7 @@ namespace big
 				Vehicle veh = PED::GET_VEHICLE_PED_IS_IN(PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(g_player_service->get_selected()->id()), FALSE);
 				if (veh == 0)
 				{
-					if (g->player.spectating)
+					if (g.player.spectating)
 						g_notification_service->push_warning("Remote Control", "Player not in a vehicle");
 					else
 						g_notification_service->push_warning("Remote Control", "Player not in a vehicle, try spectating the player");
@@ -40,7 +40,7 @@ namespace big
 				}
 
 				vehicle::remote_control_vehicle(veh);
-				g->player.spectating = false;
+				g.player.spectating = false;
 			});
 
 			ImGui::TreePop();

--- a/src/views/players/view_player.cpp
+++ b/src/views/players/view_player.cpp
@@ -7,7 +7,7 @@ namespace big
 		std::string title = std::format("Player Options: {}", g_player_service->get_selected()->get_name());
 		
 		ImGui::Text(title.c_str());
-		ImGui::Checkbox("Spectate", &g->player.spectating);
+		ImGui::Checkbox("Spectate", &g.player.spectating);
 		
 		if (g_player_service->get_selected()->is_valid())
 		{

--- a/src/views/players/view_players.cpp
+++ b/src/views/players/view_players.cpp
@@ -30,7 +30,7 @@ namespace big
 
 		// calculate icons width
 		const auto window = ImGui::GetCurrentWindow();
-		ImGui::PushFont(g->window.font_icon);
+		ImGui::PushFont(g.window.font_icon);
 		const auto icons_size = ImGui::CalcTextSize(player_iconsc, player_icons_end);
 		const ImVec2 icons_pos(window->DC.CursorPos.x + 300.0f - 32.0f - icons_size.x, window->DC.CursorPos.y + 2.0f);
 		const ImRect icons_box(icons_pos, icons_pos + icons_size);
@@ -48,7 +48,7 @@ namespace big
 		{
 			g_player_service->set_selected(plyr);
 			g_gui_service->set_selected(tabs::PLAYER);
-			g->window.switched_view = true;
+			g.window.switched_view = true;
 		}
 		ImGui::PopID();
 		ImGui::PopStyleVar();
@@ -60,7 +60,7 @@ namespace big
 			ImGui::PopStyleColor();
 
 		// render icons on top of the player button
-		ImGui::PushFont(g->window.font_icon);
+		ImGui::PushFont(g.window.font_icon);
 		ImGui::RenderTextWrapped(icons_box.Min, player_iconsc, player_icons_end, icons_size.x);
 		ImGui::PopFont();
 	}

--- a/src/views/self/view_mobile.cpp
+++ b/src/views/self/view_mobile.cpp
@@ -10,7 +10,7 @@ namespace big
 
 		components::sub_title("Lester");
 
-		ImGui::Checkbox("Off Radar", &g->self.off_radar);
+		ImGui::Checkbox("Off Radar", &g.self.off_radar);
 
 		ImGui::Separator();	
 		

--- a/src/views/self/view_self.cpp
+++ b/src/views/self/view_self.cpp
@@ -52,36 +52,36 @@ namespace big
 
 		ImGui::BeginGroup();
 
-		ImGui::Checkbox("God Mode", &g->self.god_mode);
-		ImGui::Checkbox("Off Radar", &g->self.off_radar);
-		ImGui::Checkbox("Free Cam", &g->self.free_cam);
-		ImGui::Checkbox("Disable Phone", &g->tunables.disable_phone);
-		ImGui::Checkbox("Unlimited Oxygen", &g->self.unlimited_oxygen);
-		ImGui::Checkbox("Fast Respawn", &g->self.fast_respawn);
+		ImGui::Checkbox("God Mode", &g.self.god_mode);
+		ImGui::Checkbox("Off Radar", &g.self.off_radar);
+		ImGui::Checkbox("Free Cam", &g.self.free_cam);
+		ImGui::Checkbox("Disable Phone", &g.tunables.disable_phone);
+		ImGui::Checkbox("Unlimited Oxygen", &g.self.unlimited_oxygen);
+		ImGui::Checkbox("Fast Respawn", &g.self.fast_respawn);
 
 		ImGui::EndGroup();
 		ImGui::SameLine();
 		ImGui::BeginGroup();
 
-		ImGui::Checkbox("No Clip", &g->self.noclip);
-		ImGui::Checkbox("No Ragdoll", &g->self.no_ragdoll);
-		ImGui::Checkbox("Super Run", &g->self.super_run);
-		ImGui::Checkbox("No Idle Kick", &g->tunables.no_idle_kick);
-		ImGui::Checkbox("No Water Collision", &g->self.no_water_collision);
+		ImGui::Checkbox("No Clip", &g.self.noclip);
+		ImGui::Checkbox("No Ragdoll", &g.self.no_ragdoll);
+		ImGui::Checkbox("Super Run", &g.self.super_run);
+		ImGui::Checkbox("No Idle Kick", &g.tunables.no_idle_kick);
+		ImGui::Checkbox("No Water Collision", &g.self.no_water_collision);
 
 		ImGui::EndGroup();
 		ImGui::SameLine();
 		ImGui::BeginGroup();
 
-		ImGui::Checkbox("Invisibility", &g->self.invisibility);
-		if (g->self.invisibility) {
-			ImGui::Checkbox("Locally Visible", &g->self.local_visibility);
+		ImGui::Checkbox("Invisibility", &g.self.invisibility);
+		if (g.self.invisibility) {
+			ImGui::Checkbox("Locally Visible", &g.self.local_visibility);
 		}
-		ImGui::Checkbox("Keep Player Clean", &g->self.clean_player);
-		ImGui::Checkbox("No Collision", &g->self.no_collision);
-		ImGui::Checkbox("Mobile Radio", &g->self.mobile_radio);
+		ImGui::Checkbox("Keep Player Clean", &g.self.clean_player);
+		ImGui::Checkbox("No Collision", &g.self.no_collision);
+		ImGui::Checkbox("Mobile Radio", &g.self.mobile_radio);
 
-		ImGui::Checkbox("Dance Mode", &g->self.dance_mode);
+		ImGui::Checkbox("Dance Mode", &g.self.dance_mode);
 		if (ImGui::IsItemHovered())
 			ImGui::SetTooltip("Hold Right DPAD or E to enter dance mode");
 
@@ -93,55 +93,55 @@ namespace big
 
 		if (ImGui::Button("Check all"))
 		{
-			g->self.proof_bullet = true;
-			g->self.proof_fire = true;
-			g->self.proof_collision = true;
-			g->self.proof_melee = true;
-			g->self.proof_explosion = true;
-			g->self.proof_steam = true;
-			g->self.proof_drown = true;
-			g->self.proof_water = true;
+			g.self.proof_bullet = true;
+			g.self.proof_fire = true;
+			g.self.proof_collision = true;
+			g.self.proof_melee = true;
+			g.self.proof_explosion = true;
+			g.self.proof_steam = true;
+			g.self.proof_drown = true;
+			g.self.proof_water = true;
 		}
 
 		ImGui::SameLine();
 
 		if (ImGui::Button("Uncheck all"))
 		{
-			g->self.proof_bullet = false;
-			g->self.proof_fire = false;
-			g->self.proof_collision = false;
-			g->self.proof_melee = false;
-			g->self.proof_explosion = false;
-			g->self.proof_steam = false;
-			g->self.proof_drown = false;
-			g->self.proof_water = false;
+			g.self.proof_bullet = false;
+			g.self.proof_fire = false;
+			g.self.proof_collision = false;
+			g.self.proof_melee = false;
+			g.self.proof_explosion = false;
+			g.self.proof_steam = false;
+			g.self.proof_drown = false;
+			g.self.proof_water = false;
 		}
 
 		ImGui::BeginGroup();
 
-		ImGui::Checkbox("Bullet", &g->self.proof_bullet);
-		ImGui::Checkbox("Fire", &g->self.proof_fire);
+		ImGui::Checkbox("Bullet", &g.self.proof_bullet);
+		ImGui::Checkbox("Fire", &g.self.proof_fire);
 
 		ImGui::EndGroup();
 		ImGui::SameLine();
 		ImGui::BeginGroup();
 
-		ImGui::Checkbox("Collision", &g->self.proof_collision);
-		ImGui::Checkbox("Melee", &g->self.proof_melee);
+		ImGui::Checkbox("Collision", &g.self.proof_collision);
+		ImGui::Checkbox("Melee", &g.self.proof_melee);
 
 		ImGui::EndGroup();
 		ImGui::SameLine();
 		ImGui::BeginGroup();
 
-		ImGui::Checkbox("Explosion", &g->self.proof_explosion);
-		ImGui::Checkbox("Steam", &g->self.proof_steam);
+		ImGui::Checkbox("Explosion", &g.self.proof_explosion);
+		ImGui::Checkbox("Steam", &g.self.proof_steam);
 
 		ImGui::EndGroup();
 		ImGui::SameLine();
 		ImGui::BeginGroup();
 
-		ImGui::Checkbox("Drown", &g->self.proof_drown);
-		ImGui::Checkbox("Water", &g->self.proof_water);
+		ImGui::Checkbox("Drown", &g.self.proof_drown);
+		ImGui::Checkbox("Water", &g.self.proof_water);
 
 		ImGui::EndGroup();
 
@@ -149,18 +149,18 @@ namespace big
 
 		components::sub_title("Police");
 
-		ImGui::Checkbox("Never Wanted", &g->self.never_wanted);
+		ImGui::Checkbox("Never Wanted", &g.self.never_wanted);
 
-		if (!g->self.never_wanted)
+		if (!g.self.never_wanted)
 		{
-			ImGui::Checkbox("Force Wanted Level", &g->self.force_wanted_level);
+			ImGui::Checkbox("Force Wanted Level", &g.self.force_wanted_level);
 			ImGui::Text("Wanted Level");
 			if (
-				ImGui::SliderInt("###wanted_level", &g->self.wanted_level, 0, 5) &&
-				!g->self.force_wanted_level &&
+				ImGui::SliderInt("###wanted_level", &g.self.wanted_level, 0, 5) &&
+				!g.self.force_wanted_level &&
 				g_local_player != nullptr
 				) {
-				g_local_player->m_player_info->m_wanted_level = g->self.wanted_level;
+				g_local_player->m_player_info->m_wanted_level = g.self.wanted_level;
 			}
 		}
 
@@ -170,86 +170,86 @@ namespace big
 
 		ImGui::BeginGroup();
 
-		ImGui::Checkbox("Hide Radar", &g->self.hide_radar);
+		ImGui::Checkbox("Hide Radar", &g.self.hide_radar);
 
 		ImGui::SameLine();
 
-		ImGui::Checkbox("Hide Ammo", &g->self.hide_ammo);
+		ImGui::Checkbox("Hide Ammo", &g.self.hide_ammo);
 
 		ImGui::SameLine();
 
-		ImGui::Checkbox("Force show HUD", &g->self.force_show_hud);
+		ImGui::Checkbox("Force show HUD", &g.self.force_show_hud);
 
-		ImGui::Combo("##hud_comp_combo", &g->self.selected_hud_component, hud_component_names, (int)HudComponents::HUD_WEAPONS);
+		ImGui::Combo("##hud_comp_combo", &g.self.selected_hud_component, hud_component_names, (int)HudComponents::HUD_WEAPONS);
 		ImGui::SameLine();
 		components::button("Hide", [] {
-			g->self.hud_components_states[g->self.selected_hud_component] = true;
+			g.self.hud_components_states[g.self.selected_hud_component] = true;
 		});
 		ImGui::SameLine();
 		components::button("Show", [] {
-			g->self.hud_components_states[g->self.selected_hud_component] = false;
+			g.self.hud_components_states[g.self.selected_hud_component] = false;
 		});
 
 		components::button("Hide all", [] {
-			g->self.hide_radar = true;
-			g->self.hide_ammo = true;
+			g.self.hide_radar = true;
+			g.self.hide_ammo = true;
 			for (int i = 0; i < (int)HudComponents::HUD_WEAPONS; i++)
 			{
-				g->self.hud_components_states[i] = true;
+				g.self.hud_components_states[i] = true;
 			}
 		});
 		ImGui::SameLine();
 		components::button("Show all", [] {
-			g->self.hide_radar = false;
-			g->self.hide_ammo = false;
+			g.self.hide_radar = false;
+			g.self.hide_ammo = false;
 			for (int i = 0; i < (int)HudComponents::HUD_WEAPONS; i++)
 			{
-				g->self.hud_components_states[i] = false;
+				g.self.hud_components_states[i] = false;
 			}
 		});
 		ImGui::SameLine();
-		ImGui::Checkbox("Force show HUD element", &g->self.force_show_hud_element);
+		ImGui::Checkbox("Force show HUD element", &g.self.force_show_hud_element);
 		if (ImGui::IsItemHovered())
 			ImGui::SetTooltip("To force show a HUD specific element, click Hide all then click Show on the desired element.");
 
 		ImGui::EndGroup();
 
-		g->self.proof_mask = 0;
-		if (g->self.god_mode)
+		g.self.proof_mask = 0;
+		if (g.self.god_mode)
 		{
-			g->self.proof_mask |= static_cast<int>(eEntityProofs::GOD);
+			g.self.proof_mask |= static_cast<int>(eEntityProofs::GOD);
 		}
-		if (g->self.proof_bullet)
+		if (g.self.proof_bullet)
 		{
-			g->self.proof_mask |= static_cast<int>(eEntityProofs::BULLET);
+			g.self.proof_mask |= static_cast<int>(eEntityProofs::BULLET);
 		}
-		if (g->self.proof_fire)
+		if (g.self.proof_fire)
 		{
-			g->self.proof_mask |= static_cast<int>(eEntityProofs::FIRE);
+			g.self.proof_mask |= static_cast<int>(eEntityProofs::FIRE);
 		}
-		if (g->self.proof_collision)
+		if (g.self.proof_collision)
 		{
-			g->self.proof_mask |= static_cast<int>(eEntityProofs::COLLISION);
+			g.self.proof_mask |= static_cast<int>(eEntityProofs::COLLISION);
 		}
-		if (g->self.proof_melee)
+		if (g.self.proof_melee)
 		{
-			g->self.proof_mask |= static_cast<int>(eEntityProofs::MELEE);
+			g.self.proof_mask |= static_cast<int>(eEntityProofs::MELEE);
 		}
-		if (g->self.proof_explosion)
+		if (g.self.proof_explosion)
 		{
-			g->self.proof_mask |= static_cast<int>(eEntityProofs::EXPLOSION);
+			g.self.proof_mask |= static_cast<int>(eEntityProofs::EXPLOSION);
 		}
-		if (g->self.proof_steam)
+		if (g.self.proof_steam)
 		{
-			g->self.proof_mask |= static_cast<int>(eEntityProofs::STEAM);
+			g.self.proof_mask |= static_cast<int>(eEntityProofs::STEAM);
 		}
-		if (g->self.proof_drown)
+		if (g.self.proof_drown)
 		{
-			g->self.proof_mask |= static_cast<int>(eEntityProofs::DROWN);
+			g.self.proof_mask |= static_cast<int>(eEntityProofs::DROWN);
 		}
-		if (g->self.proof_water)
+		if (g.self.proof_water)
 		{
-			g->self.proof_mask |= static_cast<int>(eEntityProofs::WATER);
+			g.self.proof_mask |= static_cast<int>(eEntityProofs::WATER);
 		}
 	}
 }

--- a/src/views/self/view_teleport.cpp
+++ b/src/views/self/view_teleport.cpp
@@ -21,7 +21,7 @@ namespace big
 			teleport::to_objective();
 		});
 
-		ImGui::Checkbox("Auto-Teleport To Waypoint", &g->self.auto_tp);
+		ImGui::Checkbox("Auto-Teleport To Waypoint", &g.self.auto_tp);
 
 		ImGui::Text("Vehicles:");
 

--- a/src/views/self/view_weapons.cpp
+++ b/src/views/self/view_weapons.cpp
@@ -15,30 +15,30 @@ namespace big
 
 		ImGui::BeginGroup();
 
-		ImGui::Checkbox("Infinite Ammo", &g->weapons.infinite_ammo);
-		ImGui::Checkbox("Infinite Clip", &g->weapons.infinite_mag);
+		ImGui::Checkbox("Infinite Ammo", &g.weapons.infinite_ammo);
+		ImGui::Checkbox("Infinite Clip", &g.weapons.infinite_mag);
 
 		ImGui::EndGroup();
 		ImGui::SameLine();
 		ImGui::BeginGroup();
 
-		if (ImGui::Checkbox("Bypass C4 Limit", &g->weapons.bypass_c4_limit))
+		if (ImGui::Checkbox("Bypass C4 Limit", &g.weapons.bypass_c4_limit))
 		{
-			if (g->weapons.bypass_c4_limit)
+			if (g.weapons.bypass_c4_limit)
 				g_pointers->m_bypass_max_count_of_active_sticky_bombs->apply();
 			else
 				g_pointers->m_bypass_max_count_of_active_sticky_bombs->restore();
 		}
-		ImGui::Checkbox("Rapid Fire", &g->weapons.rapid_fire);
+		ImGui::Checkbox("Rapid Fire", &g.weapons.rapid_fire);
 
 		ImGui::EndGroup();
 
 		ImGui::Separator();
 
-		ImGui::Checkbox("Enable Special Ammo", &g->weapons.ammo_special.toggle);
+		ImGui::Checkbox("Enable Special Ammo", &g.weapons.ammo_special.toggle);
 
-		eAmmoSpecialType selected_ammo = g->weapons.ammo_special.type;
-		eExplosionTag selected_explosion = g->weapons.ammo_special.explosion_tag;
+		eAmmoSpecialType selected_ammo = g.weapons.ammo_special.type;
+		eExplosionTag selected_explosion = g.weapons.ammo_special.explosion_tag;
 
 		if (ImGui::BeginCombo("Special Ammo", SPECIAL_AMMOS[(int)selected_ammo].name))
 		{
@@ -46,7 +46,7 @@ namespace big
 			{
 				if (ImGui::Selectable(special_ammo.name, special_ammo.type == selected_ammo))
 				{
-					g->weapons.ammo_special.type = special_ammo.type;
+					g.weapons.ammo_special.type = special_ammo.type;
 				}
 
 				if (special_ammo.type == selected_ammo)
@@ -64,7 +64,7 @@ namespace big
 			{
 				if (ImGui::Selectable(name, type == selected_explosion))
 				{
-					g->weapons.ammo_special.explosion_tag = type;
+					g.weapons.ammo_special.explosion_tag = type;
 				}
 
 				if (type == selected_explosion)
@@ -80,15 +80,15 @@ namespace big
 
 		components::sub_title("Misc");
 
-		ImGui::Checkbox("Force Crosshairs", &g->weapons.force_crosshairs);
+		ImGui::Checkbox("Force Crosshairs", &g.weapons.force_crosshairs);
 
 		ImGui::SameLine();
 
-		ImGui::Checkbox("No Recoil", &g->weapons.no_recoil);
+		ImGui::Checkbox("No Recoil", &g.weapons.no_recoil);
 
 		ImGui::SameLine();
 
-		ImGui::Checkbox("No Spread", &g->weapons.no_spread);
+		ImGui::Checkbox("No Spread", &g.weapons.no_spread);
 
 		components::button("Get All Weapons", []
 		{
@@ -111,13 +111,13 @@ namespace big
 			}
 		});
 
-		ImGui::SliderFloat("Damage Multiplier", &g->weapons.increased_damage, 1.f, 10.f, "%.1f");
+		ImGui::SliderFloat("Damage Multiplier", &g.weapons.increased_damage, 1.f, 10.f, "%.1f");
 
 		ImGui::Separator();
 
 		components::sub_title("Custom Weapons");
 
-		CustomWeapon selected = g->weapons.custom_weapon;
+		CustomWeapon selected = g.weapons.custom_weapon;
 
 		if (ImGui::BeginCombo("Weapon", custom_weapons[(int)selected].name))
 		{
@@ -125,7 +125,7 @@ namespace big
 			{
 				if (ImGui::Selectable(weapon.name, weapon.id == selected))
 				{
-					g->weapons.custom_weapon = weapon.id;
+					g.weapons.custom_weapon = weapon.id;
 				}
 
 				if (weapon.id == selected)
@@ -142,10 +142,10 @@ namespace big
 		case CustomWeapon::VEHICLE_GUN:
 			// this some ugly ass looking code
 			static char vehicle_gun[12];
-			std::memcpy(vehicle_gun, g->weapons.vehicle_gun_model.c_str(), 12);
+			std::memcpy(vehicle_gun, g.weapons.vehicle_gun_model.c_str(), 12);
 			if (ImGui::InputTextWithHint("Shooting Model", "Name of the vehicle model", vehicle_gun, sizeof(vehicle_gun)))
 			{
-				g->weapons.vehicle_gun_model = vehicle_gun;
+				g.weapons.vehicle_gun_model = vehicle_gun;
 			}
 			if (ImGui::IsItemActive())
 			{

--- a/src/views/self/view_weapons.cpp
+++ b/src/views/self/view_weapons.cpp
@@ -140,12 +140,20 @@ namespace big
 		switch (selected)
 		{
 		case CustomWeapon::VEHICLE_GUN:
-			g->weapons.vehicle_gun_model.reserve(12);
-			components::input_text_with_hint(
-				"Shooting Model",
-				"Name of the vehicle model",
-				g->weapons.vehicle_gun_model.data(), 12
-			);
+			// this some ugly ass looking code
+			static char vehicle_gun[12];
+			std::memcpy(vehicle_gun, g->weapons.vehicle_gun_model.c_str(), 12);
+			if (ImGui::InputTextWithHint("Shooting Model", "Name of the vehicle model", vehicle_gun, sizeof(vehicle_gun)))
+			{
+				g->weapons.vehicle_gun_model = vehicle_gun;
+			}
+			if (ImGui::IsItemActive())
+			{
+				g_fiber_pool->queue_job([]
+				{
+					PAD::DISABLE_ALL_CONTROL_ACTIONS(0);
+				});
+			}
 
 			break;
 		}

--- a/src/views/self/view_weapons.cpp
+++ b/src/views/self/view_weapons.cpp
@@ -140,10 +140,11 @@ namespace big
 		switch (selected)
 		{
 		case CustomWeapon::VEHICLE_GUN:
+			g->weapons.vehicle_gun_model.reserve(12);
 			components::input_text_with_hint(
 				"Shooting Model",
 				"Name of the vehicle model",
-				g->weapons.vehicle_gun_model, sizeof(g->weapons.vehicle_gun_model)
+				g->weapons.vehicle_gun_model.data(), 12
 			);
 
 			break;

--- a/src/views/settings/view_context_menu_settings.cpp
+++ b/src/views/settings/view_context_menu_settings.cpp
@@ -5,35 +5,35 @@ namespace big
 {
 	void view::context_menu_settings()
 	{
-		ImGui::Checkbox("Context Menu Enabled", &g->context_menu.enabled);
+		ImGui::Checkbox("Context Menu Enabled", &g.context_menu.enabled);
 
-		if (g->context_menu.enabled)
+		if (g.context_menu.enabled)
 		{
 			ImGui::Text("Allowed Entity Types:");
-			ImGui::CheckboxFlags("Object", reinterpret_cast<int*>(&g->context_menu.allowed_entity_types), static_cast<int>(ContextEntityType::OBJECT));
+			ImGui::CheckboxFlags("Object", reinterpret_cast<int*>(&g.context_menu.allowed_entity_types), static_cast<int>(ContextEntityType::OBJECT));
 			ImGui::SameLine();
-			ImGui::CheckboxFlags("Ped", reinterpret_cast<int*>(&g->context_menu.allowed_entity_types), static_cast<int>(ContextEntityType::PED));
+			ImGui::CheckboxFlags("Ped", reinterpret_cast<int*>(&g.context_menu.allowed_entity_types), static_cast<int>(ContextEntityType::PED));
 			ImGui::SameLine();
-			ImGui::CheckboxFlags("Player", reinterpret_cast<int*>(&g->context_menu.allowed_entity_types), static_cast<int>(ContextEntityType::PLAYER));
+			ImGui::CheckboxFlags("Player", reinterpret_cast<int*>(&g.context_menu.allowed_entity_types), static_cast<int>(ContextEntityType::PLAYER));
 			ImGui::SameLine();
-			ImGui::CheckboxFlags("Vehicle", reinterpret_cast<int*>(&g->context_menu.allowed_entity_types), static_cast<int>(ContextEntityType::VEHICLE));
+			ImGui::CheckboxFlags("Vehicle", reinterpret_cast<int*>(&g.context_menu.allowed_entity_types), static_cast<int>(ContextEntityType::VEHICLE));
 
-			static ImVec4 selected_option_color = ImGui::ColorConvertU32ToFloat4(g->context_menu.selected_option_color);
+			static ImVec4 selected_option_color = ImGui::ColorConvertU32ToFloat4(g.context_menu.selected_option_color);
 			ImGui::Text("Selected Option Color:");
 			if (ImGui::ColorEdit4("###BSelected Option Color##cm_picker", (float*)&selected_option_color, ImGuiColorEditFlags_InputRGB | ImGuiColorEditFlags_NoSidePreview))
 			{
-				g->context_menu.selected_option_color = ImGui::ColorConvertFloat4ToU32(selected_option_color);
+				g.context_menu.selected_option_color = ImGui::ColorConvertFloat4ToU32(selected_option_color);
 			}
 
-			ImGui::Checkbox("Bounding Box Enabled", &g->context_menu.bounding_box_enabled);
+			ImGui::Checkbox("Bounding Box Enabled", &g.context_menu.bounding_box_enabled);
 
-			if (g->context_menu.bounding_box_enabled)
+			if (g.context_menu.bounding_box_enabled)
 			{
-				static ImVec4 bounding_box_color = ImGui::ColorConvertU32ToFloat4(g->context_menu.bounding_box_color);
+				static ImVec4 bounding_box_color = ImGui::ColorConvertU32ToFloat4(g.context_menu.bounding_box_color);
 				ImGui::Text("Bounding Box Color:");
 				if (ImGui::ColorEdit4("###Bounding Box Color##cm_picker", (float*)&bounding_box_color, ImGuiColorEditFlags_InputRGB | ImGuiColorEditFlags_NoSidePreview))
 				{
-					g->context_menu.bounding_box_color = ImGui::ColorConvertFloat4ToU32(bounding_box_color);
+					g.context_menu.bounding_box_color = ImGui::ColorConvertFloat4ToU32(bounding_box_color);
 				}
 			}
 		}

--- a/src/views/settings/view_esp_settings.cpp
+++ b/src/views/settings/view_esp_settings.cpp
@@ -4,76 +4,76 @@ namespace big
 {
 	void view::esp_settings()
 	{
-		ImGui::Checkbox("ESP Enabled", &g->esp.enabled);
+		ImGui::Checkbox("ESP Enabled", &g.esp.enabled);
 
-		if (g->esp.enabled)
+		if (g.esp.enabled)
 		{
-			ImGui::Checkbox("Hide Self", &g->esp.hide_self);
+			ImGui::Checkbox("Hide Self", &g.esp.hide_self);
 
 			ImGui::Text("Global Render Distance (min, max)");
-			ImGui::SliderFloat2("###Global Render Distance", g->esp.global_render_distance, 0.f, 1500.f);
+			ImGui::SliderFloat2("###Global Render Distance", g.esp.global_render_distance, 0.f, 1500.f);
 
-			ImGui::Checkbox("Tracer", &g->esp.tracer);
-			if (g->esp.tracer) {
+			ImGui::Checkbox("Tracer", &g.esp.tracer);
+			if (g.esp.tracer) {
 				ImGui::Text("Tracer Draw Position (x, y)");
-				ImGui::SliderFloat2("###Draw Position", g->esp.tracer_draw_position, 0.f, 1.f);
+				ImGui::SliderFloat2("###Draw Position", g.esp.tracer_draw_position, 0.f, 1.f);
 				ImGui::Text("Tracer Render Distance (min, max)");
-				ImGui::SliderFloat2("###Tracer Render Distance", g->esp.tracer_render_distance, g->esp.global_render_distance[0], g->esp.global_render_distance[1]);
+				ImGui::SliderFloat2("###Tracer Render Distance", g.esp.tracer_render_distance, g.esp.global_render_distance[0], g.esp.global_render_distance[1]);
 			}
 
-			ImGui::Checkbox("Box ESP", &g->esp.box);
-			if (g->esp.box) {
+			ImGui::Checkbox("Box ESP", &g.esp.box);
+			if (g.esp.box) {
 				ImGui::Text("Box Render Distance (min, max)");
-				ImGui::SliderFloat2("###Box Render Distance", g->esp.box_render_distance, g->esp.global_render_distance[0], g->esp.global_render_distance[1]);
+				ImGui::SliderFloat2("###Box Render Distance", g.esp.box_render_distance, g.esp.global_render_distance[0], g.esp.global_render_distance[1]);
 			}
 
-			ImGui::Checkbox("Show Player Name", &g->esp.name);
-			ImGui::Checkbox("Show Player Distance", &g->esp.distance);
-			ImGui::Checkbox("Show Player Godmode", &g->esp.god);
-			ImGui::Checkbox("Show Player Health", &g->esp.health);
-			ImGui::Checkbox("Show Player Armor", &g->esp.armor);
+			ImGui::Checkbox("Show Player Name", &g.esp.name);
+			ImGui::Checkbox("Show Player Distance", &g.esp.distance);
+			ImGui::Checkbox("Show Player Godmode", &g.esp.god);
+			ImGui::Checkbox("Show Player Health", &g.esp.health);
+			ImGui::Checkbox("Show Player Armor", &g.esp.armor);
 
-			ImGui::Checkbox("Should ESP Color Change with Distance", &g->esp.change_esp_color_from_dist);
-			if (g->esp.health)
-				ImGui::Checkbox("Should Healthbar Scale with Distance", &g->esp.scale_health_from_dist);
+			ImGui::Checkbox("Should ESP Color Change with Distance", &g.esp.change_esp_color_from_dist);
+			if (g.esp.health)
+				ImGui::Checkbox("Should Healthbar Scale with Distance", &g.esp.scale_health_from_dist);
 
-			if (g->esp.armor)
-				ImGui::Checkbox("Should Armorbar Scale with Distance", &g->esp.scale_armor_from_dist);
+			if (g.esp.armor)
+				ImGui::Checkbox("Should Armorbar Scale with Distance", &g.esp.scale_armor_from_dist);
 
-			static ImVec4 col_enemy = ImGui::ColorConvertU32ToFloat4(g->esp.enemy_color);
-			static ImVec4 col_enemy_near = ImGui::ColorConvertU32ToFloat4(g->esp.enemy_near_color);
-			static ImVec4 col_default = ImGui::ColorConvertU32ToFloat4(g->esp.default_color);
-			static ImVec4 col_friend = ImGui::ColorConvertU32ToFloat4(g->esp.friend_color);
+			static ImVec4 col_enemy = ImGui::ColorConvertU32ToFloat4(g.esp.enemy_color);
+			static ImVec4 col_enemy_near = ImGui::ColorConvertU32ToFloat4(g.esp.enemy_near_color);
+			static ImVec4 col_default = ImGui::ColorConvertU32ToFloat4(g.esp.default_color);
+			static ImVec4 col_friend = ImGui::ColorConvertU32ToFloat4(g.esp.friend_color);
 
 			ImGui::Text("Distance threshold (min, max)");
-			ImGui::SliderFloat2("###Distance threshold", g->esp.distance_threshold, g->esp.global_render_distance[0], g->esp.global_render_distance[1]);
+			ImGui::SliderFloat2("###Distance threshold", g.esp.distance_threshold, g.esp.global_render_distance[0], g.esp.global_render_distance[1]);
 
 			if (ImGui::TreeNode("ESP Colors (RGBA)"))
 			{
-				if (g->esp.change_esp_color_from_dist) {
+				if (g.esp.change_esp_color_from_dist) {
 					ImGui::Text("Enemy Close Color:");
 					if (ImGui::ColorEdit4("###Enemy ESP Color##esp_picker", (float*)&col_enemy, ImGuiColorEditFlags_InputRGB | ImGuiColorEditFlags_NoSidePreview))
 					{
-						g->esp.enemy_color = ImGui::ColorConvertFloat4ToU32(col_enemy);
+						g.esp.enemy_color = ImGui::ColorConvertFloat4ToU32(col_enemy);
 					}
 
 					ImGui::Text("Enemy Near Color:");
 					if (ImGui::ColorEdit4("###Enemy Near ESP Color##esp_picker", (float*)&col_enemy_near, ImGuiColorEditFlags_InputRGB | ImGuiColorEditFlags_NoSidePreview))
 					{
-						g->esp.enemy_near_color = ImGui::ColorConvertFloat4ToU32(col_enemy_near);
+						g.esp.enemy_near_color = ImGui::ColorConvertFloat4ToU32(col_enemy_near);
 					}
 				}
 
 				ImGui::Text("Default Color:");
 				if (ImGui::ColorEdit4("###Default ESP Color##esp_picker", (float*)&col_default, ImGuiColorEditFlags_InputRGB | ImGuiColorEditFlags_NoSidePreview))
 				{
-					g->esp.default_color = ImGui::ColorConvertFloat4ToU32(col_default);
+					g.esp.default_color = ImGui::ColorConvertFloat4ToU32(col_default);
 				}
 
 				ImGui::Text("Friendly Color:");
 				if (ImGui::ColorEdit4("###Friend ESP Color##friend_picker", (float*)&col_friend, ImGuiColorEditFlags_InputRGB | ImGuiColorEditFlags_NoSidePreview))
 				{
-					g->esp.friend_color = ImGui::ColorConvertFloat4ToU32(col_friend);
+					g.esp.friend_color = ImGui::ColorConvertFloat4ToU32(col_friend);
 				}
 			}
 		}

--- a/src/views/settings/view_gui_settings.cpp
+++ b/src/views/settings/view_gui_settings.cpp
@@ -6,18 +6,18 @@ namespace big
 	void view::gui_settings()
 	{
 		components::sub_title("UI Scale");
-		ImGui::SliderFloat("##gui-scale", &g->window.gui_scale, 1.f, 1.5f, "%.2f");
+		ImGui::SliderFloat("##gui-scale", &g.window.gui_scale, 1.f, 1.5f, "%.2f");
 		ImGui::SameLine();
 		if (ImGui::Button("Apply##gui-scale"))
-			g_renderer->rescale(g->window.gui_scale);
+			g_renderer->rescale(g.window.gui_scale);
 		if (ImGui::IsItemHovered())
 			ImGui::SetTooltip("Changing the UI scale may break rendering and require you to unload and inject YimMenu again.");
 
 		components::sub_title("Colors");
-		static ImVec4 col_gui = ImGui::ColorConvertU32ToFloat4(g->window.color);
+		static ImVec4 col_gui = ImGui::ColorConvertU32ToFloat4(g.window.color);
 		if (ImGui::ColorEdit4("Gui Color##gui_picker", (float*)&col_gui, ImGuiColorEditFlags_InputRGB | ImGuiColorEditFlags_NoSidePreview))
 		{
-			g->window.color = ImGui::ColorConvertFloat4ToU32(col_gui);
+			g.window.color = ImGui::ColorConvertFloat4ToU32(col_gui);
 		}
 	}
 

--- a/src/views/settings/view_notification_settings.cpp
+++ b/src/views/settings/view_notification_settings.cpp
@@ -2,7 +2,7 @@
 
 namespace big
 {
-	void draw_pair_option(const std::string_view name, decltype(g->notifications.gta_thread_kill)& option)
+	void draw_pair_option(const std::string_view name, decltype(g.notifications.gta_thread_kill)& option)
 	{
 		ImGui::Text("%s", name.data());
 
@@ -16,25 +16,25 @@ namespace big
 	{
 		components::sub_title("GTA Threads");
 
-		draw_pair_option("Terminate", g->notifications.gta_thread_kill);
-		draw_pair_option("Start", g->notifications.gta_thread_start);
+		draw_pair_option("Terminate", g.notifications.gta_thread_kill);
+		draw_pair_option("Start", g.notifications.gta_thread_start);
 		
 		components::sub_title("Network Player Manager");
 
 		ImGui::Text("Player Join");
 
-		ImGui::Checkbox("Above Map", &g->notifications.player_join.above_map);
-		ImGui::Checkbox("Log", &g->notifications.player_join.log);
-		ImGui::Checkbox("Notify", &g->notifications.player_join.notify);
+		ImGui::Checkbox("Above Map", &g.notifications.player_join.above_map);
+		ImGui::Checkbox("Log", &g.notifications.player_join.log);
+		ImGui::Checkbox("Notify", &g.notifications.player_join.notify);
 
-		draw_pair_option("Player Leave", g->notifications.player_leave);
+		draw_pair_option("Player Leave", g.notifications.player_leave);
 
-		draw_pair_option("Init", g->notifications.network_player_mgr_init);
-		draw_pair_option("Shutdown", g->notifications.network_player_mgr_shutdown);
+		draw_pair_option("Init", g.notifications.network_player_mgr_init);
+		draw_pair_option("Shutdown", g.notifications.network_player_mgr_shutdown);
 
 		components::sub_title("Received Event");
 
-		auto& received_event = g->notifications.received_event;
+		auto& received_event = g.notifications.received_event;
 
 		ImGui::BeginGroup();
 		draw_pair_option("Clear Ped Tasks", received_event.clear_ped_task);
@@ -52,7 +52,7 @@ namespace big
 
 		components::sub_title("Script Event Handler");
 
-		auto& script_event_handler = g->notifications.script_event_handler;
+		auto& script_event_handler = g.notifications.script_event_handler;
 
 		ImGui::BeginGroup();
 		draw_pair_option("Bounty", script_event_handler.bounty);
@@ -100,11 +100,11 @@ namespace big
 
 		components::sub_title("Other");
 		
-		draw_pair_option("Reports", g->notifications.reports);
-		draw_pair_option("Transaction Error / Rate Limit", g->notifications.transaction_rate_limit);
-		draw_pair_option("Mismatch sync type", g->notifications.mismatch_sync_type);
-		draw_pair_option("Out of allowed range sync type", g->notifications.out_of_allowed_range_sync_type);
-		draw_pair_option("Invalid sync", g->notifications.invalid_sync);
+		draw_pair_option("Reports", g.notifications.reports);
+		draw_pair_option("Transaction Error / Rate Limit", g.notifications.transaction_rate_limit);
+		draw_pair_option("Mismatch sync type", g.notifications.mismatch_sync_type);
+		draw_pair_option("Out of allowed range sync type", g.notifications.out_of_allowed_range_sync_type);
+		draw_pair_option("Invalid sync", g.notifications.invalid_sync);
 	}
 
 }

--- a/src/views/settings/view_protection_settings.cpp
+++ b/src/views/settings/view_protection_settings.cpp
@@ -5,49 +5,49 @@ namespace big
 	void view::protection_settings()
 	{
 		ImGui::BeginGroup();
-		ImGui::Checkbox("Bounty", &g->protections.script_events.bounty);
-		ImGui::Checkbox("CEO Ban", &g->protections.script_events.ceo_ban);
-		ImGui::Checkbox("CEO Kick", &g->protections.script_events.ceo_kick);
-		ImGui::Checkbox("CEO Money", &g->protections.script_events.ceo_money);
-		ImGui::Checkbox("TSE Crash", &g->protections.script_events.crash);
-		ImGui::Checkbox("Fake Deposit", &g->protections.script_events.fake_deposit);
-		ImGui::Checkbox("Force Mission", &g->protections.script_events.force_mission);
+		ImGui::Checkbox("Bounty", &g.protections.script_events.bounty);
+		ImGui::Checkbox("CEO Ban", &g.protections.script_events.ceo_ban);
+		ImGui::Checkbox("CEO Kick", &g.protections.script_events.ceo_kick);
+		ImGui::Checkbox("CEO Money", &g.protections.script_events.ceo_money);
+		ImGui::Checkbox("TSE Crash", &g.protections.script_events.crash);
+		ImGui::Checkbox("Fake Deposit", &g.protections.script_events.fake_deposit);
+		ImGui::Checkbox("Force Mission", &g.protections.script_events.force_mission);
 		ImGui::EndGroup();
 
 		ImGui::SameLine();
 
 		ImGui::BeginGroup();
-		ImGui::Checkbox("Force Teleport", &g->protections.script_events.force_teleport);
-		ImGui::Checkbox("GTA Banner", &g->protections.script_events.gta_banner);
-		ImGui::Checkbox("MC Teleport", &g->protections.script_events.mc_teleport);
-		ImGui::Checkbox("Network Bail", &g->protections.script_events.network_bail);
-		ImGui::Checkbox("Personal Vehicle Destroyed", &g->protections.script_events.personal_vehicle_destroyed);
-		ImGui::Checkbox("Remote Off Radar", &g->protections.script_events.remote_off_radar);
-		ImGui::Checkbox("Rotate Cam", &g->protections.script_events.rotate_cam);
+		ImGui::Checkbox("Force Teleport", &g.protections.script_events.force_teleport);
+		ImGui::Checkbox("GTA Banner", &g.protections.script_events.gta_banner);
+		ImGui::Checkbox("MC Teleport", &g.protections.script_events.mc_teleport);
+		ImGui::Checkbox("Network Bail", &g.protections.script_events.network_bail);
+		ImGui::Checkbox("Personal Vehicle Destroyed", &g.protections.script_events.personal_vehicle_destroyed);
+		ImGui::Checkbox("Remote Off Radar", &g.protections.script_events.remote_off_radar);
+		ImGui::Checkbox("Rotate Cam", &g.protections.script_events.rotate_cam);
 		ImGui::EndGroup();
 
 		ImGui::SameLine();
 
 		ImGui::BeginGroup();
-		ImGui::Checkbox("Send to Cutscene", &g->protections.script_events.send_to_cutscene);
-		ImGui::Checkbox("Send to Location", &g->protections.script_events.send_to_location);
-		ImGui::Checkbox("Sound Spam", &g->protections.script_events.sound_spam);
-		ImGui::Checkbox("Spectate", &g->protections.script_events.spectate);
-		ImGui::Checkbox("Transaction Error", &g->protections.script_events.transaction_error);
-		ImGui::Checkbox("Vehicle Kick", &g->protections.script_events.vehicle_kick);
-		ImGui::Checkbox("Wanted Level", &g->protections.script_events.clear_wanted_level);
+		ImGui::Checkbox("Send to Cutscene", &g.protections.script_events.send_to_cutscene);
+		ImGui::Checkbox("Send to Location", &g.protections.script_events.send_to_location);
+		ImGui::Checkbox("Sound Spam", &g.protections.script_events.sound_spam);
+		ImGui::Checkbox("Spectate", &g.protections.script_events.spectate);
+		ImGui::Checkbox("Transaction Error", &g.protections.script_events.transaction_error);
+		ImGui::Checkbox("Vehicle Kick", &g.protections.script_events.vehicle_kick);
+		ImGui::Checkbox("Wanted Level", &g.protections.script_events.clear_wanted_level);
 		ImGui::EndGroup();
 
 		ImGui::SameLine();
 
 		ImGui::BeginGroup();
-		ImGui::Checkbox("Teleport To Warehouse", &g->protections.script_events.teleport_to_warehouse);
-		ImGui::Checkbox("Start Activity", &g->protections.script_events.start_activity);
-		components::script_patch_checkbox("Script Host Kick", &g->protections.script_host_kick);
-		ImGui::Checkbox("RID Join", &g->protections.rid_join);
+		ImGui::Checkbox("Teleport To Warehouse", &g.protections.script_events.teleport_to_warehouse);
+		ImGui::Checkbox("Start Activity", &g.protections.script_events.start_activity);
+		components::script_patch_checkbox("Script Host Kick", &g.protections.script_host_kick);
+		ImGui::Checkbox("RID Join", &g.protections.rid_join);
 		if (ImGui::IsItemHovered())
 			ImGui::SetTooltip("This will block anyone trying to join you through Rockstar ID, including your friends");
-		ImGui::Checkbox("Lessen Breakup Kicks As Host", &g->protections.lessen_breakups);
+		ImGui::Checkbox("Lessen Breakup Kicks As Host", &g.protections.lessen_breakups);
 		if (ImGui::IsItemHovered())
 			ImGui::SetTooltip("Attacker must join after you have become host for this to work. There are anti-cheat concerns with this feature");
 		ImGui::EndGroup();

--- a/src/views/settings/view_settings.cpp
+++ b/src/views/settings/view_settings.cpp
@@ -27,23 +27,23 @@ namespace big
 	void view::settings()
 	{
 		components::sub_title("Misc");
-		ImGui::Checkbox("Enable Dev DLC", &g->settings.dev_dlc);
+		ImGui::Checkbox("Enable Dev DLC", &g.settings.dev_dlc);
 
 		ImGui::Separator();
 		components::sub_title("Hotkeys");
 
 		ImGui::PushItemWidth(350.f);
 
-		if (ImGui::Hotkey("Menu Toggle", &g->settings.hotkeys.menu_toggle))
-			g->settings.hotkeys.editing_menu_toggle = true; // make our menu reappear
+		if (ImGui::Hotkey("Menu Toggle", &g.settings.hotkeys.menu_toggle))
+			g.settings.hotkeys.editing_menu_toggle = true; // make our menu reappear
 
-		if (ImGui::Hotkey("Teleport to waypoint", &g->settings.hotkeys.teleport_waypoint))
-			g_hotkey_service->update_hotkey("waypoint", g->settings.hotkeys.teleport_waypoint);
-		if (ImGui::Hotkey("Teleport to objective", &g->settings.hotkeys.teleport_objective))
-			g_hotkey_service->update_hotkey("objective", g->settings.hotkeys.teleport_objective);
+		if (ImGui::Hotkey("Teleport to waypoint", &g.settings.hotkeys.teleport_waypoint))
+			g_hotkey_service->update_hotkey("waypoint", g.settings.hotkeys.teleport_waypoint);
+		if (ImGui::Hotkey("Teleport to objective", &g.settings.hotkeys.teleport_objective))
+			g_hotkey_service->update_hotkey("objective", g.settings.hotkeys.teleport_objective);
 
-		if (ImGui::Hotkey("Toggle Noclip", &g->settings.hotkeys.noclip))
-			g_hotkey_service->update_hotkey("noclip", g->settings.hotkeys.noclip);
+		if (ImGui::Hotkey("Toggle Noclip", &g.settings.hotkeys.noclip))
+			g_hotkey_service->update_hotkey("noclip", g.settings.hotkeys.noclip);
 
 
 		ImGui::PopItemWidth();

--- a/src/views/vehicle/view_fun_vehicle.cpp
+++ b/src/views/vehicle/view_fun_vehicle.cpp
@@ -85,32 +85,32 @@ namespace big
 
 		components::sub_title("Auto Drive");
 		{
-			float auto_drive_speed_user_unit = vehicle::mps_to_speed(g->vehicle.auto_drive_speed, g->vehicle.speed_unit);
+			float auto_drive_speed_user_unit = vehicle::mps_to_speed(g.vehicle.auto_drive_speed, g.vehicle.speed_unit);
 			if (ImGui::SliderFloat(
-				std::format("Top Speed({})", speed_unit_strings[(int)g->vehicle.speed_unit]).c_str(),
+				std::format("Top Speed({})", speed_unit_strings[(int)g.vehicle.speed_unit]).c_str(),
 				&auto_drive_speed_user_unit,
-				vehicle::mps_to_speed(0.f, g->vehicle.speed_unit),
-				vehicle::mps_to_speed(150.f, g->vehicle.speed_unit),
+				vehicle::mps_to_speed(0.f, g.vehicle.speed_unit),
+				vehicle::mps_to_speed(150.f, g.vehicle.speed_unit),
 				"%.1f"
 			)) {
-				g->vehicle.auto_drive_speed = vehicle::speed_to_mps(auto_drive_speed_user_unit, g->vehicle.speed_unit);
+				g.vehicle.auto_drive_speed = vehicle::speed_to_mps(auto_drive_speed_user_unit, g.vehicle.speed_unit);
 			}
 
 			static constexpr char const* driving_style_names[] = { "Law-Abiding", "The Road Is Yours" };
-			if (ImGui::BeginCombo("Driving Style", driving_style_names[(int)g->vehicle.auto_drive_style]))
+			if (ImGui::BeginCombo("Driving Style", driving_style_names[(int)g.vehicle.auto_drive_style]))
 			{
 				for (int i = 0; i < 2; i++)
 				{
-					if (ImGui::Selectable(driving_style_names[i], g->vehicle.auto_drive_style == (AutoDriveStyle)i))
+					if (ImGui::Selectable(driving_style_names[i], g.vehicle.auto_drive_style == (AutoDriveStyle)i))
 					{
-						g->vehicle.auto_drive_style = (AutoDriveStyle)i;
+						g.vehicle.auto_drive_style = (AutoDriveStyle)i;
 						g_notification_service->push_warning(
 							"Auto Drive",
 							std::format("Driving style set to {}.", driving_style_names[i])
 						);
 					}
 
-					if (g->vehicle.auto_drive_style == (AutoDriveStyle)i)
+					if (g.vehicle.auto_drive_style == (AutoDriveStyle)i)
 					{
 						ImGui::SetItemDefaultFocus();
 					}
@@ -120,19 +120,19 @@ namespace big
 			}
 
 			if (components::button("To Objective")) {
-				g->vehicle.auto_drive_destination = AutoDriveDestination::OBJECTITVE;
+				g.vehicle.auto_drive_destination = AutoDriveDestination::OBJECTITVE;
 			}
 			ImGui::SameLine();
 			if (components::button("To Waypoint")) {
-				g->vehicle.auto_drive_destination = AutoDriveDestination::WAYPOINT;
+				g.vehicle.auto_drive_destination = AutoDriveDestination::WAYPOINT;
 			}
 			ImGui::SameLine();
 			if (components::button("Wander")) {
-				g->vehicle.auto_drive_destination = AutoDriveDestination::WANDER;
+				g.vehicle.auto_drive_destination = AutoDriveDestination::WANDER;
 			}
 			ImGui::SameLine();
 			if (components::button("Emergency Stop")) {
-				g->vehicle.auto_drive_destination = AutoDriveDestination::EMERGENCY_STOP;
+				g.vehicle.auto_drive_destination = AutoDriveDestination::EMERGENCY_STOP;
 			}
 		}
 		ImGui::Separator();
@@ -140,26 +140,26 @@ namespace big
 
 		components::sub_title("Rainbow Paint");
 		{
-			ImGui::Checkbox("Primary", &g->vehicle.rainbow_paint.primary);
+			ImGui::Checkbox("Primary", &g.vehicle.rainbow_paint.primary);
 			ImGui::SameLine();
-			ImGui::Checkbox("Secondary", &g->vehicle.rainbow_paint.secondary);
+			ImGui::Checkbox("Secondary", &g.vehicle.rainbow_paint.secondary);
 			ImGui::SameLine();
-			ImGui::Checkbox("Neon", &g->vehicle.rainbow_paint.neon);
+			ImGui::Checkbox("Neon", &g.vehicle.rainbow_paint.neon);
 			ImGui::SameLine();
-			ImGui::Checkbox("Smoke", &g->vehicle.rainbow_paint.smoke);
+			ImGui::Checkbox("Smoke", &g.vehicle.rainbow_paint.smoke);
 
 			static constexpr char const* rgb_types[] = { "Off", "Fade", "Spasm" };
 
 			ImGui::SetNextItemWidth(120);
-			if (ImGui::BeginCombo("RGB Type", rgb_types[(int)g->vehicle.rainbow_paint.type]))
+			if (ImGui::BeginCombo("RGB Type", rgb_types[(int)g.vehicle.rainbow_paint.type]))
 			{
 				for (int i = 0; i < 3; i++)
 				{
-					bool itemSelected = (int)g->vehicle.rainbow_paint.type == i;
+					bool itemSelected = (int)g.vehicle.rainbow_paint.type == i;
 
 					if (ImGui::Selectable(rgb_types[i], itemSelected))
 					{
-						g->vehicle.rainbow_paint.type = (RainbowPaintType)i;
+						g.vehicle.rainbow_paint.type = (RainbowPaintType)i;
 					}
 
 					if (itemSelected)
@@ -170,25 +170,25 @@ namespace big
 
 				ImGui::EndCombo();
 			}
-			if (g->vehicle.rainbow_paint.type != RainbowPaintType::Off)
+			if (g.vehicle.rainbow_paint.type != RainbowPaintType::Off)
 			{
 				ImGui::SameLine();
 				ImGui::SetNextItemWidth(150);
-				ImGui::SliderInt("RGB Speed", &g->vehicle.rainbow_paint.speed, 1, 10);
+				ImGui::SliderInt("RGB Speed", &g.vehicle.rainbow_paint.speed, 1, 10);
 			}
 		}
 		ImGui::Separator();
 
 		static constexpr char const* boost_behaviors[] = { "Default", "Instant Refill", "Infinite" };
-		if (ImGui::BeginCombo("Boost Behavior", boost_behaviors[static_cast<int>(g->vehicle.boost_behavior)]))
+		if (ImGui::BeginCombo("Boost Behavior", boost_behaviors[static_cast<int>(g.vehicle.boost_behavior)]))
 		{
 			for (int i = 0; i < 3; i++)
 			{
-				bool itemSelected = g->vehicle.boost_behavior == static_cast<eBoostBehaviors>(i);
+				bool itemSelected = g.vehicle.boost_behavior == static_cast<eBoostBehaviors>(i);
 
 				if (ImGui::Selectable(boost_behaviors[i], itemSelected))
 				{
-					g->vehicle.boost_behavior = static_cast<eBoostBehaviors>(i);
+					g.vehicle.boost_behavior = static_cast<eBoostBehaviors>(i);
 				}
 
 				if (itemSelected)
@@ -207,27 +207,27 @@ namespace big
 		{
 			ImGui::BeginGroup();
 
-			ImGui::Checkbox("Enabled", &g->vehicle.fly.enabled);
-			ImGui::Checkbox("Don't Stop", &g->vehicle.fly.dont_stop);
+			ImGui::Checkbox("Enabled", &g.vehicle.fly.enabled);
+			ImGui::Checkbox("Don't Stop", &g.vehicle.fly.dont_stop);
 
 			ImGui::EndGroup();
 			ImGui::SameLine();
 			ImGui::BeginGroup();
 
-			ImGui::Checkbox("Disable Collision", &g->vehicle.fly.no_collision);
-			ImGui::Checkbox("Stop On Exit", &g->vehicle.fly.stop_on_exit);
+			ImGui::Checkbox("Disable Collision", &g.vehicle.fly.no_collision);
+			ImGui::Checkbox("Stop On Exit", &g.vehicle.fly.stop_on_exit);
 
 			ImGui::EndGroup();
 
-			float fly_speed_user_unit = vehicle::mps_to_speed(g->vehicle.fly.speed, g->vehicle.speed_unit);
+			float fly_speed_user_unit = vehicle::mps_to_speed(g.vehicle.fly.speed, g.vehicle.speed_unit);
 			if (ImGui::SliderFloat(
-				std::format("Speed({})", speed_unit_strings[(int)g->vehicle.speed_unit]).c_str(),
+				std::format("Speed({})", speed_unit_strings[(int)g.vehicle.speed_unit]).c_str(),
 				&fly_speed_user_unit,
-				vehicle::mps_to_speed(0.f, g->vehicle.speed_unit),
-				vehicle::mps_to_speed(150.f, g->vehicle.speed_unit),
+				vehicle::mps_to_speed(0.f, g.vehicle.speed_unit),
+				vehicle::mps_to_speed(150.f, g.vehicle.speed_unit),
 				"%.1f"
 			)) {
-				g->vehicle.fly.speed = vehicle::speed_to_mps(fly_speed_user_unit, g->vehicle.speed_unit);
+				g.vehicle.fly.speed = vehicle::speed_to_mps(fly_speed_user_unit, g.vehicle.speed_unit);
 			}
 		}
 	}

--- a/src/views/vehicle/view_lsc.cpp
+++ b/src/views/vehicle/view_lsc.cpp
@@ -195,7 +195,7 @@ namespace big
 		}
 
 		components::button("Start LS Customs", [] {
-			g->vehicle.ls_customs = true;
+			g.vehicle.ls_customs = true;
 		});
 		ImGui::SameLine();
 		if (components::button("Max Vehicle"))

--- a/src/views/vehicle/view_persist_car.cpp
+++ b/src/views/vehicle/view_persist_car.cpp
@@ -27,7 +27,7 @@ namespace big
 			{
 				g_notification_service->push_warning("Persist Car", "Vehicle failed to spawn, there is most likely too many spawned vehicles in the area");
 			}
-			else if (g->spawn_vehicle.spawn_inside)
+			else if (g.spawn_vehicle.spawn_inside)
 				teleport::into_vehicle(vehicle);
 
 			selected_vehicle_file.clear();

--- a/src/views/vehicle/view_pv.cpp
+++ b/src/views/vehicle/view_pv.cpp
@@ -11,30 +11,30 @@ namespace big
 	void view::pv() {
 		ImGui::SetWindowSize({ 0.f, (float)*g_pointers->m_resolution_y }, ImGuiCond_Always);
 
-		if (ImGui::Checkbox("Preview", &g->clone_pv.preview_vehicle))
+		if (ImGui::Checkbox("Preview", &g.clone_pv.preview_vehicle))
 		{
-			if (!g->clone_pv.preview_vehicle)
+			if (!g.clone_pv.preview_vehicle)
 			{
 				g_model_preview_service->stop_preview();
 			}
 		}
 		ImGui::SameLine();
-		ImGui::Checkbox("Spawn In", &g->clone_pv.spawn_inside);
+		ImGui::Checkbox("Spawn In", &g.clone_pv.spawn_inside);
 		ImGui::SameLine();
 
 		static char plate_buf[9] = { 0 };
 		int num_of_rows = 3;
 
-		ImGui::Checkbox("Spawn Clone", &g->clone_pv.spawn_clone);
-		if (g->clone_pv.spawn_clone)
+		ImGui::Checkbox("Spawn Clone", &g.clone_pv.spawn_clone);
+		if (g.clone_pv.spawn_clone)
 		{
 			num_of_rows = 5;
 
-			ImGui::Checkbox("Spawn Maxed", &g->clone_pv.spawn_maxed);
+			ImGui::Checkbox("Spawn Maxed", &g.clone_pv.spawn_maxed);
 
 			ImGui::SameLine();
-			ImGui::Checkbox("Clone PV Plate", &g->clone_pv.clone_plate);
-			if (g->clone_pv.clone_plate)
+			ImGui::Checkbox("Clone PV Plate", &g.clone_pv.clone_plate);
+			if (g.clone_pv.clone_plate)
 			{
 				num_of_rows = 4;
 			}
@@ -42,9 +42,9 @@ namespace big
 			{
 				ImGui::SetNextItemWidth(300.f);
 
-				strncpy(plate_buf, g->clone_pv.plate.c_str(), 9);
+				strncpy(plate_buf, g.clone_pv.plate.c_str(), 9);
 				components::input_text_with_hint("Plate", "Plate Number", plate_buf, sizeof(plate_buf), ImGuiInputTextFlags_None, [] {
-					g->clone_pv.plate = plate_buf;
+					g.clone_pv.plate = plate_buf;
 				});
 			}
 		}
@@ -116,16 +116,16 @@ namespace big
 
 						ImGui::PushID('v' << 24 & personal_veh->get_id());
 						components::selectable(label, false, [&personal_veh] {
-							if (g->clone_pv.spawn_clone)
+							if (g.clone_pv.spawn_clone)
 							{
-								Vector3 spawn_location = vehicle::get_spawn_location(g->spawn_vehicle.spawn_inside);
+								Vector3 spawn_location = vehicle::get_spawn_location(g.spawn_vehicle.spawn_inside);
 								float spawn_heading = ENTITY::GET_ENTITY_HEADING(self::ped);
 
 								auto vehicle_idx = personal_veh->get_vehicle_idx();
 								auto owned_mods = vehicle::get_owned_mods_from_vehicle_idx(vehicle_idx);
 
 								const char* spawn_plate_buf = plate_buf;
-								if (g->clone_pv.clone_plate)
+								if (g.clone_pv.clone_plate)
 								{
 									spawn_plate_buf = personal_veh->get_plate();
 								}
@@ -138,14 +138,14 @@ namespace big
 								}
 								else
 								{
-									if (g->clone_pv.spawn_maxed)
+									if (g.clone_pv.spawn_maxed)
 									{
 										vehicle::max_vehicle(veh);
 									}
 
 									vehicle::set_plate(veh, spawn_plate_buf);
 
-									if (g->clone_pv.spawn_inside)
+									if (g.clone_pv.spawn_inside)
 									{
 										vehicle::teleport_into_vehicle(veh);
 									}
@@ -161,7 +161,7 @@ namespace big
 						});
 						ImGui::PopID();
 
-						if (!g->clone_pv.preview_vehicle || (g->clone_pv.preview_vehicle && !ImGui::IsAnyItemHovered()))
+						if (!g.clone_pv.preview_vehicle || (g.clone_pv.preview_vehicle && !ImGui::IsAnyItemHovered()))
 						{
 							g_model_preview_service->stop_preview();
 						}
@@ -170,7 +170,7 @@ namespace big
 							g_fiber_pool->queue_job([&personal_veh] {
 								g_model_preview_service->show_vehicle(
 									vehicle::get_owned_mods_from_vehicle_idx(personal_veh->get_vehicle_idx()),
-									g->clone_pv.spawn_maxed
+									g.clone_pv.spawn_maxed
 								);
 							});
 						}

--- a/src/views/vehicle/view_spawn_vehicle.cpp
+++ b/src/views/vehicle/view_spawn_vehicle.cpp
@@ -11,24 +11,24 @@ namespace big
 	{
 		ImGui::SetWindowSize({ 0.f, (float)*g_pointers->m_resolution_y }, ImGuiCond_Always);
 
-		if (ImGui::Checkbox("Preview", &g->spawn_vehicle.preview_vehicle))
+		if (ImGui::Checkbox("Preview", &g.spawn_vehicle.preview_vehicle))
 		{
-			if (!g->spawn_vehicle.preview_vehicle)
+			if (!g.spawn_vehicle.preview_vehicle)
 			{
 				g_model_preview_service->stop_preview();
 			}
 		}
 		ImGui::SameLine();
-		ImGui::Checkbox("Spawn In", &g->spawn_vehicle.spawn_inside);
+		ImGui::Checkbox("Spawn In", &g.spawn_vehicle.spawn_inside);
 		ImGui::SameLine();
-		ImGui::Checkbox("Spawn Maxed", &g->spawn_vehicle.spawn_maxed);
+		ImGui::Checkbox("Spawn Maxed", &g.spawn_vehicle.spawn_maxed);
 
 		static char plate_buf[9] = { 0 };
-		strncpy(plate_buf, g->spawn_vehicle.plate.c_str(), 9);
+		strncpy(plate_buf, g.spawn_vehicle.plate.c_str(), 9);
 
 		ImGui::SetNextItemWidth(300.f);
 		components::input_text_with_hint("Plate", "Plate Number", plate_buf, sizeof(plate_buf), ImGuiInputTextFlags_None, [] {
-			g->spawn_vehicle.plate = plate_buf;
+			g.spawn_vehicle.plate = plate_buf;
 		});
 
 
@@ -83,7 +83,7 @@ namespace big
 					components::selectable(std::format("Current Vehicle [{}]", item.m_display_name), false, [] {
 						if (self::veh)
 						{
-							Vector3 spawn_location = vehicle::get_spawn_location(g->spawn_vehicle.spawn_inside);
+							Vector3 spawn_location = vehicle::get_spawn_location(g.spawn_vehicle.spawn_inside);
 							float spawn_heading = ENTITY::GET_ENTITY_HEADING(self::ped);
 
 							auto owned_mods = vehicle::get_owned_mods_from_vehicle(self::veh);
@@ -96,14 +96,14 @@ namespace big
 							}
 							else
 							{
-								if (g->spawn_vehicle.spawn_maxed)
+								if (g.spawn_vehicle.spawn_maxed)
 								{
 									vehicle::max_vehicle(veh);
 								}
 
 								vehicle::set_plate(veh, plate_buf);
 
-								if (g->spawn_vehicle.spawn_inside)
+								if (g.spawn_vehicle.spawn_inside)
 								{
 									vehicle::teleport_into_vehicle(veh);
 								}
@@ -113,7 +113,7 @@ namespace big
 						g_model_preview_service->stop_preview();
 					});
 
-					if (!g->spawn_vehicle.preview_vehicle || (g->spawn_vehicle.preview_vehicle && !ImGui::IsAnyItemHovered()))
+					if (!g.spawn_vehicle.preview_vehicle || (g.spawn_vehicle.preview_vehicle && !ImGui::IsAnyItemHovered()))
 					{
 						g_model_preview_service->stop_preview();
 					}
@@ -122,7 +122,7 @@ namespace big
 						g_fiber_pool->queue_job([] {
 							g_model_preview_service->show_vehicle(
 								vehicle::get_owned_mods_from_vehicle(self::veh),
-								g->spawn_vehicle.spawn_maxed
+								g.spawn_vehicle.spawn_maxed
 							);
 						});
 					}
@@ -155,7 +155,7 @@ namespace big
 						ImGui::PushID(vehicle.m_hash);
 						components::selectable(vehicle.m_display_name, false, [&vehicle]
 						{
-							const auto spawn_location = vehicle::get_spawn_location(g->spawn_vehicle.spawn_inside);
+							const auto spawn_location = vehicle::get_spawn_location(g.spawn_vehicle.spawn_inside);
 							const auto spawn_heading = ENTITY::GET_ENTITY_HEADING(self::ped);
 
 							const auto veh = vehicle::spawn(vehicle.m_hash, spawn_location, spawn_heading);
@@ -166,14 +166,14 @@ namespace big
 							}
 							else
 							{
-								if (g->spawn_vehicle.spawn_maxed)
+								if (g.spawn_vehicle.spawn_maxed)
 								{
 									vehicle::max_vehicle(veh);
 								}
 
 								vehicle::set_plate(veh, plate_buf);
 
-								if (g->spawn_vehicle.spawn_inside)
+								if (g.spawn_vehicle.spawn_inside)
 								{
 									vehicle::teleport_into_vehicle(veh);
 								}
@@ -183,13 +183,13 @@ namespace big
 						});
 						ImGui::PopID();
 
-						if (!g->spawn_vehicle.preview_vehicle || (g->spawn_vehicle.preview_vehicle && !ImGui::IsAnyItemHovered()))
+						if (!g.spawn_vehicle.preview_vehicle || (g.spawn_vehicle.preview_vehicle && !ImGui::IsAnyItemHovered()))
 						{
 							g_model_preview_service->stop_preview();
 						}
 						else if (ImGui::IsItemHovered())
 						{
-							g_model_preview_service->show_vehicle(vehicle.m_hash, g->spawn_vehicle.spawn_maxed);
+							g_model_preview_service->show_vehicle(vehicle.m_hash, g.spawn_vehicle.spawn_maxed);
 						}
 					}
 				}

--- a/src/views/vehicle/view_vehicle.cpp
+++ b/src/views/vehicle/view_vehicle.cpp
@@ -20,7 +20,7 @@ namespace big
 		});
 
 		ImGui::SameLine();
-		ImGui::Checkbox("Keep Vehicle Repaired", &g->vehicle.keep_vehicle_repaired);
+		ImGui::Checkbox("Keep Vehicle Repaired", &g.vehicle.keep_vehicle_repaired);
 
 		ImGui::Separator();
 
@@ -45,8 +45,8 @@ namespace big
 			vehicle::set_engine_state(
 				self::veh,
 				true,
-				g->vehicle.change_engine_state_immediately,
-				g->vehicle.disable_engine_auto_start
+				g.vehicle.change_engine_state_immediately,
+				g.vehicle.disable_engine_auto_start
 			);
 		});
 		ImGui::SameLine();
@@ -54,42 +54,42 @@ namespace big
 			vehicle::set_engine_state(
 				self::veh,
 				false,
-				g->vehicle.change_engine_state_immediately,
-				g->vehicle.disable_engine_auto_start
+				g.vehicle.change_engine_state_immediately,
+				g.vehicle.disable_engine_auto_start
 			);
 		});
-		ImGui::Checkbox("Disable Engine Auto Start", &g->vehicle.disable_engine_auto_start);
+		ImGui::Checkbox("Disable Engine Auto Start", &g.vehicle.disable_engine_auto_start);
 		ImGui::SameLine();
-		ImGui::Checkbox("Change State Immediately", &g->vehicle.change_engine_state_immediately);
+		ImGui::Checkbox("Change State Immediately", &g.vehicle.change_engine_state_immediately);
 
 		ImGui::Separator();
 
 		components::sub_title("General");
 		{
 			ImGui::BeginGroup();
-			ImGui::Checkbox("God Mode", &g->vehicle.god_mode);
-			ImGui::Checkbox("Horn Boost", &g->vehicle.horn_boost);
-			ImGui::Checkbox("Vehicle Jump", &g->vehicle.vehicle_jump);
+			ImGui::Checkbox("God Mode", &g.vehicle.god_mode);
+			ImGui::Checkbox("Horn Boost", &g.vehicle.horn_boost);
+			ImGui::Checkbox("Vehicle Jump", &g.vehicle.vehicle_jump);
 
 			ImGui::EndGroup();
 			ImGui::SameLine();
 			ImGui::BeginGroup();
 
-			ImGui::Checkbox("Instant Brake", &g->vehicle.instant_brake);
-			ImGui::Checkbox("Can Be Targeted", &g->vehicle.is_targetable);
-			ImGui::Checkbox("Drive On Water", &g->vehicle.drive_on_water);
+			ImGui::Checkbox("Instant Brake", &g.vehicle.instant_brake);
+			ImGui::Checkbox("Can Be Targeted", &g.vehicle.is_targetable);
+			ImGui::Checkbox("Drive On Water", &g.vehicle.drive_on_water);
 
 			ImGui::EndGroup();
 			ImGui::SameLine();
 			ImGui::BeginGroup();
 
-			ImGui::Checkbox("Seatbelt", &g->vehicle.seatbelt);
-			ImGui::Checkbox("Turn Signals", &g->vehicle.turn_signals);
-			if (g->vehicle.turn_signals)
+			ImGui::Checkbox("Seatbelt", &g.vehicle.seatbelt);
+			ImGui::Checkbox("Turn Signals", &g.vehicle.turn_signals);
+			if (g.vehicle.turn_signals)
 			{
-				ImGui::Checkbox("Fully Automatic Signal", &g->vehicle.auto_turn_signals);
+				ImGui::Checkbox("Fully Automatic Signal", &g.vehicle.auto_turn_signals);
 			}
-			ImGui::Checkbox("No Water Collision", &g->vehicle.no_water_collision);
+			ImGui::Checkbox("No Water Collision", &g.vehicle.no_water_collision);
 
 			ImGui::EndGroup();
 		}
@@ -100,52 +100,52 @@ namespace big
 		{
 			if (ImGui::Button("Check all"))
 			{
-				g->vehicle.proof_bullet = true;
-				g->vehicle.proof_fire = true;
-				g->vehicle.proof_collision = true;
-				g->vehicle.proof_melee = true;
-				g->vehicle.proof_explosion = true;
-				g->vehicle.proof_steam = true;
-				g->vehicle.proof_water = true;
+				g.vehicle.proof_bullet = true;
+				g.vehicle.proof_fire = true;
+				g.vehicle.proof_collision = true;
+				g.vehicle.proof_melee = true;
+				g.vehicle.proof_explosion = true;
+				g.vehicle.proof_steam = true;
+				g.vehicle.proof_water = true;
 			}
 
 			ImGui::SameLine();
 
 			if (ImGui::Button("Uncheck all"))
 			{
-				g->vehicle.proof_bullet = false;
-				g->vehicle.proof_fire = false;
-				g->vehicle.proof_collision = false;
-				g->vehicle.proof_melee = false;
-				g->vehicle.proof_explosion = false;
-				g->vehicle.proof_steam = false;
-				g->vehicle.proof_water = false;
+				g.vehicle.proof_bullet = false;
+				g.vehicle.proof_fire = false;
+				g.vehicle.proof_collision = false;
+				g.vehicle.proof_melee = false;
+				g.vehicle.proof_explosion = false;
+				g.vehicle.proof_steam = false;
+				g.vehicle.proof_water = false;
 			}
 
 			ImGui::BeginGroup();
 
-			ImGui::Checkbox("Bullet", &g->vehicle.proof_bullet);
-			ImGui::Checkbox("Fire", &g->vehicle.proof_fire);
+			ImGui::Checkbox("Bullet", &g.vehicle.proof_bullet);
+			ImGui::Checkbox("Fire", &g.vehicle.proof_fire);
 
 			ImGui::EndGroup();
 			ImGui::SameLine();
 			ImGui::BeginGroup();
 
-			ImGui::Checkbox("Collision", &g->vehicle.proof_collision);
-			ImGui::Checkbox("Melee", &g->vehicle.proof_melee);
+			ImGui::Checkbox("Collision", &g.vehicle.proof_collision);
+			ImGui::Checkbox("Melee", &g.vehicle.proof_melee);
 
 			ImGui::EndGroup();
 			ImGui::SameLine();
 			ImGui::BeginGroup();
 
-			ImGui::Checkbox("Explosion", &g->vehicle.proof_explosion);
-			ImGui::Checkbox("Steam", &g->vehicle.proof_steam);
+			ImGui::Checkbox("Explosion", &g.vehicle.proof_explosion);
+			ImGui::Checkbox("Steam", &g.vehicle.proof_steam);
 
 			ImGui::EndGroup();
 			ImGui::SameLine();
 			ImGui::BeginGroup();
 
-			ImGui::Checkbox("Water", &g->vehicle.proof_water);
+			ImGui::Checkbox("Water", &g.vehicle.proof_water);
 
 			ImGui::EndGroup();
 		}
@@ -156,19 +156,19 @@ namespace big
 		{
 			ImGui::RadioButton(
 				speed_unit_strings[(int)SpeedUnit::KMPH].c_str(),
-				(int*)&g->vehicle.speed_unit,
+				(int*)&g.vehicle.speed_unit,
 				(int)SpeedUnit::KMPH
 			);
 			ImGui::SameLine();
 			ImGui::RadioButton(
 				speed_unit_strings[(int)SpeedUnit::MIPH].c_str(),
-				(int*)&g->vehicle.speed_unit,
+				(int*)&g.vehicle.speed_unit,
 				(int)SpeedUnit::MIPH
 			);
 			ImGui::SameLine();
 			ImGui::RadioButton(
 				speed_unit_strings[(int)SpeedUnit::MPS].c_str(),
-				(int*)&g->vehicle.speed_unit,
+				(int*)&g.vehicle.speed_unit,
 				(int)SpeedUnit::MPS
 			);
 		}
@@ -177,58 +177,58 @@ namespace big
 
 		components::sub_title("Speedo Meter");
 		{
-			ImGui::Checkbox("Enabled", &g->vehicle.speedo_meter.enabled);
+			ImGui::Checkbox("Enabled", &g.vehicle.speedo_meter.enabled);
 
-			if (g->vehicle.speedo_meter.enabled)
+			if (g.vehicle.speedo_meter.enabled)
 			{
 				ImGui::Text("Position (X, Y)");
 
-				float pos[2] = { g->vehicle.speedo_meter.x, g->vehicle.speedo_meter.y };
+				float pos[2] = { g.vehicle.speedo_meter.x, g.vehicle.speedo_meter.y };
 
 				if (ImGui::SliderFloat2("###speedo_pos", pos, .001f, .999f, "%.3f"))
 				{
-					g->vehicle.speedo_meter.x = pos[0];
-					g->vehicle.speedo_meter.y = pos[1];
+					g.vehicle.speedo_meter.x = pos[0];
+					g.vehicle.speedo_meter.y = pos[1];
 				}
 
 				ImGui::SameLine();
 
-				ImGui::Checkbox("Left Sided", &g->vehicle.speedo_meter.left_side);
+				ImGui::Checkbox("Left Sided", &g.vehicle.speedo_meter.left_side);
 			}
 		}
 
-		g->vehicle.proof_mask = 0;
-		if (g->vehicle.god_mode)
+		g.vehicle.proof_mask = 0;
+		if (g.vehicle.god_mode)
 		{
-			g->vehicle.proof_mask |= static_cast<int>(eEntityProofs::GOD);
+			g.vehicle.proof_mask |= static_cast<int>(eEntityProofs::GOD);
 		}
-		if (g->vehicle.proof_bullet)
+		if (g.vehicle.proof_bullet)
 		{
-			g->vehicle.proof_mask |= static_cast<int>(eEntityProofs::BULLET);
+			g.vehicle.proof_mask |= static_cast<int>(eEntityProofs::BULLET);
 		}
-		if (g->vehicle.proof_fire)
+		if (g.vehicle.proof_fire)
 		{
-			g->vehicle.proof_mask |= static_cast<int>(eEntityProofs::FIRE);
+			g.vehicle.proof_mask |= static_cast<int>(eEntityProofs::FIRE);
 		}
-		if (g->vehicle.proof_collision)
+		if (g.vehicle.proof_collision)
 		{
-			g->vehicle.proof_mask |= static_cast<int>(eEntityProofs::COLLISION);
+			g.vehicle.proof_mask |= static_cast<int>(eEntityProofs::COLLISION);
 		}
-		if (g->vehicle.proof_melee)
+		if (g.vehicle.proof_melee)
 		{
-			g->vehicle.proof_mask |= static_cast<int>(eEntityProofs::MELEE);
+			g.vehicle.proof_mask |= static_cast<int>(eEntityProofs::MELEE);
 		}
-		if (g->vehicle.proof_explosion)
+		if (g.vehicle.proof_explosion)
 		{
-			g->vehicle.proof_mask |= static_cast<int>(eEntityProofs::EXPLOSION);
+			g.vehicle.proof_mask |= static_cast<int>(eEntityProofs::EXPLOSION);
 		}
-		if (g->vehicle.proof_steam)
+		if (g.vehicle.proof_steam)
 		{
-			g->vehicle.proof_mask |= static_cast<int>(eEntityProofs::STEAM);
+			g.vehicle.proof_mask |= static_cast<int>(eEntityProofs::STEAM);
 		}
-		if (g->vehicle.proof_water)
+		if (g.vehicle.proof_water)
 		{
-			g->vehicle.proof_mask |= static_cast<int>(eEntityProofs::WATER);
+			g.vehicle.proof_mask |= static_cast<int>(eEntityProofs::WATER);
 		}
 	}
 }

--- a/src/views/view_context_menu.cpp
+++ b/src/views/view_context_menu.cpp
@@ -6,7 +6,7 @@ namespace big
 	static void draw_model_bounding_box(ImDrawList* draw_list, const model_bounding_box_screen_space& m_model_bounding_box_screen_space)
 	{
 		const auto& box = g_context_menu_service->m_model_bounding_box_screen_space;
-		const auto& color = g->context_menu.bounding_box_color;
+		const auto& color = g.context_menu.bounding_box_color;
 
 		draw_list->AddLine(box.edge1, box.edge2, color);
 		draw_list->AddLine(box.edge1, box.edge4, color);
@@ -38,7 +38,7 @@ namespace big
 				auto& context_target_pos = *g_context_menu_service->m_pointer->m_navigation->get_position();
 
 				const auto context_target_distance = math::calculate_distance_from_game_cam(context_target_pos);
-				const auto context_target_multplr = context_target_distance > g->esp.global_render_distance[1] ? -1.f : 6.17757f / context_target_distance;
+				const auto context_target_multplr = context_target_distance > g.esp.global_render_distance[1] ? -1.f : 6.17757f / context_target_distance;
 
 				if (g_pointers->m_get_screen_coords_for_world_coords(context_target_pos.data, &context_screen_x, &context_screen_y))
 				{
@@ -56,10 +56,10 @@ namespace big
 					for (std::uint32_t i = 0; i < cm->options.size(); i++)
 					{
 						const auto co = cm->options.at(i);
-						draw_list->AddText({ cm_start_x + 7.f, cm_start_y + (20.f * static_cast<float>(i)) + 5.f }, cm->current_option == i ? g->context_menu.selected_option_color : ImGui::ColorConvertFloat4ToU32({ 1.f, 1.f, 1.f, 1.f }), co.name.c_str());
+						draw_list->AddText({ cm_start_x + 7.f, cm_start_y + (20.f * static_cast<float>(i)) + 5.f }, cm->current_option == i ? g.context_menu.selected_option_color : ImGui::ColorConvertFloat4ToU32({ 1.f, 1.f, 1.f, 1.f }), co.name.c_str());
 					}
 
-					if (g->context_menu.bounding_box_enabled)
+					if (g.context_menu.bounding_box_enabled)
 						draw_model_bounding_box(draw_list, g_context_menu_service->m_model_bounding_box_screen_space);
 				}
 			}

--- a/src/views/world/view_spawn_ped.cpp
+++ b/src/views/world/view_spawn_ped.cpp
@@ -241,7 +241,7 @@ namespace big
 							selected_ped_player_id = -1;
 							g_model_preview_service->stop_preview();
 						}
-						else if (!g->spawn_ped.preview_ped || (g->spawn_ped.preview_ped && !ImGui::IsAnyItemHovered()))
+						else if (!g.spawn_ped.preview_ped || (g.spawn_ped.preview_ped && !ImGui::IsAnyItemHovered()))
 						{
 							g_model_preview_service->stop_preview();
 						}
@@ -272,7 +272,7 @@ namespace big
 									selected_ped_player_id = plyr_id;
 									g_model_preview_service->stop_preview();
 								}
-								else if (!g->spawn_ped.preview_ped || (g->spawn_ped.preview_ped && !ImGui::IsAnyItemHovered()))
+								else if (!g.spawn_ped.preview_ped || (g.spawn_ped.preview_ped && !ImGui::IsAnyItemHovered()))
 								{
 									g_model_preview_service->stop_preview();
 								}
@@ -386,7 +386,7 @@ namespace big
 
 						ped_model_dropdown_open = ped_model_dropdown_focused;
 
-						if (!g->spawn_ped.preview_ped || (g->spawn_ped.preview_ped && (!item_hovered || !ped_model_dropdown_open)))
+						if (!g.spawn_ped.preview_ped || (g.spawn_ped.preview_ped && (!item_hovered || !ped_model_dropdown_open)))
 						{
 							g_model_preview_service->stop_preview();
 						}
@@ -550,9 +550,9 @@ namespace big
 		ImGui::Separator();
 
 
-		if (ImGui::Checkbox("Preview", &g->spawn_ped.preview_ped))
+		if (ImGui::Checkbox("Preview", &g.spawn_ped.preview_ped))
 		{
-			if (!g->spawn_ped.preview_ped)
+			if (!g.spawn_ped.preview_ped)
 			{
 				g_model_preview_service->stop_preview();
 			}

--- a/src/views/world/view_time_and_weather.cpp
+++ b/src/views/world/view_time_and_weather.cpp
@@ -8,13 +8,13 @@ namespace big
 	{
 		if (ImGui::TreeNode("Local Time"))
 		{
-			ImGui::Checkbox("Override Time", &g->session.override_time);
+			ImGui::Checkbox("Override Time", &g.session.override_time);
 
-			if (g->session.override_time)
+			if (g.session.override_time)
 			{
-				ImGui::SliderInt("Hour", &g->session.custom_time.hour, 0, 23);
-				ImGui::SliderInt("Minute", &g->session.custom_time.minute, 0, 59);
-				ImGui::SliderInt("Second", &g->session.custom_time.second, 0, 59);
+				ImGui::SliderInt("Hour", &g.session.custom_time.hour, 0, 23);
+				ImGui::SliderInt("Minute", &g.session.custom_time.minute, 0, 59);
+				ImGui::SliderInt("Second", &g.session.custom_time.second, 0, 59);
 			}
 
 			ImGui::TreePop();
@@ -27,7 +27,7 @@ namespace big
 				MISC::CLEAR_OVERRIDE_WEATHER();
 			});
 
-			if (ImGui::ListBox("", &g->session.local_weather, session::weathers, 15))
+			if (ImGui::ListBox("", &g.session.local_weather, session::weathers, 15))
 			{
 				g_fiber_pool->queue_job([]
 				{


### PR DESCRIPTION
This PR should be compatible with the old settings except for enum values which will be reset to their default values.
The global will no longer be accessible as a pointer and instead be changed to a static instance.

```cpp
// instead of 
g->

// use 
g.
```

Closes #374 