### PR TITLE
update for PDB filters notify and status 

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,37 @@
+name: CMake
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -C ${{env.BUILD_TYPE}}
+

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,5 +1,3 @@
-name: CMake
-
 on:
   push:
     branches: [ "master" ]

--- a/src/hooks/player_management/assign_physical_index.cpp
+++ b/src/hooks/player_management/assign_physical_index.cpp
@@ -91,6 +91,7 @@ namespace big
 							plyr->is_modder         = entry->is_modder;
 							plyr->block_join        = entry->block_join;
 							plyr->block_join_reason = entry->block_join_reason;
+							plyr->is_friends        = entry->is_friends;
 
 							if (strcmp(plyr->get_name(), entry->name.data()))
 							{

--- a/src/hooks/player_management/assign_physical_index.cpp
+++ b/src/hooks/player_management/assign_physical_index.cpp
@@ -91,6 +91,8 @@ namespace big
 							plyr->is_modder         = entry->is_modder;
 							plyr->block_join        = entry->block_join;
 							plyr->block_join_reason = entry->block_join_reason;
+							plyr->is_friends        = entry->is_friends;
+							plyr->notify_online     = entry->notify_online;
 
 							if (strcmp(plyr->get_name(), entry->name.data()))
 							{

--- a/src/hooks/player_management/assign_physical_index.cpp
+++ b/src/hooks/player_management/assign_physical_index.cpp
@@ -92,7 +92,7 @@ namespace big
 							plyr->block_join        = entry->block_join;
 							plyr->block_join_reason = entry->block_join_reason;
 							plyr->is_friends        = entry->is_friends;
-            	plyr->notify_online     = entry->notify_online;
+            						plyr->notify_online     = entry->notify_online;
 
 
 							if (strcmp(plyr->get_name(), entry->name.data()))

--- a/src/services/player_database/persistent_player.hpp
+++ b/src/services/player_database/persistent_player.hpp
@@ -52,6 +52,7 @@ namespace big
 		int block_join_reason     = 1;
 		bool is_modder            = false;
 		bool is_friends           = false;
+		
 		std::unordered_set<int> infractions;
 		std::optional<CommandAccessLevel> command_access_level = std::nullopt;
 		PlayerOnlineStatus online_state                        = PlayerOnlineStatus::UNKNOWN;

--- a/src/services/player_database/persistent_player.hpp
+++ b/src/services/player_database/persistent_player.hpp
@@ -51,13 +51,12 @@ namespace big
 		bool block_join           = false;
 		int block_join_reason     = 1;
 		bool is_modder            = false;
-		bool is_friends            = false;
-		
+		bool is_friends           = false;
 		std::unordered_set<int> infractions;
 		std::optional<CommandAccessLevel> command_access_level = std::nullopt;
 		PlayerOnlineStatus online_state                        = PlayerOnlineStatus::UNKNOWN;
 
-		NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(persistent_player, name, rockstar_id, block_join, block_join_reason, is_modder, is_friends, infractions, command_access_level)
+		NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(persistent_player, name, rockstar_id, block_join, block_join_reason, is_friends, is_modder, infractions, command_access_level)
 	};
 
 };

--- a/src/services/player_database/persistent_player.hpp
+++ b/src/services/player_database/persistent_player.hpp
@@ -51,11 +51,13 @@ namespace big
 		bool block_join           = false;
 		int block_join_reason     = 1;
 		bool is_modder            = false;
+		bool is_friends           = false;
+		bool notify_online        = false;
 		std::unordered_set<int> infractions;
 		std::optional<CommandAccessLevel> command_access_level = std::nullopt;
 		PlayerOnlineStatus online_state                        = PlayerOnlineStatus::UNKNOWN;
 
-		NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(persistent_player, name, rockstar_id, block_join, block_join_reason, is_modder, infractions, command_access_level)
+		NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(persistent_player, name, rockstar_id, block_join, block_join_reason, is_modder, is_friends, notify_online, infractions, command_access_level)
 	};
 
 };

--- a/src/services/player_database/persistent_player.hpp
+++ b/src/services/player_database/persistent_player.hpp
@@ -52,6 +52,7 @@ namespace big
 		int block_join_reason     = 1;
 		bool is_modder            = false;
 		bool is_friends            = false;
+		
 		std::unordered_set<int> infractions;
 		std::optional<CommandAccessLevel> command_access_level = std::nullopt;
 		PlayerOnlineStatus online_state                        = PlayerOnlineStatus::UNKNOWN;

--- a/src/services/player_database/persistent_player.hpp
+++ b/src/services/player_database/persistent_player.hpp
@@ -51,11 +51,12 @@ namespace big
 		bool block_join           = false;
 		int block_join_reason     = 1;
 		bool is_modder            = false;
+		bool is_friends            = false;
 		std::unordered_set<int> infractions;
 		std::optional<CommandAccessLevel> command_access_level = std::nullopt;
 		PlayerOnlineStatus online_state                        = PlayerOnlineStatus::UNKNOWN;
 
-		NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(persistent_player, name, rockstar_id, block_join, block_join_reason, is_modder, infractions, command_access_level)
+		NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(persistent_player, name, rockstar_id, block_join, block_join_reason, is_modder, is_friends, infractions, command_access_level)
 	};
 
 };

