### PR TITLE
feat(protections): block receive pickup

### DIFF
--- a/src/core/globals.hpp
+++ b/src/core/globals.hpp
@@ -232,9 +232,10 @@ namespace big
 
 			bool desync_kick = false;
 			bool rid_join = false;
-			bool lessen_breakups = false; // disabled by default due to anticheat concerns
+			bool lessen_breakups = false;
+			bool receive_pickup = false; // disabled by default due to anticheat concerns
 
-			NLOHMANN_DEFINE_TYPE_INTRUSIVE(protections, script_events, rid_join, lessen_breakups, desync_kick)
+			NLOHMANN_DEFINE_TYPE_INTRUSIVE(protections, script_events, rid_join, lessen_breakups, desync_kick, receive_pickup)
 		} protections{};
 
 		struct self 

--- a/src/core/globals.hpp
+++ b/src/core/globals.hpp
@@ -232,8 +232,8 @@ namespace big
 
 			bool desync_kick = false;
 			bool rid_join = false;
-			bool lessen_breakups = false;
-			bool receive_pickup = false; // disabled by default due to anticheat concerns
+			bool lessen_breakups = false; // disabled by default due to anticheat concerns
+			bool receive_pickup = false;
 
 			NLOHMANN_DEFINE_TYPE_INTRUSIVE(protections, script_events, rid_join, lessen_breakups, desync_kick, receive_pickup)
 		} protections{};

--- a/src/hooking.cpp
+++ b/src/hooking.cpp
@@ -101,6 +101,8 @@ namespace big
 
 		detour_hook_helper::add<hooks::received_array_update>("RAU", g_pointers->m_received_array_update);
 
+		detour_hook_helper::add<hooks::receive_pickup>("RPI", g_pointers->m_receive_pickup);
+
 		g_hooking = this;
 	}
 

--- a/src/hooking.hpp
+++ b/src/hooking.hpp
@@ -145,6 +145,8 @@ namespace big
 		static void* infinite_train_crash(void* carriage);
 
 		static bool received_array_update(rage::netArrayHandlerBase* array, CNetGamePlayer* sender, rage::datBitBuffer* buffer, int size, std::int16_t cycle);
+
+		static bool receive_pickup(rage::netObject* netobject, void* unk, CPed* ped);
 	};
 
 	class minhook_keepalive

--- a/src/hooks/protections/receive_pickup.cpp
+++ b/src/hooks/protections/receive_pickup.cpp
@@ -1,0 +1,15 @@
+#include "hooking.hpp"
+
+namespace big
+{
+    bool hooks::receive_pickup(rage::netObject* object, void* unk, CPed* ped)
+    {
+        if (g.protections.receive_pickup)
+        {
+            g_notification_service->push_error("PROTECTIONS"_T.data(), "Blocked pickup");
+            return false;
+        }
+
+        return g_hooking->get_original<hooks::receive_pickup>()(object, unk, ped);
+    }
+}

--- a/src/pointers.cpp
+++ b/src/pointers.cpp
@@ -812,6 +812,12 @@ namespace big
 			m_received_array_update = ptr.as<PVOID>();
 		});
 
+		// Receive Pickup
+        main_batch.add("RPI", "49 8B 80 ? ? ? ? 48 85 C0 74 0C F6 80 ? ? ? ? ? 75 03 32 C0 C3", [this](memory::handle ptr)
+        {
+            m_receive_pickup = ptr.as<PVOID>();
+        });
+
 		auto mem_region = memory::module("GTA5.exe");
 		if (!main_batch.run(mem_region))
 		{

--- a/src/pointers.cpp
+++ b/src/pointers.cpp
@@ -813,10 +813,10 @@ namespace big
 		});
 
 		// Receive Pickup
-        main_batch.add("RPI", "49 8B 80 ? ? ? ? 48 85 C0 74 0C F6 80 ? ? ? ? ? 75 03 32 C0 C3", [this](memory::handle ptr)
-        {
-            m_receive_pickup = ptr.as<PVOID>();
-        });
+		main_batch.add("RPI", "49 8B 80 ? ? ? ? 48 85 C0 74 0C F6 80 ? ? ? ? ? 75 03 32 C0 C3", [this](memory::handle ptr)
+		{
+			m_receive_pickup = ptr.as<PVOID>();
+		});
 
 		auto mem_region = memory::module("GTA5.exe");
 		if (!main_batch.run(mem_region))

--- a/src/pointers.hpp
+++ b/src/pointers.hpp
@@ -237,6 +237,8 @@ namespace big
 		functions::get_entity_attached_to m_get_entity_attached_to;
 
 		PVOID m_received_array_update;
+
+		PVOID m_receive_pickup{};
 	};
 
 	inline pointers* g_pointers{};

--- a/src/views/settings/view_protection_settings.cpp
+++ b/src/views/settings/view_protection_settings.cpp
@@ -45,6 +45,9 @@ namespace big
 		ImGui::Checkbox("LESSEN_BREAKUP_KICK"_T.data(), &g.protections.lessen_breakups);
 		if (ImGui::IsItemHovered())
 			ImGui::SetTooltip("LESSEN_BREAKUP_KICK_DESCRIPTION"_T.data());
+		ImGui::Checkbox("Receive Pickup", &g.protections.receive_pickup);
+		if (ImGui::IsItemHovered())
+			ImGui::SetTooltip("This prevents any pickup from the ground such as unwanted money drops.\nAttention: Normal pickups are also no longer possible.");
 		ImGui::EndGroup();
 	}
 


### PR DESCRIPTION
This protection will prevent any pickups such as money drops from being collected.
Since all pickups are basically blocked, normal items can't be picked up either, so I have disabled the option by default.