### PR TITLE
Context menu: Fixed irregular distribution of operations and added some more

### DIFF
--- a/src/services/context_menu/context_menu_service.hpp
+++ b/src/services/context_menu/context_menu_service.hpp
@@ -71,6 +71,29 @@ namespace big
 			         else
 				         g_notification_service->push_warning("Toxic", "Failed to take control of vehicle.");
 		         }},
+		        {"BURST TIRES",
+		            [this] {
+			            if (entity::take_control_of(m_handle))
+			            {
+				            VEHICLE::SET_VEHICLE_TYRES_CAN_BURST(m_handle, true);
+
+				            for (int i = 0; i < 8; i++)
+				            {
+					            VEHICLE::SET_VEHICLE_TYRE_BURST(m_handle, i, true, 1000.0);
+				            }
+			            }
+			            else
+				            g_notification_service->push_warning("Toxic", "Failed to take control of vehicle.");
+		            }},
+				{"HALT",
+		            [this] {
+			            if (entity::take_control_of(m_handle))
+			            {
+				            VEHICLE::BRING_VEHICLE_TO_HALT(m_handle, 1, 5, true);
+			            }
+			            else
+				            g_notification_service->push_warning("Toxic", "Failed to take control of vehicle.");
+		            }},
 		        {"COPY VEHICLE",
 		            [this] {
 			            Vehicle v = persist_car_service::clone_ped_car(PLAYER::PLAYER_PED_ID(), m_handle);
@@ -102,13 +125,6 @@ namespace big
 			            TASK::CLEAR_PED_TASKS_IMMEDIATELY(VEHICLE::GET_PED_IN_VEHICLE_SEAT(m_handle, -1, 0));
 			            TASK::CLEAR_PED_TASKS_IMMEDIATELY(m_handle);
 		            }},
-		        {"DELETE",
-		            [this] {
-			            if (entity::take_control_of(m_handle))
-			            {
-				            entity::delete_entity(m_handle);
-			            }
-		            }},
 		        {"TP INTO", [this] {
 			         teleport::into_vehicle(m_handle);
 		         }}}};
@@ -125,8 +141,27 @@ namespace big
 		            [this] {
 			            PED::SET_PED_TO_RAGDOLL(m_handle, 2000, 2000, 0, 0, 0, 0);
 		            }},
-		        {"DANCE", [this] {
-			         ped::ped_play_animation(m_handle, "mini@strip_club@private_dance@part1", "priv_dance_p1");
+		        {"DANCE",
+		            [this] {
+			            ped::ped_play_animation(m_handle, "mini@strip_club@private_dance@part1", "priv_dance_p1");
+		            }},
+		        {"RECRUIT", [this] {
+			         TASK::CLEAR_PED_TASKS(m_handle);
+			         PED::SET_PED_AS_GROUP_MEMBER(m_handle, PED::GET_PED_GROUP_INDEX(self::ped));
+					 PED::SET_PED_RELATIONSHIP_GROUP_HASH(m_handle, PED::GET_PED_RELATIONSHIP_GROUP_HASH(self::ped));
+			         PED::SET_PED_NEVER_LEAVES_GROUP(m_handle, true);
+			         PED::SET_CAN_ATTACK_FRIENDLY(m_handle, 0, 1);
+			         PED::SET_PED_COMBAT_ABILITY(m_handle, 2);
+			         PED::SET_PED_CAN_TELEPORT_TO_GROUP_LEADER(m_handle, PED::GET_PED_GROUP_INDEX(self::ped), true);
+			         PED::SET_PED_FLEE_ATTRIBUTES(m_handle, 512 | 1024 | 2048 | 16384 | 131072 | 262144, true);
+			         PED::SET_PED_COMBAT_ATTRIBUTES(m_handle, 5, true);
+			         PED::SET_PED_COMBAT_ATTRIBUTES(m_handle, 13, true);
+			         PED::SET_PED_CONFIG_FLAG(m_handle, 394, true);
+			         PED::SET_PED_CONFIG_FLAG(m_handle, 400, true);
+					 PED::SET_PED_CONFIG_FLAG(m_handle, 134, true);
+			         WEAPON::GIVE_WEAPON_TO_PED(m_handle, RAGE_JOAAT("weapon_microsmg"), 9999, false, false);
+			         WEAPON::GIVE_WEAPON_TO_PED(m_handle, RAGE_JOAAT("weapon_carbinerifle"), 9999, false, true);
+			         TASK::TASK_COMBAT_HATED_TARGETS_AROUND_PED(self::ped, 100, 67108864);
 		         }}}};
 
 		s_context_menu object_menu{ContextEntityType::OBJECT, 0, {}, {}};
