### PR TITLE
Hotfix crash

### DIFF
--- a/src/hooks/protections/can_apply_data.cpp
+++ b/src/hooks/protections/can_apply_data.cpp
@@ -668,7 +668,7 @@ namespace big
 			}
 			case RAGE_JOAAT("CVehicleProximityMigrationDataNode"):
 			{
-				if (g_local_player && g_local_player->m_net_object)
+				if (object && g_local_player && g_local_player->m_net_object)
 				{
 					const auto migration_node = (CVehicleProximityMigrationDataNode*)(node);
 					if (is_in_vehicle(g_local_player, g_local_player->m_vehicle) && g_local_player->m_vehicle->m_net_object
@@ -687,6 +687,8 @@ namespace big
 						}
 					}
 				}
+
+				break;
 			}
 			}
 		}

--- a/src/hooks/toxic/write_vehicle_proximity_migration_data_node.cpp
+++ b/src/hooks/toxic/write_vehicle_proximity_migration_data_node.cpp
@@ -13,7 +13,7 @@ namespace big
 
 		g_hooking->get_original<hooks::write_vehicle_proximity_migration_data_node>()(veh, node);
 
-		if (vehicle->m_net_object->m_object_id = g.m_tp_veh_net_id)
+		if (vehicle->m_net_object->m_object_id == g.m_tp_veh_net_id)
 		{
 			node->m_has_occupants[0]  = true;
 			node->m_occupants[0]      = g.m_tp_player_net_id;


### PR DESCRIPTION
Crash was caused by the use of `=` instead of `==`
Fixes #1061