### PR TITLE
refactor: Load tooltips from commands and disable unusable command buttons

### DIFF
--- a/src/gui/components/components.hpp
+++ b/src/gui/components/components.hpp
@@ -71,5 +71,15 @@ namespace big
 			if (ImGui::IsItemHovered())
 				ImGui::SetTooltip(command->get_description().c_str());
 		}
+
+		template<typename PredicateFn, typename ComponentsFn>
+		static void disable_unless(PredicateFn predicate_fn, ComponentsFn components_fn) {
+			auto const result = predicate_fn();
+			if (!result)
+				ImGui::BeginDisabled(true);
+			components_fn();
+			if (!result)
+				ImGui::EndDisabled();
+		}
 	};
 }

--- a/src/gui/components/components.hpp
+++ b/src/gui/components/components.hpp
@@ -48,6 +48,8 @@ namespace big
 			static command* command = command::get(rage::consteval_joaat(cmd_str.value));
 			if (ImGui::Button(label_override.value_or(command->get_label()).data()))
 				command->call(args);
+			if (ImGui::IsItemHovered())
+				ImGui::SetTooltip(command->get_description().c_str());
 		}
 
 		template<template_str cmd_str>
@@ -56,6 +58,8 @@ namespace big
 			static player_command* command = (player_command*)command::get(rage::consteval_joaat(cmd_str.value));
 			if (ImGui::Button(label_override.value_or(command->get_label()).data()))
 				command->call(player, args);
+			if (ImGui::IsItemHovered())
+				ImGui::SetTooltip(command->get_description().c_str());
 		}
 
 		template<template_str cmd_str>
@@ -64,6 +68,8 @@ namespace big
 			static bool_command* command = (bool_command*)command::get(rage::consteval_joaat(cmd_str.value));
 			if (ImGui::Checkbox(label_override.value_or(command->get_label()).data(), &command->is_enabled()))
 				command->refresh();
+			if (ImGui::IsItemHovered())
+				ImGui::SetTooltip(command->get_description().c_str());
 		}
 	};
 }

--- a/src/views/players/player/player_kick.cpp
+++ b/src/views/players/player/player_kick.cpp
@@ -8,19 +8,21 @@ namespace big
 	{
 		if (ImGui::TreeNode("Kick"))
 		{
+			auto const is_session_host = [] { return gta_util::get_network()->m_game_session_ptr->is_host(); };
+
 			components::player_command_button<"breakup">(g_player_service->get_selected());
-			components::player_command_button<"lckick">(g_player_service->get_selected());
+			components::disable_unless(std::not_fn(is_session_host), [] {
+				components::player_command_button<"lckick">(g_player_service->get_selected());
+			});
 			components::player_command_button<"bailkick">(g_player_service->get_selected());
 			components::player_command_button<"nfkick">(g_player_service->get_selected());
 			components::player_command_button<"oomkick">(g_player_service->get_selected());
 			components::player_command_button<"shkick">(g_player_service->get_selected());
 			components::player_command_button<"endkick">(g_player_service->get_selected());
-			if (ImGui::IsItemHovered())
-				ImGui::SetTooltip("The kick can take around 10 seconds to work");
-			components::player_command_button<"hostkick">(g_player_service->get_selected());
+			components::disable_unless(is_session_host, [] {
+				components::player_command_button<"hostkick">(g_player_service->get_selected());
+			});
 			components::player_command_button<"desync">(g_player_service->get_selected());
-			if (ImGui::IsItemHovered())
-				ImGui::SetTooltip("The kick can take around 10 seconds to work");
 
 			ImGui::TreePop();
 		}

--- a/src/views/self/view_self.cpp
+++ b/src/views/self/view_self.cpp
@@ -54,8 +54,6 @@ namespace big
 		components::command_checkbox<"mobileradio">();
 
 		ImGui::Checkbox("Dance Mode", &g.self.dance_mode);
-		if (ImGui::IsItemHovered())
-			ImGui::SetTooltip("Hold Right DPAD or E to enter dance mode");
 
 		ImGui::EndGroup();
 


### PR DESCRIPTION
- Replaces manual `SetTooltip` calls now that most checkboxes/buttons are backed by commands with their own descriptions
- Adds a `disable_unless` component wrapper that prevents players from being able to press buttons they can't use
  - This both greys out buttons and prevents them from being pressed
  - An unfortunate consequence is that tooltips can't be shown, as disabled components aren't marked as hovered in imgui. I don't think this is a big deal though.