--- a/src/services/player_database/player_database_service.cpp
+++ b/src/services/player_database/player_database_service.cpp
@@ -200,7 +200,14 @@ namespace big
 					{
 						it->second->online_state = PlayerOnlineStatus::OFFLINE;
 						if (online[i] == 1)
+						{
 							it->second->online_state = PlayerOnlineStatus::ONLINE;
+							if (it->second->notify_online)
+							{
+								g_notification_service->push_warning("Player Online Notification",
+								    std::format("{} is now online!", it->second->name));
+							}
+						}
 					}
 				}
 			}

--- a/src/services/players/player.hpp
+++ b/src/services/players/player.hpp
@@ -78,6 +78,7 @@ namespace big
 		int block_join_reason          = 0;
 		bool is_spammer                = false;
 		bool is_admin                  = false;
+		bool is_friends                = false;
 		std::optional<std::uint32_t> player_time_value;
 		std::optional<std::chrono::time_point<std::chrono::system_clock, std::chrono::milliseconds>> player_time_value_received_time;
 		std::optional<std::uint32_t> time_difference;

--- a/src/services/players/player.hpp
+++ b/src/services/players/player.hpp
@@ -79,6 +79,7 @@ namespace big
 		bool is_spammer                = false;
 		bool is_admin                  = false;
 		bool is_friends                = false;
+		
 		std::optional<std::uint32_t> player_time_value;
 		std::optional<std::chrono::time_point<std::chrono::system_clock, std::chrono::milliseconds>> player_time_value_received_time;
 		std::optional<std::uint32_t> time_difference;

--- a/src/services/players/player.hpp
+++ b/src/services/players/player.hpp
@@ -78,6 +78,8 @@ namespace big
 		int block_join_reason          = 0;
 		bool is_spammer                = false;
 		bool is_admin                  = false;
+		bool is_friends                = false;
+		bool notify_online             = false;
 		std::optional<std::uint32_t> player_time_value;
 		std::optional<std::chrono::time_point<std::chrono::system_clock, std::chrono::milliseconds>> player_time_value_received_time;
 		std::optional<std::uint32_t> time_difference;

--- a/src/views/network/view_player_database.cpp
+++ b/src/views/network/view_player_database.cpp
@@ -19,44 +19,54 @@ namespace big
 	{
 		std::string name = player->name;
 		std::transform(name.begin(), name.end(), name.begin(), ::tolower);
+		bool isBlocked = player->block_join;
 		bool isFriend  = player->is_friends;
 		bool isModder  = player->is_modder;
-		bool isBlocked = player->block_join;
 
+		ImVec4 onlineColor  = ImVec4(0.0f, 1.0f, 0.0f, 1.0f); // Green
+		ImVec4 offlineColor = ImVec4(0.7f, 0.7f, 0.7f, 1.0f); // Light grey
 		ImVec4 backgroundColor = ImVec4(0.0f, 0.0f, 0.0f, 0.0f);
-
-		if (isBlocked) 
-			backgroundColor = ImVec4(1.000f, 0.000f, 0.000f, 0.900f); // Red
-		else if (isFriend) 
-			backgroundColor = ImVec4(0.0f, 0.0f, 1.0f, 1.0f); // Blue
+		
+		if (isBlocked)
+		    backgroundColor = ImVec4(1.000f, 0.000f, 0.000f, 0.900f); // Red
+		else if (isFriend)
+			backgroundColor = ImVec4(0.031f, 0.347f, 0.706f, 0.902f); // Blue
 		else if (isModder) 
 			backgroundColor = ImVec4(1.0f, 0.5f, 0.0f, 1.0f); //Orange
-		//if (isFriend || isModder || isBlocked)
-
-	
+			
 		if (lower_search.empty() || name.find(lower_search) != std::string::npos)
 		{
 			//  Set background color for the entire row
-			//	ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.0f, 0.0f, 0.0f, 1.0f)); // breaks all the colors on the menu dont think i need this one
 			ImGui::PushStyleColor(ImGuiCol_Header, backgroundColor);
 			ImGui::PushStyleColor(ImGuiCol_HeaderHovered, backgroundColor);
 			ImGui::PushStyleColor(ImGuiCol_HeaderActive, backgroundColor);
 
-
 			ImGui::PushID(player->rockstar_id);
 
-			float circle_size = 7.5f;
+			float circle_size = 10.0f;
 			auto cursor_pos   = ImGui::GetCursorScreenPos();
 			auto plyr_state   = player->online_state;
 
 			//render status circle
 			ImGui::GetWindowDrawList()->AddCircleFilled(ImVec2(cursor_pos.x + 4.f + circle_size, cursor_pos.y + 4.f + circle_size),
 			    circle_size,
-			    ImColor(plyr_state == PlayerOnlineStatus::ONLINE  ? ImVec4(0.f, 1.f, 0.f, 1.f) :
-			            plyr_state == PlayerOnlineStatus::OFFLINE ? ImVec4(1.f, 0.f, 0.f, 1.f) :
-			            plyr_state == PlayerOnlineStatus::UNKNOWN ? ImVec4(.5f, .5f, .5f, 1.0f) :
-			                                                        ImVec4(.5f, .5f, .5f, 1.0f)));
-			
+			    ImColor(plyr_state == PlayerOnlineStatus::ONLINE  ? onlineColor :
+						plyr_state == PlayerOnlineStatus::OFFLINE ? offlineColor :
+			            plyr_state == PlayerOnlineStatus::UNKNOWN ? ImVec4(.5f, .5f, .5f, 1.0f) :   
+			                                                        ImVec4(.5f, .5f, .5f, 1.0f))); 
+
+			// Render additional circles for blocked, friends, and modders
+			if (isBlocked)
+				ImGui::GetWindowDrawList()->AddCircleFilled(ImVec2(cursor_pos.x + 4.f + circle_size, cursor_pos.y + 4.f + circle_size),
+					circle_size - 3.0f, ImColor(backgroundColor));
+
+			if (isFriend)
+				ImGui::GetWindowDrawList()->AddCircleFilled(ImVec2(cursor_pos.x + 4.f + circle_size, cursor_pos.y + 4.f + circle_size),
+					circle_size - 3.0f, ImColor(backgroundColor));
+
+			if (isModder)
+				ImGui::GetWindowDrawList()->AddCircleFilled(ImVec2(cursor_pos.x + 4.f + circle_size, cursor_pos.y + 4.f + circle_size),
+					circle_size - 3.0f, ImColor(backgroundColor));
 
 			//we need some padding
 			ImVec2 cursor = ImGui::GetCursorPos();
@@ -72,7 +82,6 @@ namespace big
 			ImGui::PopID();
 			ImGui::PopStyleVar();
 			ImGui::PopStyleColor();
-
 		}
 	}
 
