### PR TITLE
feat(exception_handler): use single stack_trace instance

### DIFF
--- a/src/logger/exception_handler.cpp
+++ b/src/logger/exception_handler.cpp
@@ -13,7 +13,7 @@ namespace big
     {
         RemoveVectoredExceptionHandler(m_exception_handler);
     }
-
+    
     LONG vectored_exception_handler(EXCEPTION_POINTERS* exception_info)
     {
         const auto exception_code = exception_info->ExceptionRecord->ExceptionCode;
@@ -22,17 +22,15 @@ namespace big
             exception_code == DBG_PRINTEXCEPTION_WIDE_C)
             return EXCEPTION_CONTINUE_SEARCH;
 
-        stack_trace stack_trace(exception_info);
-        LOG(FATAL) << stack_trace;
+        static stack_trace trace;
+        trace.new_stack_trace(exception_info);
+        LOG(FATAL) << trace;
 
         ZyanU64 opcode_address = exception_info->ContextRecord->Rip;
         ZydisDisassembledInstruction instruction;
         ZydisDisassembleIntel(ZYDIS_MACHINE_MODE_LONG_64, opcode_address, reinterpret_cast<void*>(opcode_address), 32, &instruction);
 
-        if(stack_trace.m_ret_context.Rip)
-            *exception_info->ContextRecord = stack_trace.m_ret_context;
-        else
-            exception_info->ContextRecord->Rip += instruction.info.length;
+        exception_info->ContextRecord->Rip += instruction.info.length;
 
         return EXCEPTION_CONTINUE_EXECUTION;
     }

--- a/src/logger/exception_handler.cpp
+++ b/src/logger/exception_handler.cpp
@@ -14,6 +14,7 @@ namespace big
         RemoveVectoredExceptionHandler(m_exception_handler);
     }
     
+    inline static stack_trace trace;
     LONG vectored_exception_handler(EXCEPTION_POINTERS* exception_info)
     {
         const auto exception_code = exception_info->ExceptionRecord->ExceptionCode;
@@ -22,7 +23,6 @@ namespace big
             exception_code == DBG_PRINTEXCEPTION_WIDE_C)
             return EXCEPTION_CONTINUE_SEARCH;
 
-        static stack_trace trace;
         trace.new_stack_trace(exception_info);
         LOG(FATAL) << trace;
 

--- a/src/logger/stack_trace.hpp
+++ b/src/logger/stack_trace.hpp
@@ -6,11 +6,10 @@ namespace big
     class stack_trace
     {
     public:
-        stack_trace(EXCEPTION_POINTERS* exception_info);
+        stack_trace();
         virtual ~stack_trace();
 
-        CONTEXT m_ret_context{};
-
+        void new_stack_trace(EXCEPTION_POINTERS* exception_info);
         std::string str() const;
 
         friend std::ostream& operator<< (std::ostream& os, const stack_trace& st);


### PR DESCRIPTION
With these changes the exception handler no longer lags the game every time it generates a stack trace.

Closes #835

Reverted some changes made in PR #969 as they possibly corrupted the stack pointer by instantly returning to the caller on an exception.