### PR TITLE
fix(overlay): timezone crash

### DIFF
--- a/src/views/core/view_overlay.cpp
+++ b/src/views/core/view_overlay.cpp
@@ -25,8 +25,8 @@ namespace big
 			if (CNetworkPlayerMgr *network_player_mgr = gta_util::get_network_player_mgr(); g.window.ingame_overlay.show_players)
 				ImGui::Text(std::format("Players: {}/{}", network_player_mgr->m_player_count, network_player_mgr->m_player_limit).c_str());
 
-			if (g.window.ingame_overlay.show_time)
-				ImGui::Text(std::format("Time: {:%d-%m-%Y %H:%M:%OS}", std::chrono::current_zone()->to_local(std::chrono::system_clock::now())).c_str());
+			//if (g.window.ingame_overlay.show_time)
+			//	ImGui::Text(std::format("Time: {:%d-%m-%Y %H:%M:%OS}", std::chrono::current_zone()->to_local(std::chrono::system_clock::now())).c_str());
 
 			if (auto replay_interface = *g_pointers->m_replay_interface; g.window.ingame_overlay.show_replay_interface)
 			{

--- a/src/views/settings/view_gui_settings.cpp
+++ b/src/views/settings/view_gui_settings.cpp
@@ -30,6 +30,8 @@ namespace big
 		ImGui::Checkbox("Show FPS", &g.window.ingame_overlay.show_fps);
 		ImGui::Checkbox("Show Players", &g.window.ingame_overlay.show_players);
 		ImGui::Checkbox("Show Time", &g.window.ingame_overlay.show_time);
+		if (ImGui::IsItemHovered())
+			ImGui::SetTooltip("Show time is currently disabled as it caused problems for some users.");
 
 		ImGui::EndGroup();
 		ImGui::SameLine();


### PR DESCRIPTION
This fixes a crash that some users were experiencing.

We'll have to either abandon using this or find an alternative way of achieving this.