@@ -88,19 +97,19 @@ namespace big
 			{
 				std::string lower_search = search;
 				std::transform(lower_search.begin(), lower_search.end(), lower_search.begin(), tolower);
-		
+
 				for (auto& player : item_arr | std::ranges::views::values)
 				{
 					if (player->online_state == PlayerOnlineStatus::ONLINE)
 						draw_player_db_entry(player, lower_search);
-					    ImGui::PopStyleColor();
+					ImGui::PopStyleColor();
 				}
 
 				for (auto& player : item_arr | std::ranges::views::values)
 				{
 					if (player->online_state != PlayerOnlineStatus::ONLINE)
 						draw_player_db_entry(player, lower_search);
-						ImGui::PopStyleColor();
+					ImGui::PopStyleColor();
 				}
 			}
 			else

--- a/src/views/network/view_player_database.cpp
+++ b/src/views/network/view_player_database.cpp
@@ -95,7 +95,7 @@ namespace big
 					current_player->name = name_buf;
 				}
 
-				if (ImGui::InputScalar("RID"_T.data(), ImGuiDataType_S64, &current_player->rockstar_id) || ImGui::Checkbox("IS_FRIENDS"_T.data(), &current_player->is_FRIENDS) || ImGui::Checkbox("IS_MODDER"_T.data(), &current_player->is_modder) || ImGui::Checkbox("BLOCK_JOIN"_T.data(), &current_player->block_join))
+				if (ImGui::InputScalar("RID"_T.data(), ImGuiDataType_S64, &current_player->rockstar_id) || ImGui::Checkbox("IS_FRIENDS"_T.data(), &current_player->is_friends) || ImGui::Checkbox("IS_MODDER"_T.data(), &current_player->is_modder) || ImGui::Checkbox("BLOCK_JOIN"_T.data(), &current_player->block_join))
 				{
 					if (current_player->rockstar_id != selected->rockstar_id)
 						g_player_database_service->update_rockstar_id(selected->rockstar_id, current_player->rockstar_id);

--- a/src/views/network/view_player_database.cpp
+++ b/src/views/network/view_player_database.cpp
@@ -31,12 +31,18 @@ namespace big
 			backgroundColor = ImVec4(0.0f, 0.0f, 1.0f, 1.0f); // Blue
 		else if (isModder) 
 			backgroundColor = ImVec4(1.0f, 0.5f, 0.0f, 1.0f); //Orange
-		if (isFriend || isModder || isBlocked)
-			//notsure i need this
-			ImGui::PopStyleColor();
-				
+		//if (isFriend || isModder || isBlocked)
+
+	
 		if (lower_search.empty() || name.find(lower_search) != std::string::npos)
 		{
+			//  Set background color for the entire row
+			//	ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.0f, 0.0f, 0.0f, 1.0f)); // breaks all the colors on the menu dont think i need this one
+			ImGui::PushStyleColor(ImGuiCol_Header, backgroundColor);
+			ImGui::PushStyleColor(ImGuiCol_HeaderHovered, backgroundColor);
+			ImGui::PushStyleColor(ImGuiCol_HeaderActive, backgroundColor);
+
+
 			ImGui::PushID(player->rockstar_id);
 
 			float circle_size = 7.5f;
@@ -50,13 +56,7 @@ namespace big
 			            plyr_state == PlayerOnlineStatus::OFFLINE ? ImVec4(1.f, 0.f, 0.f, 1.f) :
 			            plyr_state == PlayerOnlineStatus::UNKNOWN ? ImVec4(.5f, .5f, .5f, 1.0f) :
 			                                                        ImVec4(.5f, .5f, .5f, 1.0f)));
-			//  Set background color for the entire row
-			//	ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.0f, 0.0f, 0.0f, 1.0f)); // breaks all the colors on the menu dont think i need this one
-				ImGui::PushStyleColor(ImGuiCol_Header, backgroundColor);
-				ImGui::PushStyleColor(ImGuiCol_HeaderHovered, backgroundColor);
-				ImGui::PushStyleColor(ImGuiCol_HeaderActive, backgroundColor);
-			//notsure i need this 
-				ImGui::PopStyleColor();
+			
 
 			//we need some padding
 			ImVec2 cursor = ImGui::GetCursorPos();
