### PR TITLE
feat: add casino country restriction bypass

### DIFF
--- a/src/native_hooks/casino.hpp
+++ b/src/native_hooks/casino.hpp
@@ -1,0 +1,10 @@
+namespace big
+{
+	namespace casino
+	{
+		void NETWORK_CASINO_CAN_BET(rage::scrNativeCallContext* src)
+		{
+			src->set_return_value<BOOL>(TRUE);
+		}
+	}
+}

--- a/src/native_hooks/native_hooks.cpp
+++ b/src/native_hooks/native_hooks.cpp
@@ -6,6 +6,7 @@
 #include "shop_controller.hpp"
 #include "network_session_host.hpp"
 #include "am_launcher.hpp"
+#include "casino.hpp"
 #include "creator.hpp"
 #include "crossmap.hpp"
 
@@ -143,6 +144,14 @@ namespace big
 		add_native_detour(RAGE_JOAAT("fm_lts_creator"), 0x3D3D8B3BE5A83D35, creator::GET_USED_CREATOR_BUDGET);
 		add_native_detour(RAGE_JOAAT("fm_survival_creator"), 0x3D3D8B3BE5A83D35, creator::GET_USED_CREATOR_BUDGET);
 
+		//bypass casino country restrictions
+		add_native_detour(RAGE_JOAAT("casino_slots"), 0x158C16F5E4CF41F8, casino::NETWORK_CASINO_CAN_BET);
+		add_native_detour(RAGE_JOAAT("three_card_poker"), 0x158C16F5E4CF41F8, casino::NETWORK_CASINO_CAN_BET);
+		add_native_detour(RAGE_JOAAT("casinoroulette"), 0x158C16F5E4CF41F8, casino::NETWORK_CASINO_CAN_BET);
+		add_native_detour(RAGE_JOAAT("casino_lucky_wheel"), 0x158C16F5E4CF41F8, casino::NETWORK_CASINO_CAN_BET);
+		add_native_detour(RAGE_JOAAT("blackjack"), 0x158C16F5E4CF41F8, casino::NETWORK_CASINO_CAN_BET);
+		add_native_detour(RAGE_JOAAT("am_mp_casino"), 0x158C16F5E4CF41F8, casino::NETWORK_CASINO_CAN_BET);
+		add_native_detour(RAGE_JOAAT("am_mp_casino_apartment"), 0x158C16F5E4CF41F8, casino::NETWORK_CASINO_CAN_BET);
 
 		for (auto& entry : *g_pointers->m_script_program_table)
 			if (entry.m_program)

--- a/src/native_hooks/native_hooks.cpp
+++ b/src/native_hooks/native_hooks.cpp
@@ -145,13 +145,7 @@ namespace big
 		add_native_detour(RAGE_JOAAT("fm_survival_creator"), 0x3D3D8B3BE5A83D35, creator::GET_USED_CREATOR_BUDGET);
 
 		//bypass casino country restrictions
-		add_native_detour(RAGE_JOAAT("casino_slots"), 0x158C16F5E4CF41F8, casino::NETWORK_CASINO_CAN_BET);
-		add_native_detour(RAGE_JOAAT("three_card_poker"), 0x158C16F5E4CF41F8, casino::NETWORK_CASINO_CAN_BET);
-		add_native_detour(RAGE_JOAAT("casinoroulette"), 0x158C16F5E4CF41F8, casino::NETWORK_CASINO_CAN_BET);
-		add_native_detour(RAGE_JOAAT("casino_lucky_wheel"), 0x158C16F5E4CF41F8, casino::NETWORK_CASINO_CAN_BET);
-		add_native_detour(RAGE_JOAAT("blackjack"), 0x158C16F5E4CF41F8, casino::NETWORK_CASINO_CAN_BET);
-		add_native_detour(RAGE_JOAAT("am_mp_casino"), 0x158C16F5E4CF41F8, casino::NETWORK_CASINO_CAN_BET);
-		add_native_detour(RAGE_JOAAT("am_mp_casino_apartment"), 0x158C16F5E4CF41F8, casino::NETWORK_CASINO_CAN_BET);
+		add_native_detour(0x158C16F5E4CF41F8, casino::NETWORK_CASINO_CAN_BET);
 
 		for (auto& entry : *g_pointers->m_script_program_table)
 			if (entry.m_program)


### PR DESCRIPTION
thx to @Aure7138 
Tested with a vpn to Luxembourg

~~The native is also used in scripts like freemode or the maintransition. To avoid side effects I only hooked the needed scripts instead of hooking all of them.~~

It seems that in every script we can override the return value.
R* seems to restrict the casino's functions in each script (like notifications and so on).

