### PR TITLE
fix(Hotkey): Fast run and Freecam not working

### DIFF
--- a/src/backend/looped/self/noclip.cpp
+++ b/src/backend/looped/self/noclip.cpp
@@ -21,7 +21,6 @@ namespace big
 
 		virtual void on_tick() override
 		{
-
 			if (g_orbital_drone_service.initialized())
 				return;
 
@@ -35,7 +34,7 @@ namespace big
 			if (m_entity != ent)
 			{
 				ENTITY::FREEZE_ENTITY_POSITION(m_entity, false);
-				ENTITY::SET_ENTITY_COLLISION(m_entity, true, true);
+				ENTITY::SET_ENTITY_COLLISION(m_entity, true, false);
 
 				m_entity = ent;
 			}

--- a/src/services/hotkey/hotkey_service.cpp
+++ b/src/services/hotkey/hotkey_service.cpp
@@ -11,23 +11,26 @@ namespace big
 {
 	hotkey_service::hotkey_service()
 	{
-		register_hotkey("waypoint", g.settings.hotkeys.teleport_waypoint, RAGE_JOAAT("waypointtp"));
-		register_hotkey("objective", g.settings.hotkeys.teleport_objective, RAGE_JOAAT("objectivetp"));
-		register_hotkey("noclip", g.settings.hotkeys.noclip, RAGE_JOAAT("noclip"));
-		register_hotkey("bringpv", g.settings.hotkeys.bringvehicle, RAGE_JOAAT("bringpv"));
-		register_hotkey("invis", g.settings.hotkeys.invis, RAGE_JOAAT("invis"));
-		register_hotkey("heal", g.settings.hotkeys.heal, RAGE_JOAAT("heal"));
-		register_hotkey("fillsnacks", g.settings.hotkeys.fill_inventory, RAGE_JOAAT("fillsnacks"));
-		register_hotkey("skipcutscene", g.settings.hotkeys.skip_cutscene, RAGE_JOAAT("skipcutscene"));
-		register_hotkey("superjump", g.settings.hotkeys.superjump, RAGE_JOAAT("superjump"));
+		// ordered alphabetically to more easily see if a certain hotkey is present
 		register_hotkey("beastjump", g.settings.hotkeys.beastjump, RAGE_JOAAT("beastjump"));
-		register_hotkey("invisveh", g.settings.hotkeys.invisveh, RAGE_JOAAT("invisveh"));
-		register_hotkey("localinvisveh", g.settings.hotkeys.localinvisveh, RAGE_JOAAT("localinvisveh"));
+		register_hotkey("bringpv", g.settings.hotkeys.bringvehicle, RAGE_JOAAT("bringpv"));
+		register_hotkey("quicksearch", g.settings.hotkeys.cmd_excecutor, RAGE_JOAAT("cmdexecutor"));
+		register_hotkey("fastrun", g.settings.hotkeys.teleport_waypoint, RAGE_JOAAT("fastrun"));
 		register_hotkey("fastquit", g.settings.hotkeys.fast_quit, RAGE_JOAAT("fastquit"));
 		register_hotkey("fillammo", g.settings.hotkeys.fill_ammo, RAGE_JOAAT("fillammo"));
-		register_hotkey("quicksearch", g.settings.hotkeys.cmd_excecutor, RAGE_JOAAT("cmdexecutor"));
+		register_hotkey("fillsnacks", g.settings.hotkeys.fill_inventory, RAGE_JOAAT("fillsnacks"));
+		register_hotkey("freecam", g.settings.hotkeys.teleport_waypoint, RAGE_JOAAT("freecam"));
+		register_hotkey("heal", g.settings.hotkeys.heal, RAGE_JOAAT("heal"));
+		register_hotkey("invis", g.settings.hotkeys.invis, RAGE_JOAAT("invis"));
+		register_hotkey("invisveh", g.settings.hotkeys.invisveh, RAGE_JOAAT("invisveh"));
+		register_hotkey("localinvisveh", g.settings.hotkeys.localinvisveh, RAGE_JOAAT("localinvisveh"));
+		register_hotkey("noclip", g.settings.hotkeys.noclip, RAGE_JOAAT("noclip"));
+		register_hotkey("objective", g.settings.hotkeys.teleport_objective, RAGE_JOAAT("objectivetp"));
 		register_hotkey("repairpv", g.settings.hotkeys.repairpv, RAGE_JOAAT("repairpv"));
+		register_hotkey("skipcutscene", g.settings.hotkeys.skip_cutscene, RAGE_JOAAT("skipcutscene"));
+		register_hotkey("superjump", g.settings.hotkeys.superjump, RAGE_JOAAT("superjump"));
 		register_hotkey("vehiclecontroller", g.settings.hotkeys.open_vehicle_controller, RAGE_JOAAT("vehiclecontrol"));
+		register_hotkey("waypoint", g.settings.hotkeys.teleport_waypoint, RAGE_JOAAT("waypointtp"));
 
 		g_renderer->add_wndproc_callback([this](HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam) {
 			wndproc(static_cast<eKeyState>(msg), wparam);

--- a/src/util/entity.hpp
+++ b/src/util/entity.hpp
@@ -72,6 +72,9 @@ namespace big::entity
 
 	inline bool take_control_of(Entity ent, int timeout = 300)
 	{
+		if (!*g_pointers->m_gta.m_is_session_started)
+			return true;
+
 		auto hnd = g_pointers->m_gta.m_handle_to_ptr(ent);
 
 		if (!hnd || !hnd->m_net_object || !*g_pointers->m_gta.m_is_session_started)

--- a/src/views/settings/view_hotkey_settings.cpp
+++ b/src/views/settings/view_hotkey_settings.cpp
@@ -30,11 +30,11 @@ namespace big
 			g_hotkey_service->update_hotkey("skipcutscene", g.settings.hotkeys.skip_cutscene);
 		if (ImGui::Hotkey("Toggle Freecam", &g.settings.hotkeys.freecam))
 			g_hotkey_service->update_hotkey("freecam", g.settings.hotkeys.freecam);
-		if (ImGui::Hotkey("Toggle fastrun", &g.settings.hotkeys.superrun))
+		if (ImGui::Hotkey("Toggle Fastrun", &g.settings.hotkeys.superrun))
 			g_hotkey_service->update_hotkey("fastrun", g.settings.hotkeys.superrun);
-		if (ImGui::Hotkey("Toggle superjump", &g.settings.hotkeys.superjump))
+		if (ImGui::Hotkey("Toggle Superjump", &g.settings.hotkeys.superjump))
 			g_hotkey_service->update_hotkey("superjump", g.settings.hotkeys.superjump);
-		if (ImGui::Hotkey("Toggle beastjump", &g.settings.hotkeys.beastjump))
+		if (ImGui::Hotkey("Toggle Beastjump", &g.settings.hotkeys.beastjump))
 			g_hotkey_service->update_hotkey("beastjump", g.settings.hotkeys.beastjump);
 		if (ImGui::Hotkey("Toggle Vehicle Invisibility", &g.settings.hotkeys.invisveh))
 			g_hotkey_service->update_hotkey("invisveh", g.settings.hotkeys.invisveh);


### PR DESCRIPTION
Fixed an issue where no clip wouldn't disable correctly in single player, this should also fix any other issues in regards to grabbing control of entities in single player.

Fixes #1178