### PR TITLE
Prevent exploit reports

### DIFF
--- a/src/native_hooks/all_scripts.hpp
+++ b/src/native_hooks/all_scripts.hpp
@@ -144,5 +144,10 @@ namespace big
 		{
 			src->set_return_value<BOOL>(TRUE);
 		}
+
+		void RETURN_FALSE(rage::scrNativeCallContext* src)
+		{
+			src->set_return_value<BOOL>(FALSE);
+		}
 	}
 }

--- a/src/native_hooks/native_hooks.cpp
+++ b/src/native_hooks/native_hooks.cpp
@@ -112,6 +112,8 @@ namespace big
 		add_native_detour(0xFE99B66D079CF6BC, all_scripts::DISABLE_CONTROL_ACTION);
 		add_native_detour(0xEB354E5376BC81A7, all_scripts::HUD_FORCE_WEAPON_WHEEL);
 		add_native_detour(0x158C16F5E4CF41F8, all_scripts::RETURN_TRUE); //bypass casino country restrictions
+		
+		add_native_detour(RAGE_JOAAT("shop_controller"), 0x34616828CD07F1A1, all_scripts::RETURN_FALSE); // prevent exploit reports
 
 		add_native_detour(RAGE_JOAAT("carmod_shop"), 0x06843DA7060A026B, carmod_shop::SET_ENTITY_COORDS);
 		add_native_detour(RAGE_JOAAT("carmod_shop"), 0x8E2530AA8ADA980E, carmod_shop::SET_ENTITY_HEADING);


### PR DESCRIPTION
Exploit reports for god mode and invisibility are sent in shop_controller, there is only one occurrence of the native being called in this script so it is safe to patch it this way.