### PR TITLE
Context menu: Fixed janky entity detection

### DIFF
--- a/src/core/globals.hpp
+++ b/src/core/globals.hpp
@@ -759,7 +759,9 @@ namespace big
 			bool bounding_box_enabled = true;
 			ImU32 bounding_box_color  = 4278255360;
 
-			NLOHMANN_DEFINE_TYPE_INTRUSIVE(context_menu, enabled, allowed_entity_types, selected_option_color, bounding_box_enabled, bounding_box_color)
+			bool show_contextual_info = false;
+
+			NLOHMANN_DEFINE_TYPE_INTRUSIVE(context_menu, enabled, allowed_entity_types, selected_option_color, bounding_box_enabled, bounding_box_color, show_contextual_info)
 		} context_menu{};
 
 		struct esp

--- a/src/services/context_menu/context_menu_service.cpp
+++ b/src/services/context_menu/context_menu_service.cpp
@@ -198,8 +198,7 @@ namespace big
 		{
 			double distance = 1;
 
-			const auto get_closest_to_center = [this, &distance](auto entity_getter_func) -> auto
-			{
+			const auto get_closest_to_center = [this, &distance](auto entity_getter_func) -> auto {
 				rage::fvector2 screen_pos{};
 				bool got_an_entity = false;
 				for (const auto entity : entity_getter_func())
@@ -215,8 +214,14 @@ namespace big
 					const auto distance_from_middle = distance_to_middle_of_screen(screen_pos);
 					if (distance_from_middle < distance && ENTITY::HAS_ENTITY_CLEAR_LOS_TO_ENTITY(self::ped, temp_handle, 17) && temp_handle != self::ped)
 					{
-						m_handle      = temp_handle;
-						m_pointer     = temp_pointer;
+						m_handle  = temp_handle;
+						m_pointer = temp_pointer;
+						switch (m_pointer->m_model_info->m_model_type)
+						{
+						case eModelType::Vehicle: m_veh_pointer = temp_pointer; break;
+						case eModelType::Ped: m_ped_pointer = temp_pointer; break;
+						case eModelType::Object: m_prop_pointer = temp_pointer; break;
+						}
 						distance      = distance_from_middle;
 						got_an_entity = true;
 					}
@@ -228,6 +233,44 @@ namespace big
 			auto got_an_entity = get_closest_to_center(pools::get_all_vehicles);
 			got_an_entity |= get_closest_to_center(pools::get_all_peds);
 			got_an_entity |= get_closest_to_center(pools::get_all_props);
+
+			
+			//To avoid priority issues that result in unwanted behaviour, we added another algorithm to compare the 3 different entity types (screen distance).
+			float veh_distance = 1; 
+			float ped_distance = 1;
+			float prop_distance = 1;
+			rage::fvector2 veh_screen_pos{}, ped_screen_pos{}, prop_screen_pos{};
+
+			if(m_veh_pointer)
+			{
+				const auto veh_pos = m_veh_pointer->m_navigation->get_position();
+				HUD::GET_HUD_SCREEN_POSITION_FROM_WORLD_POSITION(veh_pos->x, veh_pos->y, veh_pos->z, &veh_screen_pos.x, &veh_screen_pos.y);
+				veh_distance = distance_to_middle_of_screen(veh_screen_pos);
+			}
+
+			if(m_ped_pointer)
+			{
+				const auto ped_pos = m_ped_pointer->m_navigation->get_position();
+				HUD::GET_HUD_SCREEN_POSITION_FROM_WORLD_POSITION(ped_pos->x, ped_pos->y, ped_pos->z, &ped_screen_pos.x, &ped_screen_pos.y);
+				ped_distance = distance_to_middle_of_screen(ped_screen_pos);
+			}
+
+			if(m_prop_pointer)
+			{
+				const auto prop_pos = m_prop_pointer->m_navigation->get_position();
+				HUD::GET_HUD_SCREEN_POSITION_FROM_WORLD_POSITION(prop_pos->x, prop_pos->y, prop_pos->z, &prop_screen_pos.x, &prop_screen_pos.y);
+				prop_distance = distance_to_middle_of_screen(prop_screen_pos);
+			}
+			
+			float closest = (veh_distance < ped_distance) ? ((veh_distance < prop_distance) ? veh_distance : prop_distance) :
+                   ((ped_distance < prop_distance) ? ped_distance : prop_distance);
+
+			if(closest == veh_distance)
+				m_pointer = m_veh_pointer;
+			else if(closest == ped_distance)
+				m_pointer = m_ped_pointer;
+			else
+				m_pointer = m_prop_pointer;
 
 			if (got_an_entity)
 			{

--- a/src/services/context_menu/context_menu_service.hpp
+++ b/src/services/context_menu/context_menu_service.hpp
@@ -59,6 +59,7 @@ namespace big
 		rage::fwEntity* m_veh_pointer{};
 		rage::fwEntity* m_ped_pointer{};
 		rage::fwEntity* m_prop_pointer{};
+		std::string contextual_info;
 		model_bounding_box_screen_space m_model_bounding_box_screen_space;
 
 		s_context_menu vehicle_menu{ContextEntityType::VEHICLE,
@@ -96,6 +97,11 @@ namespace big
 			            }
 			            else
 				            g_notification_service->push_warning("Toxic", "Failed to take control of vehicle.");
+		            }},
+					{"EMP",
+		            [this] {
+			           Vector3 pos = ENTITY::GET_ENTITY_COORDS(m_handle, false);
+					   FIRE::ADD_EXPLOSION(pos.x, pos.y, pos.z, eExplosionTag::EXP_TAG_EMPLAUNCHER_EMP, 1, true, false, 0, false);
 		            }},
 		        {"COPY VEHICLE",
 		            [this] {

--- a/src/services/context_menu/context_menu_service.hpp
+++ b/src/services/context_menu/context_menu_service.hpp
@@ -56,6 +56,9 @@ namespace big
 
 		Entity m_handle;
 		rage::fwEntity* m_pointer{};
+		rage::fwEntity* m_veh_pointer{};
+		rage::fwEntity* m_ped_pointer{};
+		rage::fwEntity* m_prop_pointer{};
 		model_bounding_box_screen_space m_model_bounding_box_screen_space;
 
 		s_context_menu vehicle_menu{ContextEntityType::VEHICLE,
@@ -85,7 +88,7 @@ namespace big
 			            else
 				            g_notification_service->push_warning("Toxic", "Failed to take control of vehicle.");
 		            }},
-				{"HALT",
+		        {"HALT",
 		            [this] {
 			            if (entity::take_control_of(m_handle))
 			            {
@@ -148,7 +151,7 @@ namespace big
 		        {"RECRUIT", [this] {
 			         TASK::CLEAR_PED_TASKS(m_handle);
 			         PED::SET_PED_AS_GROUP_MEMBER(m_handle, PED::GET_PED_GROUP_INDEX(self::ped));
-					 PED::SET_PED_RELATIONSHIP_GROUP_HASH(m_handle, PED::GET_PED_RELATIONSHIP_GROUP_HASH(self::ped));
+			         PED::SET_PED_RELATIONSHIP_GROUP_HASH(m_handle, PED::GET_PED_RELATIONSHIP_GROUP_HASH(self::ped));
 			         PED::SET_PED_NEVER_LEAVES_GROUP(m_handle, true);
 			         PED::SET_CAN_ATTACK_FRIENDLY(m_handle, 0, 1);
 			         PED::SET_PED_COMBAT_ABILITY(m_handle, 2);
@@ -158,7 +161,7 @@ namespace big
 			         PED::SET_PED_COMBAT_ATTRIBUTES(m_handle, 13, true);
 			         PED::SET_PED_CONFIG_FLAG(m_handle, 394, true);
 			         PED::SET_PED_CONFIG_FLAG(m_handle, 400, true);
-					 PED::SET_PED_CONFIG_FLAG(m_handle, 134, true);
+			         PED::SET_PED_CONFIG_FLAG(m_handle, 134, true);
 			         WEAPON::GIVE_WEAPON_TO_PED(m_handle, RAGE_JOAAT("weapon_microsmg"), 9999, false, false);
 			         WEAPON::GIVE_WEAPON_TO_PED(m_handle, RAGE_JOAAT("weapon_carbinerifle"), 9999, false, true);
 			         TASK::TASK_COMBAT_HATED_TARGETS_AROUND_PED(self::ped, 100, 67108864);

--- a/src/views/settings/view_context_menu_settings.cpp
+++ b/src/views/settings/view_context_menu_settings.cpp
@@ -34,6 +34,7 @@ namespace big
 			}
 
 			ImGui::Checkbox("SETTINGS_CONTEXT_MENU_BOUNDING_BOX"_T.data(), &g.context_menu.bounding_box_enabled);
+			ImGui::Checkbox("Contextual info", &g.context_menu.show_contextual_info);
 
 			if (g.context_menu.bounding_box_enabled)
 			{

--- a/src/views/view_context_menu.cpp
+++ b/src/views/view_context_menu.cpp
@@ -62,6 +62,11 @@ namespace big
 						draw_list->AddText({cm_start_x + 7.f, cm_start_y + (20.f * static_cast<float>(i)) + 5.f},
 						    cm->current_option == i ? g.context_menu.selected_option_color : ImGui::ColorConvertFloat4ToU32({1.f, 1.f, 1.f, 1.f}),
 						    co.name.c_str());
+
+						if (i == cm->options.size() - 1 && g.context_menu.show_contextual_info)
+							draw_list->AddText({cm_start_x + 7.f, cm_start_y + (20.f * static_cast<float>(cm->options.size())) + 5.f},
+							    ImGui::ColorConvertFloat4ToU32({1.f, 1.f, 1.f, 1.f}),
+							    g_context_menu_service->contextual_info.c_str());
 					}
 
 					if (g.context_menu.bounding_box_enabled)


### PR DESCRIPTION
The feature was prioritizing entity types due to the nature of its iteration. It stuck to certain entities while others were closer to the center of the screen. I have decided to stick with its way of scanning the pools, but added a different (small) algorithm to fix the said issue.