### PR TITLE
fix(session_browser): decrease session limit

### DIFF
--- a/src/services/matchmaking/matchmaking_service.hpp
+++ b/src/services/matchmaking/matchmaking_service.hpp
@@ -5,7 +5,7 @@ namespace big
 	class matchmaking_service
 	{
 	public:
-		constexpr static int MAX_SESSIONS_TO_FIND = 1400;
+		constexpr static int MAX_SESSIONS_TO_FIND = 1057;
 
 		struct session_attributes
 		{

--- a/src/views/network/view_session_browser.cpp
+++ b/src/views/network/view_session_browser.cpp
@@ -18,6 +18,8 @@ namespace big
 		static char search[64];
 		static char session_info[255];
 
+		ImGui::Text(std::format("Total sessions found: {}", g_matchmaking_service->get_num_found_sessions()).data());
+
 		ImGui::SetNextItemWidth(300.f);
 
 		if (ImGui::ListBoxHeader("###sessions", { 300, static_cast<float>(*g_pointers->m_resolution_y - 400 - 38 * 4) }))


### PR DESCRIPTION
It seems that Rockstar has simply limited the number of sessions we can find.
With the reduced limit, the session browser works perfectly again!