### PR TITLE
potential fix for some infinite loop train(?) crash

### DIFF
--- a/src/function_types.hpp
+++ b/src/function_types.hpp
@@ -137,5 +137,5 @@ namespace big::functions
 
 	using migrate_object = void (*)(CNetGamePlayer* player, rage::netObject* object, int type);
 
-	using some_train_crash = bool (*)(size_t index_into_array, float* i);
+	using some_train_crash = bool (*)(char index_into_array, float* i);
 }

--- a/src/function_types.hpp
+++ b/src/function_types.hpp
@@ -136,4 +136,6 @@ namespace big::functions
 	using get_entity_attached_to = rage::CDynamicEntity* (*)(rage::CDynamicEntity* entity);
 
 	using migrate_object = void (*)(CNetGamePlayer* player, rage::netObject* object, int type);
+
+	using some_train_crash = bool (*)(size_t index_into_array, float* i);
 }

--- a/src/gta_pointers.hpp
+++ b/src/gta_pointers.hpp
@@ -268,6 +268,9 @@ namespace big
 		GenericPool** m_ped_pool{};
 		GenericPool** m_prop_pool{};
 		VehiclePool*** m_vehicle_pool{};
+
+		functions::some_train_crash m_some_train_crash{};
+		PVOID m_some_train_array{};
 	};
 #pragma pack(pop)
 	static_assert(sizeof(gta_pointers) % 8 == 0, "Pointers are not properly aligned");

--- a/src/hooking.cpp
+++ b/src/hooking.cpp
@@ -125,6 +125,8 @@ namespace big
 
 		detour_hook_helper::add<hooks::allow_weapons_in_vehicle>("AWIV", g_pointers->m_gta.m_allow_weapons_in_vehicle);
 
+		detour_hook_helper::add<hooks::fix_some_train_crash>("FSTC", g_pointers->m_gta.m_some_train_crash);
+
 		g_hooking = this;
 	}
 

--- a/src/hooking.hpp
+++ b/src/hooking.hpp
@@ -163,6 +163,8 @@ namespace big
 		static bool fipackfile_mount(rage::fiPackfile* this_, const char* mount_point);
 
 		static bool allow_weapons_in_vehicle(int64_t unk, int weaponinfo_group);
+
+		static bool fix_some_train_crash(size_t index_into_array, float* i);
 	};
 
 	class minhook_keepalive

--- a/src/hooking.hpp
+++ b/src/hooking.hpp
@@ -164,7 +164,7 @@ namespace big
 
 		static bool allow_weapons_in_vehicle(int64_t unk, int weaponinfo_group);
 
-		static bool fix_some_train_crash(size_t index_into_array, float* i);
+		static bool fix_some_train_crash(char index_into_array, float* i);
 	};
 
 	class minhook_keepalive

--- a/src/hooks/protections/fix_some_train_crash.cpp
+++ b/src/hooks/protections/fix_some_train_crash.cpp
@@ -4,7 +4,7 @@
 
 namespace big
 {
-	bool hooks::fix_some_train_crash(size_t index_into_array, float* i)
+	bool hooks::fix_some_train_crash(char index_into_array, float* i)
 	{
 		if (index_into_array < 0)
 			return 0;
@@ -12,9 +12,12 @@ namespace big
 		constexpr size_t sizeof_some_struct = 592;
 		size_t obj_offset                   = sizeof_some_struct * index_into_array;
 
-		if (*((byte*)&g_pointers->m_gta.m_some_train_array + obj_offset + 5))
+		const byte* train_array = reinterpret_cast<byte*>(g_pointers->m_gta.m_some_train_array);
+
+		if (*(train_array + obj_offset + 5))
 		{
-			float exit_cond = *(float*)((byte*)&g_pointers->m_gta.m_some_train_array + obj_offset + 32);
+			float exit_cond = *(float*)(train_array + obj_offset + 32);
+
 			if (exit_cond <= 0)
 			{
 				return 0;

--- a/src/hooks/protections/fix_some_train_crash.cpp
+++ b/src/hooks/protections/fix_some_train_crash.cpp
@@ -1,0 +1,26 @@
+#include "hooking.hpp"
+
+#include <pointers.hpp>
+
+namespace big
+{
+	bool hooks::fix_some_train_crash(size_t index_into_array, float* i)
+	{
+		if (index_into_array < 0)
+			return 0;
+
+		constexpr size_t sizeof_some_struct = 592;
+		size_t obj_offset                   = sizeof_some_struct * index_into_array;
+
+		if (*((byte*)&g_pointers->m_gta.m_some_train_array + obj_offset + 5))
+		{
+			float exit_cond = *(float*)((byte*)&g_pointers->m_gta.m_some_train_array + obj_offset + 32);
+			if (exit_cond <= 0)
+			{
+				return 0;
+			}
+		}
+
+		return g_hooking->get_original<hooks::fix_some_train_crash>()(index_into_array, i);
+	}
+}

--- a/src/pointers.cpp
+++ b/src/pointers.cpp
@@ -1385,6 +1385,16 @@ namespace big
                 g_pointers->m_gta.m_script_vm_patch_5 = ptr;
                 g_pointers->m_gta.m_script_vm_patch_6 = ptr.add(0x26);
             }
+        },
+        // Some Train Crash
+        {
+            "STC",
+            "45 32 C0 84 C9 79 03",
+            [](memory::handle ptr)
+            {
+                g_pointers->m_gta.m_some_train_crash = ptr.as<functions::some_train_crash>();
+                g_pointers->m_gta.m_some_train_array = ptr.add(0x11).rip().as<PVOID>();
+            }
         }
         >(); // don't leave a trailing comma at the end
 


### PR DESCRIPTION
Need someone to sanity check this
func is located at
`45 32 C0 84 C9 79 03`

the infinite (do while) loop was found with the following callstack:


```
0, GTA5.exe+0xf1f2d6
1, GTA5.exe+0xfafa0a
2, GTA5.exe+0xf901d7
3, GTA5.exe+0x94026c
4, GTA5.exe+0x164c04d
5, GTA5.exe+0x6c4cfd
6, GTA5.exe+0x6d49a0
7, GTA5.exe+0x93309f
8, GTA5.exe+0x94ffad
9, GTA5.exe+0x1606401
10, GTA5.exe+0x1605c37
11, GTA5.exe+0x2765c
12, GTA5.exe+0x20d4b
13, GTA5.exe+0x1605840
14, GTA5.exe+0x1494
15, GTA5.exe+0x12e0267
16, GTA5.exe+0x17f7ea4
17, kernel32.dll!BaseThreadInitThunk+0x1d
18, ntdll.dll!RtlUserThreadStart+0x28
```
