### PR TITLE
fix(ci)[nightly]: checkout repo

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,6 +65,7 @@ jobs:
     needs: [ check_date, build_nightly ]
     if: ${{ needs.check_date.outputs.should_run != 'false' }}
     steps:
+      - uses: actions/checkout@v3
       - name: Download Artifact
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
The action that updates the tag needs the git repo. Trigger another nightly after merging