@@ -70,6 +70,9 @@ namespace big
 			}
 
 			ImGui::PopID();
+			ImGui::PopStyleVar();
+			ImGui::PopStyleColor();
+
 		}
 	}
 
@@ -90,12 +93,14 @@ namespace big
 				{
 					if (player->online_state == PlayerOnlineStatus::ONLINE)
 						draw_player_db_entry(player, lower_search);
+					    ImGui::PopStyleColor();
 				}
 
 				for (auto& player : item_arr | std::ranges::views::values)
 				{
 					if (player->online_state != PlayerOnlineStatus::ONLINE)
 						draw_player_db_entry(player, lower_search);
+						ImGui::PopStyleColor();
 				}
 			}
 			else

--- a/src/views/network/view_player_database.cpp
+++ b/src/views/network/view_player_database.cpp
@@ -95,7 +95,7 @@ namespace big
 					current_player->name = name_buf;
 				}
 
-				if (ImGui::InputScalar("RID"_T.data(), ImGuiDataType_S64, &current_player->rockstar_id) || ImGui::Checkbox("IS_MODDER"_T.data(), &current_player->is_modder) || ImGui::Checkbox("BLOCK_JOIN"_T.data(), &current_player->block_join))
+				if (ImGui::InputScalar("RID"_T.data(), ImGuiDataType_S64, &current_player->rockstar_id) || ImGui::Checkbox("IS_FRIENDS"_T.data(), &current_player->is_FRIENDS) || ImGui::Checkbox("IS_MODDER"_T.data(), &current_player->is_modder) || ImGui::Checkbox("BLOCK_JOIN"_T.data(), &current_player->block_join))
 				{
 					if (current_player->rockstar_id != selected->rockstar_id)
 						g_player_database_service->update_rockstar_id(selected->rockstar_id, current_player->rockstar_id);

--- a/src/views/network/view_player_database.cpp
+++ b/src/views/network/view_player_database.cpp
@@ -19,7 +19,19 @@ namespace big
 	{
 		std::string name = player->name;
 		std::transform(name.begin(), name.end(), name.begin(), ::tolower);
+		bool isFriend  = player->is_friends;
+		bool isModder  = player->is_modder;
+		bool isBlocked = player->block_join;
 
+		ImVec4 backgroundColor = ImVec4(0.0f, 0.0f, 0.0f, 0.0f);
+
+		if (isFriend)
+			backgroundColor = ImVec4(0.0f, 0.0f, 1.0f, 1.0f); // Blue
+		else if (isModder)
+			backgroundColor = ImVec4(1.0f, 0.5f, 0.0f, 1.0f); //Orange
+		else if (isBlocked)
+			backgroundColor = ImVec4(1.000f, 0.000f, 0.000f, 0.900f); // Red
+				
 		if (lower_search.empty() || name.find(lower_search) != std::string::npos)
 		{
 			ImGui::PushID(player->rockstar_id);
@@ -30,11 +42,18 @@ namespace big
 
 			//render status circle
 			ImGui::GetWindowDrawList()->AddCircleFilled(ImVec2(cursor_pos.x + 4.f + circle_size, cursor_pos.y + 4.f + circle_size),
-				circle_size,
-				ImColor(plyr_state == PlayerOnlineStatus::ONLINE  ? ImVec4(0.f, 1.f, 0.f, 1.f) :
-						plyr_state == PlayerOnlineStatus::OFFLINE ? ImVec4(1.f, 0.f, 0.f, 1.f) :
-						plyr_state == PlayerOnlineStatus::UNKNOWN ? ImVec4(.5f, .5f, .5f, 1.0f) :
-																	ImVec4(.5f, .5f, .5f, 1.0f)));
+			    circle_size,
+			    ImColor(plyr_state == PlayerOnlineStatus::ONLINE  ? ImVec4(0.f, 1.f, 0.f, 1.f) :
+			            plyr_state == PlayerOnlineStatus::OFFLINE ? ImVec4(1.f, 0.f, 0.f, 1.f) :
+			            plyr_state == PlayerOnlineStatus::UNKNOWN ? ImVec4(.5f, .5f, .5f, 1.0f) :
+			                                                        ImVec4(.5f, .5f, .5f, 1.0f)));
+			//  Set background color for the entire row
+			//	ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.0f, 0.0f, 0.0f, 1.0f)); // breaks all the colors on the menu dont think i need this one
+				ImGui::PushStyleColor(ImGuiCol_Header, backgroundColor);
+				ImGui::PushStyleColor(ImGuiCol_HeaderHovered, backgroundColor);
+				ImGui::PushStyleColor(ImGuiCol_HeaderActive, backgroundColor);
+			//notsure i need this 
+				ImGui::PopStyleColor();
 
 			//we need some padding
 			ImVec2 cursor = ImGui::GetCursorPos();
@@ -53,7 +72,6 @@ namespace big
 
 	void view::player_database()
 	{
-
 		ImGui::SetNextItemWidth(300.f);
 		components::input_text_with_hint("PLAYER"_T, "SEARCH"_T, search, sizeof(search), ImGuiInputTextFlags_None);
 
@@ -64,7 +82,7 @@ namespace big
 			{
 				std::string lower_search = search;
 				std::transform(lower_search.begin(), lower_search.end(), lower_search.begin(), tolower);
-
+		
 				for (auto& player : item_arr | std::ranges::views::values)
 				{
 					if (player->online_state == PlayerOnlineStatus::ONLINE)
@@ -95,7 +113,10 @@ namespace big
 					current_player->name = name_buf;
 				}
 
-				if (ImGui::InputScalar("RID"_T.data(), ImGuiDataType_S64, &current_player->rockstar_id) || ImGui::Checkbox("IS_FRIENDS"_T.data(), &current_player->is_friends) || ImGui::Checkbox("IS_MODDER"_T.data(), &current_player->is_modder) || ImGui::Checkbox("BLOCK_JOIN"_T.data(), &current_player->block_join))
+				if (ImGui::InputScalar("RID"_T.data(), ImGuiDataType_S64, &current_player->rockstar_id)
+				    || ImGui::Checkbox("IS_FRIENDS"_T.data(), &current_player->is_friends)
+				    || ImGui::Checkbox("IS_MODDER"_T.data(), &current_player->is_modder)
+				    || ImGui::Checkbox("BLOCK_JOIN"_T.data(), &current_player->block_join))
 				{
 					if (current_player->rockstar_id != selected->rockstar_id)
 						g_player_database_service->update_rockstar_id(selected->rockstar_id, current_player->rockstar_id);

--- a/src/views/network/view_player_database.cpp
+++ b/src/views/network/view_player_database.cpp
@@ -88,7 +88,7 @@ namespace big
 		ImGui::SetNextItemWidth(300.f);
 		components::input_text_with_hint("PLAYER"_T, "SEARCH"_T, search, sizeof(search), ImGuiInputTextFlags_None);
 
-		float comboWidth = 50.0f;
+		ImGui::SetNextItemWidth(300.f);
 		ImGui::Combo("##filterCombo", &filterIndex, filterOptions, IM_ARRAYSIZE(filterOptions));
 		ImGui::SameLine();
 		ImGui::Text("Filter");

--- a/src/views/network/view_player_database.cpp
+++ b/src/views/network/view_player_database.cpp
@@ -25,12 +25,15 @@ namespace big
 
 		ImVec4 backgroundColor = ImVec4(0.0f, 0.0f, 0.0f, 0.0f);
 
-		if (isFriend)
-			backgroundColor = ImVec4(0.0f, 0.0f, 1.0f, 1.0f); // Blue
-		else if (isModder)
-			backgroundColor = ImVec4(1.0f, 0.5f, 0.0f, 1.0f); //Orange
-		else if (isBlocked)
+		if (isBlocked) 
 			backgroundColor = ImVec4(1.000f, 0.000f, 0.000f, 0.900f); // Red
+		else if (isFriend) 
+			backgroundColor = ImVec4(0.0f, 0.0f, 1.0f, 1.0f); // Blue
+		else if (isModder) 
+			backgroundColor = ImVec4(1.0f, 0.5f, 0.0f, 1.0f); //Orange
+		if (isFriend || isModder || isBlocked)
+			//notsure i need this
+			ImGui::PopStyleColor();
 				
 		if (lower_search.empty() || name.find(lower_search) != std::string::npos)
 		{

--- a/src/views/network/view_player_database.cpp
+++ b/src/views/network/view_player_database.cpp
@@ -15,30 +15,60 @@ namespace big
 	char search[64];
 	std::shared_ptr<persistent_player> current_player;
 
+	int filterIndex             = 0;
+	const char* filterOptions[] = {"All", "Friends", "Modders", "Blocked", "Command Level Access", "Notify Online", "Not classified"};
+
 	void draw_player_db_entry(std::shared_ptr<persistent_player> player, const std::string& lower_search)
 	{
 		std::string name = player->name;
 		std::transform(name.begin(), name.end(), name.begin(), ::tolower);
-
+		bool isBlocked = player->block_join;
+		bool isFriend  = player->is_friends;
+		bool isModder  = player->is_modder;
+		
+		ImVec4 onlineColor  = ImVec4(0.0f, 1.0f, 0.0f, 1.0f); // Green
+		ImVec4 offlineColor = ImVec4(0.7f, 0.7f, 0.7f, 1.0f); // Light grey
+		ImVec4 backgroundColor = ImVec4(0.0f, 0.0f, 0.0f, 0.0f);
+		
+		if (isBlocked)
+		    backgroundColor = ImVec4(1.000f, 0.000f, 0.000f, 0.900f); // Red
+		else if (isFriend)
+			backgroundColor = ImVec4(0.031f, 0.347f, 0.706f, 0.902f); // Blue
+		else if (isModder) 
+			backgroundColor = ImVec4(1.0f, 0.5f, 0.0f, 1.0f); //Orange
+			
 		if (lower_search.empty() || name.find(lower_search) != std::string::npos)
 		{
 			ImGui::PushID(player->rockstar_id);
 
-			float circle_size = 7.5f;
+			float circle_size = 10.0f;
 			auto cursor_pos   = ImGui::GetCursorScreenPos();
 			auto plyr_state   = player->online_state;
 
 			//render status circle
 			ImGui::GetWindowDrawList()->AddCircleFilled(ImVec2(cursor_pos.x + 4.f + circle_size, cursor_pos.y + 4.f + circle_size),
-				circle_size,
-				ImColor(plyr_state == PlayerOnlineStatus::ONLINE  ? ImVec4(0.f, 1.f, 0.f, 1.f) :
-						plyr_state == PlayerOnlineStatus::OFFLINE ? ImVec4(1.f, 0.f, 0.f, 1.f) :
-						plyr_state == PlayerOnlineStatus::UNKNOWN ? ImVec4(.5f, .5f, .5f, 1.0f) :
-																	ImVec4(.5f, .5f, .5f, 1.0f)));
+			    circle_size,
+			    ImColor(plyr_state == PlayerOnlineStatus::ONLINE  ? onlineColor :
+						plyr_state == PlayerOnlineStatus::OFFLINE ? offlineColor :
+			            plyr_state == PlayerOnlineStatus::UNKNOWN ? ImVec4(.5f, .5f, .5f, 1.0f) :   
+			                                                        ImVec4(.5f, .5f, .5f, 1.0f))); 
+
+			// Render additional circles for blocked, friends, and modders
+			if (isBlocked)
+				ImGui::GetWindowDrawList()->AddCircleFilled(ImVec2(cursor_pos.x + 4.f + circle_size, cursor_pos.y + 4.f + circle_size),
+					circle_size - 3.0f, ImColor(backgroundColor));
+
+			if (isFriend)
+				ImGui::GetWindowDrawList()->AddCircleFilled(ImVec2(cursor_pos.x + 4.f + circle_size, cursor_pos.y + 4.f + circle_size),
+					circle_size - 3.0f, ImColor(backgroundColor));
+
+			if (isModder)
+				ImGui::GetWindowDrawList()->AddCircleFilled(ImVec2(cursor_pos.x + 4.f + circle_size, cursor_pos.y + 4.f + circle_size),
+					circle_size - 3.0f, ImColor(backgroundColor));
 
 			//we need some padding
 			ImVec2 cursor = ImGui::GetCursorPos();
-			ImGui::SetCursorPos(ImVec2(cursor.x + 25.f, cursor.y));
+			ImGui::SetCursorPos(ImVec2(cursor.x + 30.f, cursor.y));
 
 			if (components::selectable(player->name, player == g_player_database_service->get_selected()))
 			{
@@ -48,15 +78,19 @@ namespace big
 			}
 
 			ImGui::PopID();
+		
 		}
 	}
 
 	void view::player_database()
 	{
-
 		ImGui::SetNextItemWidth(300.f);
 		components::input_text_with_hint("PLAYER"_T, "SEARCH"_T, search, sizeof(search), ImGuiInputTextFlags_None);
-
+		ImGui::SetNextItemWidth(300.f);
+		ImGui::Combo("##filterCombo", &filterIndex, filterOptions, IM_ARRAYSIZE(filterOptions));
+		ImGui::SameLine();
+		ImGui::Text("Filter");
+				
 		if (ImGui::ListBoxHeader("###players", {180, static_cast<float>(*g_pointers->m_gta.m_resolution_y - 400 - 38 * 4)}))
 		{
 			auto& item_arr = g_player_database_service->get_sorted_players();
@@ -64,23 +98,103 @@ namespace big
 			{
 				std::string lower_search = search;
 				std::transform(lower_search.begin(), lower_search.end(), lower_search.begin(), tolower);
-
+				
+				// Loop through the players, considering online state and filtering
 				for (auto& player : item_arr | std::ranges::views::values)
 				{
-					if (player->online_state == PlayerOnlineStatus::ONLINE)
+					// Check if the player meets the filtering criteria
+					bool isFiltered = false;
+					switch (filterIndex)
+					{
+					case 0: // All
+						break;
+					case 1: // Friends
+						if (!player->is_friends)
+							isFiltered = true;
+						break;
+					case 2: // Modders
+						if (!player->is_modder)
+							isFiltered = true;
+						break;
+					case 3: // Blocked
+						if (!player->block_join)
+							isFiltered = true;
+					case 4: // Command level access
+						if (!player->command_access_level.has_value()
+							|| (player->command_access_level != CommandAccessLevel::FRIENDLY 
+							&& player->command_access_level != CommandAccessLevel::AGGRESSIVE
+						    && player->command_access_level != CommandAccessLevel::TOXIC 
+							&& player->command_access_level != CommandAccessLevel::ADMIN))
+							isFiltered = true;
+						break;
+					case 5: // Notify Online
+						if (!player->notify_online)
+							isFiltered = true;
+						break;
+					case 6: // Not classified as modder, friend, blocked, or notify 
+						if (player->is_modder || player->is_friends || player->block_join || player->notify_online)
+							isFiltered = true;
+						break;
+					}
+
+					// Draw the player entry if it's not filtered and online
+					if (!isFiltered && player->online_state == PlayerOnlineStatus::ONLINE)
 						draw_player_db_entry(player, lower_search);
 				}
 
+				ImGui::Separator();
+
+				// Loop through the players again for offline entries
 				for (auto& player : item_arr | std::ranges::views::values)
 				{
-					if (player->online_state != PlayerOnlineStatus::ONLINE)
+					// Check if the player meets the filtering criteria
+					bool isFiltered = false;
+					switch (filterIndex)
+					{
+					case 0: // All
+						break;
+					case 1: // Friends
+						if (!player->is_friends)
+							isFiltered = true;
+						break;
+					case 2: // Modders
+						if (!player->is_modder)
+							isFiltered = true;
+						break;
+					case 3: // Blocked
+						if (!player->block_join)
+							isFiltered = true;
+						break;
+					case 4: // Command level access
+						if (!player->command_access_level.has_value() 
+							|| (player->command_access_level != CommandAccessLevel::FRIENDLY 
+							&& player->command_access_level != CommandAccessLevel::AGGRESSIVE
+							&& player->command_access_level != CommandAccessLevel::TOXIC 
+							&& player->command_access_level != CommandAccessLevel::ADMIN))
+     						isFiltered = true;
+						break;
+					case 5: // Notify Online
+						if (!player->notify_online)
+							isFiltered = true;
+						break;
+					case 6: // Not classified as modder, friend, blocked, or notify
+						if (player->is_modder || player->is_friends || player->block_join || player->notify_online)
+							isFiltered = true;
+						break;
+					}
+
+					// Draw the player entry if it's not filtered and offline
+					if (!isFiltered && player->online_state != PlayerOnlineStatus::ONLINE)
 						draw_player_db_entry(player, lower_search);
 				}
+
+				ImGui::PopStyleColor();
 			}
 			else
 			{
 				ImGui::Text("NO_STORED_PLAYERS"_T.data());
 			}
+
 
 			ImGui::ListBoxFooter();
 		}
@@ -95,7 +209,11 @@ namespace big
 					current_player->name = name_buf;
 				}
 
-				if (ImGui::InputScalar("RID"_T.data(), ImGuiDataType_S64, &current_player->rockstar_id) || ImGui::Checkbox("IS_MODDER"_T.data(), &current_player->is_modder) || ImGui::Checkbox("BLOCK_JOIN"_T.data(), &current_player->block_join))
+				if (ImGui::InputScalar("RID"_T.data(), ImGuiDataType_S64, &current_player->rockstar_id)
+				    || ImGui::Checkbox("Notify When Online"_T.data(), &current_player->notify_online)
+				    || ImGui::Checkbox("IS_FRIENDS"_T.data(), &current_player->is_friends)
+				    || ImGui::Checkbox("IS_MODDER"_T.data(), &current_player->is_modder)
+				    || ImGui::Checkbox("BLOCK_JOIN"_T.data(), &current_player->block_join))
 				{
 					if (current_player->rockstar_id != selected->rockstar_id)
 						g_player_database_service->update_rockstar_id(selected->rockstar_id, current_player->rockstar_id);

--- a/src/views/players/view_players.cpp
+++ b/src/views/players/view_players.cpp
@@ -16,7 +16,7 @@ namespace big
 	{
 		bool selected_player = plyr == g_player_service->get_selected();
 
-// generate icons string
+		// generate icons string
 		std::string player_icons;
 		if (plyr->is_host())
 			player_icons += FONT_ICON_HOST;
@@ -40,14 +40,16 @@ namespace big
 		const ImRect icons_box(icons_pos, icons_pos + icons_size);
 		ImGui::PopFont();
 
-		if (plyr->is_admin)
-			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.f, 0.67f, 0.f, 1.f));
-		else if (plyr->is_friends)
-			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.017f, 0.670f, 0.053f, 0.900f));
-		else if (plyr->is_modder)
-			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.019f, 0.000f, 1.000f, 0.900f));
-		else if (plyr->block_join)
-			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.000f, 0.000f, 0.000f, 0.900f));
+			if (plyr->is_admin)
+			    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.f, 0.67f, 0.f, 1.f));
+		        else if (plyr->is_friend())
+			    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.031f, 0.347f, 0.706f, 0.902f)); // Blue
+			else if (plyr->is_friends)
+			    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.031f, 0.347f, 0.706f, 0.902f)); // Blue
+			else if (plyr->is_modder)
+			    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.0f, 0.5f, 0.0f, 1.0f)); //Orange
+			else if (plyr->block_join)
+				ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.000f, 0.000f, 0.000f, 0.900f)); // Red
 
 		if (selected_player)
 			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.29f, 0.45f, 0.69f, 1.f));

