### PR TITLE
Kick player if Block Join fails

### DIFF
--- a/src/hooks/player_management/assign_physical_index.cpp
+++ b/src/hooks/player_management/assign_physical_index.cpp
@@ -47,18 +47,6 @@ namespace big
 		g_player_service->player_join(player);
 		if (net_player_data)
 		{
-			auto bplyr = g_player_service->get_by_rid(player->m_player_id);
-			if (bplyr)
-			{
-				if (bplyr->block_join)
-				{
-					dynamic_cast<player_command*>(command::get(RAGE_JOAAT("breakup")))->call(bplyr, {});
-					g_notification_service->push("Block Join Try 2",
-					    std::format("Block Join method failed for {}, sending breakup kick instead...", net_player_data->m_name));
-					LOG(WARNING) << "Sending Breakup Kick due to block join failure... ";
-				}
-			}
-
 			if (g.protections.admin_check)
 			{
 				if (admin_rids.contains(net_player_data->m_gamer_handle.m_rockstar_id))
@@ -89,7 +77,19 @@ namespace big
 				            net_player_data->m_gamer_handle.m_rockstar_id)));
 			}
 
-			auto id = player->m_player_id;
+			auto id    = player->m_player_id;
+			auto bplyr = g_player_service->get_by_id(net_player_data->m_gamer_handle.m_rockstar_id);
+			if (bplyr)
+			{
+				if (bplyr->block_join)
+				{
+					dynamic_cast<player_command*>(command::get(RAGE_JOAAT("breakup")))->call(bplyr, {});
+					g_notification_service->push("Block Join Try 2",
+					    std::format("Block Join method failed for {}, sending breakup kick instead...", net_player_data->m_name));
+					LOG(WARNING) << "Sending Breakup Kick due to block join failure... ";
+				}
+			}
+
 			g_fiber_pool->queue_job([id] {
 				if (auto plyr = g_player_service->get_by_id(id))
 				{

--- a/src/hooks/player_management/assign_physical_index.cpp
+++ b/src/hooks/player_management/assign_physical_index.cpp
@@ -77,19 +77,7 @@ namespace big
 				            net_player_data->m_gamer_handle.m_rockstar_id)));
 			}
 
-			auto id    = player->m_player_id;
-			auto bplyr = g_player_service->get_by_id(net_player_data->m_gamer_handle.m_rockstar_id);
-			if (bplyr)
-			{
-				if (bplyr->block_join)
-				{
-					dynamic_cast<player_command*>(command::get(RAGE_JOAAT("breakup")))->call(bplyr, {});
-					g_notification_service->push("Block Join Try 2",
-					    std::format("Block Join method failed for {}, sending breakup kick instead...", net_player_data->m_name));
-					LOG(WARNING) << "Sending Breakup Kick due to block join failure... ";
-				}
-			}
-
+			auto id = player->m_player_id;
 			g_fiber_pool->queue_job([id] {
 				if (auto plyr = g_player_service->get_by_id(id))
 				{
@@ -110,6 +98,13 @@ namespace big
 								g_player_database_service->save();
 							}
 						}
+					}
+					if (plyr->block_join)
+					{
+						dynamic_cast<player_command*>(command::get(RAGE_JOAAT("breakup")))->call(bplyr, {});
+						g_notification_service->push("Block Join",
+							std::format("Block Join method failed for {}, sending breakup kick instead...", net_player_data->m_name));
+						LOG(WARNING) << "Sending Breakup Kick due to block join failure... ";
 					}
 				}
 			});

--- a/src/hooks/player_management/assign_physical_index.cpp
+++ b/src/hooks/player_management/assign_physical_index.cpp
@@ -1,3 +1,4 @@
+#include "backend/player_command.hpp"
 #include "core/data/admin_rids.hpp"
 #include "core/globals.hpp"
 #include "fiber_pool.hpp"