@@ -134,10 +169,14 @@ namespace big
 		s_context_menu player_menu{ContextEntityType::PLAYER,
 		    0,
 		    {},
-		    {{"STEAL IDENTITY",
+		    {{"SET SELECTED",
 		         [this] {
-			         ped::steal_identity(m_handle);
+			         g_player_service->set_selected(ped::get_player_from_ped(m_handle));
 		         }},
+		        {"STEAL IDENTITY",
+		            [this] {
+			            ped::steal_identity(m_handle);
+		            }},
 		        {"BREAKUP KICK",
 		            [this] {
 			            static player_command* command = dynamic_cast<player_command*>(command::get(rage::consteval_joaat("breakup")));
@@ -175,12 +214,23 @@ namespace big
 			            rage::fvector3 pos = *m_pointer->m_navigation->get_position();
 			            teleport::to_coords({pos.x, pos.y, pos.z});
 		            }},
+		        {"TP ON TOP",
+		            [this] {
+			            teleport::tp_on_top(m_handle, true);
+		            }},
 		        {"ENFLAME",
 		            [this] {
 			            Vector3 pos = ENTITY::GET_ENTITY_COORDS(m_handle, TRUE);
 			            FIRE::START_ENTITY_FIRE(m_handle);
 			            FIRE::START_SCRIPT_FIRE(pos.x, pos.y, pos.z, 25, TRUE);
-			            MISC::SHOOT_SINGLE_BULLET_BETWEEN_COORDS(pos.x, pos.y, pos.z, pos.x, pos.y, pos.z, 1.f, 0, 615608432, PLAYER::PLAYER_PED_ID(), TRUE, TRUE, 1.f);
+			            FIRE::ADD_EXPLOSION(pos.x, pos.y, pos.z, eExplosionTag::DIR_FLAME, 1, false, false, 0, false);
+		            }},
+		        {"DELETE",
+		            [this] {
+			            if (entity::take_control_of(m_handle))
+			            {
+				            entity::delete_entity(m_handle);
+			            }
 		            }},
 		        {"COPY HASH", [this] {
 			         ImGui::SetClipboardText(std::format("0x{:08X}", (rage::joaat_t)m_pointer->m_model_info->m_hash).c_str());

--- a/src/services/context_menu/context_menu_service.hpp
+++ b/src/services/context_menu/context_menu_service.hpp
@@ -223,7 +223,7 @@ namespace big
 			            Vector3 pos = ENTITY::GET_ENTITY_COORDS(m_handle, TRUE);
 			            FIRE::START_ENTITY_FIRE(m_handle);
 			            FIRE::START_SCRIPT_FIRE(pos.x, pos.y, pos.z, 25, TRUE);
-			            FIRE::ADD_EXPLOSION(pos.x, pos.y, pos.z, eExplosionTag::DIR_FLAME, 1, false, false, 0, false);
+			            FIRE::ADD_EXPLOSION(pos.x, pos.y, pos.z, eExplosionTag::MOLOTOV, 1, false, false, 0, false);
 		            }},
 		        {"DELETE",
 		            [this] {

--- a/src/util/teleport.hpp
+++ b/src/util/teleport.hpp
@@ -163,4 +163,24 @@ namespace big::teleport
 
 		return false;
 	}
+
+	inline bool tp_on_top(Entity ent, bool match_velocity)
+	{
+		if (!ENTITY::DOES_ENTITY_EXIST(ent))
+			return false;
+
+		Vector3 ent_dimensions_max{}, ent_pos{};
+
+		MISC::GET_MODEL_DIMENSIONS(ENTITY::GET_ENTITY_MODEL(ent), nullptr, &ent_dimensions_max);
+		ent_pos = ENTITY::GET_OFFSET_FROM_ENTITY_IN_WORLD_COORDS(ent, 0, 0, ent_dimensions_max.z);
+		ENTITY::SET_ENTITY_COORDS_NO_OFFSET(self::ped, ent_pos.x, ent_pos.y, ent_pos.z, 0, 0, 0);
+
+		if (match_velocity)
+		{
+			auto ent_velocity = ENTITY::GET_ENTITY_VELOCITY(ent);
+			ENTITY::SET_ENTITY_VELOCITY(self::ped, ent_velocity.x, ent_velocity.y, ent_velocity.z);
+		}
+
+		return false;
+	}
 }


### PR DESCRIPTION
Some operations that needed to be in the Shared pool were exclusive and there were some trivial operations missing.

Added:
-Burst tires (Vehicle)
-Halt vehicle (Vehicle)
-Recruit Ped (Ped)
-Set selected player (Player)
-Tp on top (Shared)
-Delete (Shared)
-Enflame (Shared), changed bullet spawning to explosion spawning.

Currently, recruited peds act scared and cower when entering the player vehicle. No idea why and how to fix that.