--- a/src/views/players/view_players.cpp
+++ b/src/views/players/view_players.cpp
@@ -15,6 +15,9 @@ namespace big
 	static void player_button(const player_ptr& plyr)
 	{
 		bool selected_player = plyr == g_player_service->get_selected();
+		bool isFriend        = plyr->is_friends;
+		bool isModder        = plyr->is_modder;
+		bool isBlocked       = plyr->block_join;
 
 		// generate icons string
 		std::string player_icons;
@@ -22,6 +25,10 @@ namespace big
 			player_icons += FONT_ICON_HOST;
 		if (plyr->is_friend())
 			player_icons += FONT_ICON_FRIEND;
+		if (plyr->is_friends)
+			player_icons += FONT_ICON_FRIEND;
+		if (plyr->block_join)
+			player_icons += FONT_ICON_NOTFRIEND;
 		if (const auto ped = plyr->get_ped(); ped != nullptr && ped->m_ped_task_flag & (uint8_t)ePedTask::TASK_DRIVING)
 			player_icons += FONT_ICON_VEHICLE;
 
@@ -38,14 +45,21 @@ namespace big
 
 		if (plyr->is_admin)
 			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.f, 0.67f, 0.f, 1.f));
+		else if (plyr->block_join)
+			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.000f, 0.000f, 0.000f, 0.900f)); // Red
+		else if (plyr->is_friend())
+			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.031f, 0.347f, 0.706f, 0.902f)); // Blue
+		else if (plyr->is_friends)
+			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.031f, 0.347f, 0.706f, 0.902f)); // Blue
 		else if (plyr->is_modder)
