### PR TITLE
chore: remove session name spoof

### DIFF
--- a/src/core/globals.hpp
+++ b/src/core/globals.hpp
@@ -68,10 +68,10 @@ namespace big
 		{
 			bool enabled = false;
 		} cmd_executor{};
-    
+
 		rage::scrThread* m_modshop_thread = nullptr;
 		bool in_script_vm                 = false;
-    
+
 		struct debug
 		{
 			struct logs
@@ -329,9 +329,6 @@ namespace big
 			bool player_magnet_enabled = false;
 			int player_magnet_count    = 32;
 			bool is_team               = false;
-			bool name_spoof_enabled    = false;
-			bool advertise_menu        = false;
-			std::string spoofed_name   = "";
 			bool join_in_sctv_slots    = false;
 
 			const char chat_command_prefix = '/';
@@ -370,7 +367,7 @@ namespace big
 			bool show_cheating_message = false;
 			bool anonymous_bounty      = true;
 
-			NLOHMANN_DEFINE_TYPE_INTRUSIVE(session, local_weather, override_time, override_weather, custom_time, chat_force_clean, log_chat_messages, log_text_messages, decloak_players, force_session_host, force_script_host, player_magnet_enabled, player_magnet_count, is_team, name_spoof_enabled, advertise_menu, spoofed_name, join_in_sctv_slots, kick_chat_spammers, kick_host_when_forcing_host, explosion_karma, damage_karma, disable_traffic, disable_peds, force_thunder, block_ceo_money, randomize_ceo_colors, block_jobs, block_muggers, block_ceo_raids, send_to_apartment_idx, send_to_warehouse_idx, chat_commands, chat_command_default_access_level, show_cheating_message, anonymous_bounty)
+			NLOHMANN_DEFINE_TYPE_INTRUSIVE(session, local_weather, override_time, override_weather, custom_time, chat_force_clean, log_chat_messages, log_text_messages, decloak_players, force_session_host, force_script_host, player_magnet_enabled, player_magnet_count, is_team, join_in_sctv_slots, kick_chat_spammers, kick_host_when_forcing_host, explosion_karma, damage_karma, disable_traffic, disable_peds, force_thunder, block_ceo_money, randomize_ceo_colors, block_jobs, block_muggers, block_ceo_raids, send_to_apartment_idx, send_to_warehouse_idx, chat_commands, chat_command_default_access_level, show_cheating_message, anonymous_bounty)
 		} session{};
 
 		struct settings
@@ -432,7 +429,7 @@ namespace big
 		{
 			struct orbital_drone
 			{
-				bool enabled = false;
+				bool enabled             = false;
 				bool detect_player       = false;
 				float nav_ovverride_fast = 3.f;
 				float nav_ovverride_slow = 0.25f;

--- a/src/views/network/view_session.cpp
+++ b/src/views/network/view_session.cpp
@@ -83,7 +83,7 @@ namespace big
 		ImGui::Checkbox("AUTO_KICK_CHAT_SPAMMERS"_T.data(), &g.session.kick_chat_spammers);
 		ImGui::Checkbox("DISABLE_FILTER"_T.data(), &g.session.chat_force_clean);
 		if (ImGui::IsItemHovered())
-			ImGui::SetTooltip("Your sent chat messages will not be censored to the receivers");// TODO: add translation
+			ImGui::SetTooltip("Your sent chat messages will not be censored to the receivers"); // TODO: add translation
 		ImGui::Checkbox("LOG_CHAT_MSG"_T.data(), &g.session.log_chat_messages);
 		ImGui::Checkbox("LOG_TXT_MSG"_T.data(), &g.session.log_text_messages);
 		static char msg[256];
@@ -150,31 +150,6 @@ namespace big
 					if (auto script = gta_util::find_script_thread(RAGE_JOAAT("fmmc_launcher")); script && script->m_net_component)
 						script->m_net_component->block_host_migration(true);
 				});
-		}
-
-		components::sub_title("REMOTE_NAME_SPOOFING"_T);
-		ImGui::Checkbox("SPOOF_PLAYER_NAMES"_T.data(), &g.session.name_spoof_enabled);
-		if (ImGui::IsItemHovered())
-			ImGui::SetTooltip("SPOOF_PLAYER_NAMES_DESC"_T.data());
-
-		if (g.session.name_spoof_enabled)
-		{
-			ImGui::Checkbox("ADVERTISE_YIMMENU"_T.data(), &g.session.advertise_menu);
-			if (ImGui::IsItemHovered())
-				ImGui::SetTooltip("ADVERTISE_YIMMENU_DESC"_T.data());
-
-			if (!g.session.advertise_menu)
-			{
-				constexpr size_t name_size = RTL_FIELD_SIZE(rage::rlGamerInfo, m_name);
-				static char name[name_size];
-				strcpy_s(name, sizeof(name), g.session.spoofed_name.c_str());
-
-				ImGui::Text("PLAYER_SPOOFED_NAME"_T.data());
-				components::input_text("##username_input", name, sizeof(name));
-
-				if (name != g.session.spoofed_name)
-					g.session.spoofed_name = std::string(name);
-			}
 		}
 
 		components::sub_title("ALL_PLAYERS"_T);


### PR DESCRIPTION
These features haven't worked since update 1.64 so I'm removing them.