### PR TITLE
More context menu operations

### DIFF
--- a/src/backend/commands/player/toxic/remove_all_weapons.cpp
+++ b/src/backend/commands/player/toxic/remove_all_weapons.cpp
@@ -1,6 +1,7 @@
 #include "backend/player_command.hpp"
 #include "natives.hpp"
 #include "pointers.hpp"
+#include "services/gta_data/gta_data_service.hpp"
 
 namespace big
 {
@@ -15,8 +16,8 @@ namespace big
 
 		virtual void execute(player_ptr player, const std::vector<std::uint64_t>& _args, const std::shared_ptr<command_context> ctx)
 		{
-			// TODO: Doesn't actually do anything
-			WEAPON::REMOVE_ALL_PED_WEAPONS(PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id()), FALSE);
+			for (auto& [_, weapon] : g_gta_data_service->weapons())
+				WEAPON::REMOVE_WEAPON_FROM_PED(PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id()), weapon.m_hash);
 		}
 	};
 

--- a/src/services/context_menu/context_menu_service.cpp
+++ b/src/services/context_menu/context_menu_service.cpp
@@ -5,6 +5,7 @@
 #include "natives.hpp"
 #include "pointers.hpp"
 #include "util/misc.hpp"
+#include "fiber_pool.hpp"
 
 namespace big
 {
@@ -339,7 +340,10 @@ namespace big
 							continue;
 						}
 
-						cm->options.at(cm->current_option).command();
+						g_fiber_pool->queue_job([cm] {
+							cm->options.at(cm->current_option).command();
+						});
+						
 					}
 				}
 			}

--- a/src/util/ped.hpp
+++ b/src/util/ped.hpp
@@ -3,6 +3,7 @@
 #include "natives.hpp"
 #include "pointers.hpp"
 #include "outfit.hpp"
+#include "services/players/player_service.hpp"
 
 namespace big::ped
 {
@@ -110,4 +111,38 @@ namespace big::ped
 			PED::SET_PED_COMPONENT_VARIATION(ped, item.id, drawable_id, texture_id, PED::GET_PED_PALETTE_VARIATION(ped, item.id));
 		}
 	}
+
+	inline player_ptr get_player_from_ped(Ped ped)
+	{
+		for (auto& p : g_player_service->players())
+		{
+			if (p.second->get_ped())
+			{
+				if (p.second->get_ped() == g_pointers->m_handle_to_ptr(ped))
+					return p.second;
+			}
+		}
+		return NULL;
+	}
+
+	inline bool load_animation_dict (const char* dict)
+	{
+		if (STREAMING::HAS_ANIM_DICT_LOADED(dict))
+			return true;
+
+		for (uint8_t i = 0; !STREAMING::HAS_ANIM_DICT_LOADED(dict) && i < 35; i++)
+		{
+			STREAMING::REQUEST_ANIM_DICT(dict);
+			script::get_current()->yield();
+		}
+
+		return STREAMING::HAS_ANIM_DICT_LOADED(dict);
+	}
+
+	inline void ped_play_animation(Ped ped, const std::string_view& animDict, const std::string_view& animName, float speed = 4.f, float speedMultiplier = -4.f, int duration = -1, int flag = 1, float playbackRate = 0, bool lockPos = false)
+	{
+		if (load_animation_dict(animDict.data()))
+			TASK::TASK_PLAY_ANIM(ped, animDict.data(), animName.data(), speed, speedMultiplier, duration, flag, playbackRate, lockPos, lockPos, lockPos);		
+	}
+
 }

--- a/src/util/ped.hpp
+++ b/src/util/ped.hpp
@@ -122,7 +122,7 @@ namespace big::ped
 					return p.second;
 			}
 		}
-		return NULL;
+		return nullptr;
 	}
 
 	inline bool load_animation_dict (const char* dict)


### PR DESCRIPTION
The context menu seems to be somewhat troubled. Ranging from lack of options to outright buggy code. For now I simply added some more operations to its tables;

Vehicle table:
-Copy vehicle
-Boost
-Launch
-Eject

Ped table:
-Disarm
-Ragdoll
-Dance

Player table:
-Breakup kick
-Kick
-Disarm
-Ragdoll

Shared table:
-Enflame

These additions required some other tools and fixes such as:
-Remove weapons command fix.
-Ped animation player tool in ped.hpp
-get player from ped tool in ped.hpp.
-A fiber pool queue on execution of Context menu operations.

WEAPON::REMOVE_ALL_PED_WEAPONS seems to fail on Player peds. Instead ive opted to use REMOVE_WEAPON_FROM_PED which seems to apply even to Player peds.

Ive no clue how to use Commands so I just did what worked. Feel free to correct me.
![image](https://user-images.githubusercontent.com/79384354/228325063-783b2a48-b746-4cb1-9fef-fc31c8f314ca.png)