-			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.f, 0.1f, 0.1f, 1.f));
+			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.0f, 0.5f, 0.0f, 1.0f)); //Orange
 
 		if (selected_player)
 			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.29f, 0.45f, 0.69f, 1.f));
 
 		ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, {0.0, 0.5});
 		ImGui::PushID(plyr->id());
+
 		if (ImGui::Button(plyr->get_name(), {300.0f - ImGui::GetStyle().ScrollbarSize, 0.f}))
 		{
 			g_player_service->set_selected(plyr);
@@ -58,8 +72,9 @@ namespace big
 		if (selected_player)
 			ImGui::PopStyleColor();
 
-		if (plyr->is_admin || plyr->is_modder)
-			ImGui::PopStyleColor();
+		if (plyr->is_admin && plyr->is_friends || plyr->is_modder || plyr->block_join)
+		    
+		ImGui::PopStyleColor();
 
 		// render icons on top of the player button
 		ImGui::PushFont(g.window.font_icon);
@@ -84,7 +99,8 @@ namespace big
 		if (ImGui::Begin("playerlist", nullptr, window_flags))
 		{
 			float window_height = (ImGui::CalcTextSize("A").y + ImGui::GetStyle().ItemInnerSpacing.y * 2 + 6.0f) * player_count + 10.0f;
-			window_height = window_height + window_pos > (float)*g_pointers->m_gta.m_resolution_y - 10.f ? (float)*g_pointers->m_gta.m_resolution_y - (window_pos + 40.f) : window_height;
+			window_height =
+			    window_height + window_pos > (float)*g_pointers->m_gta.m_resolution_y - 10.f ? (float)*g_pointers->m_gta.m_resolution_y - (window_pos + 40.f) : window_height;
 
 			ImGui::PushStyleColor(ImGuiCol_FrameBg, {0.f, 0.f, 0.f, 0.f});
 			ImGui::PushStyleColor(ImGuiCol_ScrollbarBg, {0.f, 0.f, 0.f, 0.f});

--- a/src/views/players/view_players.cpp
+++ b/src/views/players/view_players.cpp
@@ -16,12 +16,16 @@ namespace big
 	{
 		bool selected_player = plyr == g_player_service->get_selected();
 
-		// generate icons string
+// generate icons string
 		std::string player_icons;
 		if (plyr->is_host())
 			player_icons += FONT_ICON_HOST;
 		if (plyr->is_friend())
 			player_icons += FONT_ICON_FRIEND;
+		if (plyr->is_friends)
+			player_icons += FONT_ICON_FRIEND;
+		if (plyr->block_join)
+			player_icons += FONT_ICON_NOTFRIEND;
 		if (const auto ped = plyr->get_ped(); ped != nullptr && ped->m_ped_task_flag & (uint8_t)ePedTask::TASK_DRIVING)
 			player_icons += FONT_ICON_VEHICLE;
 
@@ -38,8 +42,12 @@ namespace big
 
 		if (plyr->is_admin)
 			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.f, 0.67f, 0.f, 1.f));
+		else if (plyr->is_friends)
+			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.017f, 0.670f, 0.053f, 0.900f));
 		else if (plyr->is_modder)