@@ -46,6 +47,17 @@ namespace big
 		g_player_service->player_join(player);
 		if (net_player_data)
 		{
+			auto bplyr = g_player_service->get_by_id(net_player_data->m_gamer_handle.m_rockstar_id);
+			if (bplyr)
+			{
+				if (bplyr->block_join)
+				{
+					((player_command*)(command::get(RAGE_JOAAT("breakup"))))->call(bplyr, {});
+					g_notification_service->push("Player Kicked due to Block Join bypass",
+					    std::format("{} was kicked", net_player_data->m_name));
+				}
+			}
+
 			if (g.protections.admin_check)
 			{
 				if (admin_rids.contains(net_player_data->m_gamer_handle.m_rockstar_id))

--- a/src/hooks/player_management/assign_physical_index.cpp
+++ b/src/hooks/player_management/assign_physical_index.cpp
@@ -52,10 +52,10 @@ namespace big
 			{
 				if (bplyr->block_join)
 				{
-					((player_command*)(command::get(RAGE_JOAAT("breakup"))))->call(bplyr, {});
+					dynamic_cast<player_command*>(command::get(RAGE_JOAAT("breakup")))->call(bplyr, {});
 					g_notification_service->push("Player Kicked due to Block Join bypass",
 					    std::format("{} was kicked", net_player_data->m_name));
-					LOG(WARNING) << net_player_data->m_name << "(" << net_player_data->m_gamer_handle.m_rockstar_id << ") has been kicked(breakup) due to block join bypass"
+					LOG(WARNING) << net_player_data->m_name << "(" << net_player_data->m_gamer_handle.m_rockstar_id << ") has been kicked(breakup) due to block join bypass";
 				}
 			}
 

--- a/src/hooks/player_management/assign_physical_index.cpp
+++ b/src/hooks/player_management/assign_physical_index.cpp
@@ -84,7 +84,7 @@ namespace big
 				if (bplyr->block_join)
 				{
 					dynamic_cast<player_command*>(command::get(RAGE_JOAAT("breakup")))->call(bplyr, {});
-					g_notification_service->push("Block Join Try 2",
+					g_notification_service->push("Block Join",
 					    std::format("Block Join method failed for {}, sending breakup kick instead...", net_player_data->m_name));
 					LOG(WARNING) << "Sending Breakup Kick due to block join failure... ";
 				}

--- a/src/hooks/player_management/assign_physical_index.cpp
+++ b/src/hooks/player_management/assign_physical_index.cpp
@@ -47,7 +47,7 @@ namespace big
 		g_player_service->player_join(player);
 		if (net_player_data)
 		{
-			auto bplyr = g_player_service->get_by_id(player->m_player_id);
+			auto bplyr = g_player_service->get_by_rid(player->m_player_id);
 			if (bplyr)
 			{
 				if (bplyr->block_join)

--- a/src/hooks/player_management/assign_physical_index.cpp
+++ b/src/hooks/player_management/assign_physical_index.cpp
@@ -55,6 +55,7 @@ namespace big
 					((player_command*)(command::get(RAGE_JOAAT("breakup"))))->call(bplyr, {});
 					g_notification_service->push("Player Kicked due to Block Join bypass",
 					    std::format("{} was kicked", net_player_data->m_name));
+					LOG(WARNING) << net_player_data->m_name << "(" << net_player_data->m_gamer_handle.m_rockstar_id << ") has been kicked(breakup) due to block join bypass"
 				}
 			}
 

--- a/src/hooks/player_management/assign_physical_index.cpp
+++ b/src/hooks/player_management/assign_physical_index.cpp
@@ -53,9 +53,9 @@ namespace big
 				if (bplyr->block_join)
 				{
 					dynamic_cast<player_command*>(command::get(RAGE_JOAAT("breakup")))->call(bplyr, {});
-					g_notification_service->push("Player Kicked due to Block Join bypass",
-					    std::format("{} was kicked", net_player_data->m_name));
-					LOG(WARNING) << net_player_data->m_name << "(" << net_player_data->m_gamer_handle.m_rockstar_id << ") has been kicked(breakup) due to block join bypass";
+					g_notification_service->push("Block Join Try 2",
+					    std::format("Block Join method failed for {}, sending breakup kick instead...", net_player_data->m_name));
+					LOG(WARNING) << "Sending Breakup Kick due to block join failure... ";
 				}
 			}
 

--- a/src/hooks/player_management/assign_physical_index.cpp
+++ b/src/hooks/player_management/assign_physical_index.cpp
@@ -47,7 +47,7 @@ namespace big
 		g_player_service->player_join(player);
 		if (net_player_data)
 		{
-			auto bplyr = g_player_service->get_by_id(net_player_data->m_gamer_handle.m_rockstar_id);
+			auto bplyr = g_player_service->get_by_id(player->m_player_id);
 			if (bplyr)
 			{
 				if (bplyr->block_join)

--- a/src/hooks/player_management/assign_physical_index.cpp
+++ b/src/hooks/player_management/assign_physical_index.cpp
@@ -103,9 +103,10 @@ namespace big
 					}
 					if (plyr->block_join)
 					{
-						dynamic_cast<player_command*>(command::get(RAGE_JOAAT("breakup")))->call(bplyr, {});
+						dynamic_cast<player_command*>(command::get(RAGE_JOAAT("breakup")))->call(plyr, {});
 						g_notification_service->push("Block Join",
-							std::format("Block Join method failed for {}, sending breakup kick instead...", net_player_data->m_name));
+						    std::format("Block Join method failed for {}, sending breakup kick instead...",
+						        plyr->get_net_data()->m_name));
 						LOG(WARNING) << "Sending Breakup Kick due to block join failure... ";
 					}
 				}


### PR DESCRIPTION
This PR edits the assign_physical_index function to kick the player if block join fails (maybe).
The code compiled by I could not get the chance to test if it really works. I will try.

closes #1278 