### PR TITLE
feat: Improved exception handling

### DIFF
--- a/src/logger/exception_handler.cpp
+++ b/src/logger/exception_handler.cpp
@@ -22,13 +22,17 @@ namespace big
             exception_code == DBG_PRINTEXCEPTION_WIDE_C)
             return EXCEPTION_CONTINUE_SEARCH;
 
-        LOG(FATAL) << stack_trace(exception_info);
+        auto stack_trace_instance = std::make_unique<stack_trace>(exception_info);
+        LOG(FATAL) << *stack_trace_instance.get();
 
         ZyanU64 opcode_address = exception_info->ContextRecord->Rip;
         ZydisDisassembledInstruction instruction;
         ZydisDisassembleIntel(ZYDIS_MACHINE_MODE_LONG_64, opcode_address, reinterpret_cast<void*>(opcode_address), 32, &instruction);
 
-        exception_info->ContextRecord->Rip += instruction.info.length;
+        if(stack_trace_instance->m_ret_context.Rip)
+            *exception_info->ContextRecord = stack_trace_instance->m_ret_context;
+        else
+            exception_info->ContextRecord->Rip += instruction.info.length;
 
         return EXCEPTION_CONTINUE_EXECUTION;
     }

--- a/src/logger/exception_handler.cpp
+++ b/src/logger/exception_handler.cpp
@@ -22,15 +22,15 @@ namespace big
             exception_code == DBG_PRINTEXCEPTION_WIDE_C)
             return EXCEPTION_CONTINUE_SEARCH;
 
-        auto stack_trace_instance = std::make_unique<stack_trace>(exception_info);
-        LOG(FATAL) << stack_trace_instance.get();
+        stack_trace stack_trace(exception_info);
+        LOG(FATAL) << stack_trace;
 
         ZyanU64 opcode_address = exception_info->ContextRecord->Rip;
         ZydisDisassembledInstruction instruction;
         ZydisDisassembleIntel(ZYDIS_MACHINE_MODE_LONG_64, opcode_address, reinterpret_cast<void*>(opcode_address), 32, &instruction);
 
-        if(stack_trace_instance->m_ret_context.Rip)
-            *exception_info->ContextRecord = stack_trace_instance->m_ret_context;
+        if(stack_trace.m_ret_context.Rip)
+            *exception_info->ContextRecord = stack_trace.m_ret_context;
         else
             exception_info->ContextRecord->Rip += instruction.info.length;
 

--- a/src/logger/exception_handler.cpp
+++ b/src/logger/exception_handler.cpp
@@ -23,7 +23,7 @@ namespace big
             return EXCEPTION_CONTINUE_SEARCH;
 
         auto stack_trace_instance = std::make_unique<stack_trace>(exception_info);
-        LOG(FATAL) << *stack_trace_instance.get();
+        LOG(FATAL) << stack_trace_instance.get();
 
         ZyanU64 opcode_address = exception_info->ContextRecord->Rip;
         ZydisDisassembledInstruction instruction;

--- a/src/logger/stack_trace.cpp
+++ b/src/logger/stack_trace.cpp
@@ -172,6 +172,9 @@ namespace big
                 break;
             }
             m_frame_pointers[i] = frame.AddrPC.Offset;
+
+            if (i == 1)
+                m_ret_context = context;
         }
     }
 

--- a/src/logger/stack_trace.hpp
+++ b/src/logger/stack_trace.hpp
@@ -9,6 +9,8 @@ namespace big
         stack_trace(EXCEPTION_POINTERS* exception_info);
         virtual ~stack_trace();
 
+        CONTEXT m_ret_context{};
+
         std::string str() const;
 
         friend std::ostream& operator<< (std::ostream& os, const stack_trace& st);

--- a/src/logger/stack_trace.hpp
+++ b/src/logger/stack_trace.hpp
@@ -14,6 +14,7 @@ namespace big
         std::string str() const;
 
         friend std::ostream& operator<< (std::ostream& os, const stack_trace& st);
+        friend std::ostream& operator<< (std::ostream& os, const stack_trace* st);
 
     private:
         struct module_info
@@ -56,6 +57,13 @@ namespace big
     inline std::ostream& operator<< (std::ostream& os, const stack_trace& st)
     {
         os << st.str();
+
+        return os;
+    }
+
+    inline std::ostream& operator<< (std::ostream& os, const stack_trace* st)
+    {
+        os << st->str();
 
         return os;
     }


### PR DESCRIPTION
![image](https://i.imgur.com/DMlnR9F.png)
![image](https://i.imgur.com/gNEyYm3.png)

In the crash of #914, the current exception handling has a probability of causing the process to enter an infinite EXCEPTION_ACCESS_VIOLATION (or whatever that is) function. 

Yes, this is my mistake. It didn’t happen when I tested it. Maybe it’s because I only triggered a few crashes, didn't spam it.

Well, after closing #914, I privately spam the crash and found that I entered an infinite loop function (0x14B51 in the second picture), this pr should fix this problem