-			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.f, 0.1f, 0.1f, 1.f));
+			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.019f, 0.000f, 1.000f, 0.900f));
+		else if (plyr->block_join)
+			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.000f, 0.000f, 0.000f, 0.900f));
 
 		if (selected_player)
 			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.29f, 0.45f, 0.69f, 1.f));
@@ -58,7 +66,7 @@ namespace big
 		if (selected_player)
 			ImGui::PopStyleColor();
 
-		if (plyr->is_admin || plyr->is_modder)
+		if (plyr->is_admin || plyr->is_friends || plyr->is_modder || plyr->block_join)
 			ImGui::PopStyleColor();
 
 		// render icons on top of the player button

--- a/src/views/players/view_players.cpp
+++ b/src/views/players/view_players.cpp
@@ -42,14 +42,14 @@ namespace big
 
 			if (plyr->is_admin)
 			    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.f, 0.67f, 0.f, 1.f));
-		        else if (plyr->is_friend())
+			else if (plyr->block_join)
+				ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.000f, 0.000f, 0.000f, 0.900f)); // Red
+			else if (plyr->is_friend())
 			    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.031f, 0.347f, 0.706f, 0.902f)); // Blue
 			else if (plyr->is_friends)
 			    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.031f, 0.347f, 0.706f, 0.902f)); // Blue
 			else if (plyr->is_modder)
 			    ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.0f, 0.5f, 0.0f, 1.0f)); //Orange
-			else if (plyr->block_join)
-				ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(1.000f, 0.000f, 0.000f, 0.900f)); // Red
 
 		if (selected_player)
 			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.29f, 0.45f, 0.69f, 1.f));


### PR DESCRIPTION
adds colors to player list player DB
and friends to PDB only with online status
and online notify from rxan 
with notice in circle
red blocked 
blue friends
orange modders

filters in PDB
friends
modders
blocked
command level access
notify online
and people that are unclassed but in the PDB
same colors apply 
friends, modders, blocked
no colors for CLA or NO
theres no onhover or selected player or player colors the status is in the overlayed circle

also adds player icons for friends you select as in PDB as well as R* friends 
also added icon for non-friends ie. blocked in PDB for those that get by and still manage to join will have a head with a x in it and be red

this should about cover it 

if they select to many as notify you will get a flood of notices when it updates every idk 5mins i guess i didnt change 
any thing for that 

