### PR TITLE
fix(globals): keep thread running

### DIFF
--- a/src/core/globals.cpp
+++ b/src/core/globals.cpp
@@ -3,14 +3,20 @@
 
 namespace big
 {
+    void menu_settings::destroy()
+    {
+        m_running = false;
+    }
+
     void menu_settings::init(const file& save_file)
     {
+        m_running = true;
         m_save_file = std::make_unique<file>(save_file.get_path());
         load();
 
         g_thread_pool->push([this]
         {
-            while (g_running)
+            while (m_running)
             {
                 std::this_thread::sleep_for(100ms);
                 attempt_save();

--- a/src/core/globals.hpp
+++ b/src/core/globals.hpp
@@ -20,6 +20,7 @@ namespace big
 	class menu_settings
 	{
 	public:
+		void destroy();
 		void init(const file& save_file);
 
 		void attempt_save();
@@ -31,6 +32,8 @@ namespace big
 		bool write_default_config();
 
 	private:
+		bool m_running;
+
 		std::unique_ptr<file> m_save_file;
 
 		nlohmann::json m_default_options;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -133,6 +133,9 @@ BOOL APIENTRY DllMain(HMODULE hmod, DWORD reason, PVOID)
 				g_script_mgr.remove_all_scripts();
 				LOG(INFO) << "Scripts unregistered.";
 
+				// cleans up the thread responsible for saving settings
+				g.destroy();
+
 				// Make sure that all threads created don't have any blocking loops
 				// otherwise make sure that they have stopped executing
 				thread_pool_instance->destroy();


### PR DESCRIPTION
I forgot that `g_running` is only set to true right before entering the while loop, this would cause the global saving thread to exit instantly.