### PR TITLE
Fix: Request control 

### DIFF
--- a/src/util/entity.hpp
+++ b/src/util/entity.hpp
@@ -72,37 +72,29 @@ namespace big::entity
 
 	inline bool take_control_of(Entity ent, int timeout = 300)
 	{
-		if (auto hnd = g_pointers->m_handle_to_ptr(ent))
-		{
-			if (!*g_pointers->m_is_session_started || !hnd->m_net_object || network_has_control_of_entity(hnd->m_net_object))
-			{
-				return true;
-			}
-		}
-		else
-		{
+		auto hnd = g_pointers->m_handle_to_ptr(ent);
+
+		if(!hnd || !hnd->m_net_object || !*g_pointers->m_is_session_started) 
 			return false;
-		}
+		
+		if(network_has_control_of_entity(hnd->m_net_object))
+			return true;
 
 		for (int i = 0; i < timeout; i++)
 		{
-			auto hnd = g_pointers->m_handle_to_ptr(ent);
-
 			if (!hnd || !hnd->m_net_object)
 				return false;
 
 			g_pointers->m_request_control(hnd->m_net_object);
+
+			if(network_has_control_of_entity(hnd->m_net_object))
+				break;
+
 			if (timeout != 0)
 				script::get_current()->yield();
 		}
 
-		auto hnd = g_pointers->m_handle_to_ptr(ent);
-		if (!hnd || !hnd->m_net_object || !network_has_control_of_entity(hnd->m_net_object))
-			return false;
-
-		int netHandle = NETWORK::NETWORK_GET_NETWORK_ID_FROM_ENTITY(ent);
-		NETWORK::SET_NETWORK_ID_CAN_MIGRATE(netHandle, true);
-		return true;
+		return network_has_control_of_entity(hnd->m_net_object);
 	}
 
 	inline std::vector<Entity> get_entities(bool vehicles, bool peds)

--- a/src/util/entity.hpp
+++ b/src/util/entity.hpp
@@ -74,17 +74,17 @@ namespace big::entity
 	{
 		auto hnd = g_pointers->m_handle_to_ptr(ent);
 
-		if(!hnd || !hnd->m_net_object || !*g_pointers->m_is_session_started) 
+		if (!hnd || !hnd->m_net_object || !*g_pointers->m_is_session_started)
 			return false;
-		
-		if(network_has_control_of_entity(hnd->m_net_object))
+
+		if (network_has_control_of_entity(hnd->m_net_object))
 			return true;
 
 		for (int i = 0; i < timeout; i++)
 		{
 			g_pointers->m_request_control(hnd->m_net_object);
 
-			if(network_has_control_of_entity(hnd->m_net_object))
+			if (network_has_control_of_entity(hnd->m_net_object))
 				return true;
 
 			if (timeout != 0)
@@ -194,11 +194,10 @@ namespace big::entity
 
 	inline Entity get_entity_closest_to_middle_of_screen()
 	{
-	
 		Entity closest_entity{};
 		float distance = 1;
 
-		auto replayInterface = *g_pointers->m_replay_interface;
+		auto replayInterface  = *g_pointers->m_replay_interface;
 		auto vehicleInterface = replayInterface->m_vehicle_interface;
 		auto pedInterface     = replayInterface->m_ped_interface;
 

--- a/src/util/entity.hpp
+++ b/src/util/entity.hpp
@@ -82,19 +82,16 @@ namespace big::entity
 
 		for (int i = 0; i < timeout; i++)
 		{
-			if (!hnd || !hnd->m_net_object)
-				return false;
-
 			g_pointers->m_request_control(hnd->m_net_object);
 
 			if(network_has_control_of_entity(hnd->m_net_object))
-				break;
+				return true;
 
 			if (timeout != 0)
 				script::get_current()->yield();
 		}
 
-		return network_has_control_of_entity(hnd->m_net_object);
+		return false;
 	}
 
 	inline std::vector<Entity> get_entities(bool vehicles, bool peds)


### PR DESCRIPTION
The 'take_control_of' method was a little broken. Mostly due to poor coding and a simple mistake. The mistake was not stopping with the request when the control had already been taken, so the supposed timeout essentially became a timer instead. I believe my changes have alleviated this issue. Using features such as 'Boost vehicle', 'Flying vehicle, 'Burst tyres' should now work much faster. Closes #1220 .


