### PR TITLE
feat: CTaskGeneralSweep crash protection

### DIFF
--- a/src/common.hpp
+++ b/src/common.hpp
@@ -54,6 +54,7 @@
 #include "core/globals.hpp"
 #include "gta/natives.hpp"
 #include "ped/CPed.hpp"
+#include "memory/module.hpp"
 
 #include "services/notifications/notification_service.hpp"
 
@@ -65,6 +66,7 @@ namespace big
 	inline HANDLE g_main_thread{};
 	inline DWORD g_main_thread_id{};
 	inline std::atomic_bool g_running{ false };
+	inline std::unique_ptr<memory::module> g_main_module;
 
 	inline CPed* g_local_player;
 }

--- a/src/hooking.cpp
+++ b/src/hooking.cpp
@@ -62,6 +62,7 @@ namespace big
 		detour_hook_helper::add<hooks::invalid_mods_crash_detour>("IMCD", g_pointers->m_invalid_mods_crash_detour);
 		detour_hook_helper::add<hooks::constraint_attachment_crash>("CAC", g_pointers->m_constraint_attachment_crash);
 		detour_hook_helper::add<hooks::invalid_decal>("IDC", g_pointers->m_invalid_decal_crash);
+		detour_hook_helper::add<hooks::anim_task_crash>("ATC", g_pointers->m_anim_task_crash);
 
 		detour_hook_helper::add<hooks::update_presence_attribute_int>("UPAI", g_pointers->m_update_presence_attribute_int);
 		detour_hook_helper::add<hooks::update_presence_attribute_string>("UPAS", g_pointers->m_update_presence_attribute_string);

--- a/src/hooking.hpp
+++ b/src/hooking.hpp
@@ -102,6 +102,7 @@ namespace big
 		static void invalid_mods_crash_detour(int64_t a1, int64_t a2, int a3, char a4);
 		static std::int64_t constraint_attachment_crash(std::uintptr_t a1);
 		static uint64_t invalid_decal(uintptr_t a1, int a2);
+		static bool anim_task_crash(int64_t a1, int64_t a2, int64_t a3, int64_t a4, int64_t a5);
 
 		static bool update_presence_attribute_int(void* presence_data, int profile_index, char* attr, std::uint64_t value);
 		static bool update_presence_attribute_string(void* presence_data, int profile_index, char* attr, char* value);

--- a/src/hooks/protections/anim_task_crash.cpp
+++ b/src/hooks/protections/anim_task_crash.cpp
@@ -1,0 +1,12 @@
+#include "hooking.hpp"
+#include "util/misc.hpp"
+
+namespace big
+{
+    bool hooks::anim_task_crash(int64_t a1, int64_t a2, int64_t a3, int64_t a4, int64_t a5)
+    {
+        if (!misc::is_valid_ptr(a2))
+            return 0;
+        return g_hooking->get_original<hooks::anim_task_crash>()(a1, a2, a3, a4, a5);
+    }
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,6 +53,8 @@ BOOL APIENTRY DllMain(HMODULE hmod, DWORD reason, PVOID)
 
 			EnableMenuItem(GetSystemMenu(GetConsoleWindow(), 0), SC_CLOSE, MF_BYCOMMAND | MF_DISABLED | MF_GRAYED);
 
+			g_main_module = std::make_unique<memory::module>("GTA5.exe");
+
 			try
 			{
 				LOG(INFO) << "Yim's Menu Initializing";

--- a/src/pointers.cpp
+++ b/src/pointers.cpp
@@ -681,6 +681,12 @@ namespace big
 			m_invalid_decal_crash = ptr.add(1).rip().as<PVOID>();
 		});
 
+		// Anim Task Crash
+		main_batch.add("ATC", "E8 ? ? ? ? 84 C0 74 8D", [this](memory::handle ptr)
+		{
+			m_anim_task_crash = ptr.add(1).rip().as<PVOID>();
+		});
+
 		// Encode Session Info
 		main_batch.add("ESI", "48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 20 57 48 81", [this](memory::handle ptr)
 		{

--- a/src/pointers.hpp
+++ b/src/pointers.hpp
@@ -155,6 +155,7 @@ namespace big
 		PVOID m_invalid_mods_crash_detour{};
 		PVOID m_constraint_attachment_crash{};
 		PVOID m_invalid_decal_crash{};
+		PVOID m_anim_task_crash{};
 
 		int64_t** m_send_chat_ptr{};
 		functions::send_chat_message m_send_chat_message{};

--- a/src/util/misc.hpp
+++ b/src/util/misc.hpp
@@ -39,12 +39,30 @@ namespace big::misc
 	}
 
 	template<typename T>
-	inline bool is_valid_ptr(T ptr) {
+	inline bool is_valid_ptr(T ptr)
+	{
 		uint64_t address = (uint64_t)ptr;
 		if (address < 0x5000) return false;
 		if ((address & 0xFFFFFFFF) == 0xFFFFFFFF) return false;
 		if ((address & 0xFFFFFFFF) <= 0xFF) return false;
 		if (address > 0xFFFFFFFFFFFF) return false;
 		return true;
+	}
+
+	template<typename T>
+	inline bool is_valid_vtable(T ptr)
+	{
+		uint64_t address = (uint64_t)ptr;
+		if (!is_valid_ptr(address))
+			return false;
+		return address > g_main_module->begin().as<uint64_t>() && address < g_main_module->end().as<uint64_t>();
+	}
+
+	template<typename T>
+	inline bool has_valid_vtable(T ptr)
+	{
+		if (!is_valid_ptr(ptr))
+			return false;
+		return is_valid_vtable(*reinterpret_cast<uint64_t*>(ptr));
 	}
 }

--- a/src/util/misc.hpp
+++ b/src/util/misc.hpp
@@ -53,8 +53,6 @@ namespace big::misc
 	inline bool is_valid_vtable(T ptr)
 	{
 		uint64_t address = (uint64_t)ptr;
-		if (!is_valid_ptr(address))
-			return false;
 		return address > g_main_module->begin().as<uint64_t>() && address < g_main_module->end().as<uint64_t>();
 	}
 

--- a/src/util/misc.hpp
+++ b/src/util/misc.hpp
@@ -37,4 +37,14 @@ namespace big::misc
 	{
 		*address |= bits;
 	}
+
+	template<typename T>
+	inline bool is_valid_ptr(T ptr) {
+		uint64_t address = (uint64_t)ptr;
+		if (address < 0x5000) return false;
+		if ((address & 0xFFFFFFFF) == 0xFFFFFFFF) return false;
+		if ((address & 0xFFFFFFFF) <= 0xFF) return false;
+		if (address > 0xFFFFFFFFFFFF) return false;
+		return true;
+	}
 }


### PR DESCRIPTION
[_.log](https://github.com/YimMenu/YimMenu/files/10530512/_.log)

![](https://i.imgur.com/ASYVf70.png)

For some reason, passing invalid names to `TASK::TASK_SWEEP_AIM_POSITION` will trigger this crash (Thanks to unnamed204 for the code)

Not the best solution but I just put here