### PR TITLE
fix: Bool CMD hotkey toggle message showing translation key

### DIFF
--- a/src/backend/bool_command.cpp
+++ b/src/backend/bool_command.cpp
@@ -1,4 +1,5 @@
 #include "bool_command.hpp"
+#include "services/translation_service/translation_service.hpp"
 
 namespace big
 {
@@ -18,14 +19,14 @@ namespace big
 				m_toggle = false;
 
 				if (m_show_notify)
-					ctx->report_output(std::format("{} has been disabled", m_label));
+					ctx->report_output(std::format("{} has been disabled", g_translation_service.get_translation(m_label)));
 			}
 			else
 			{
 				m_toggle = true;
 
 				if (m_show_notify)
-					ctx->report_output(std::format("{} has been enabled", m_label));
+					ctx->report_output(std::format("{} has been enabled", g_translation_service.get_translation(m_label)));
 			}
 		}
 		else

--- a/src/services/translation_service/translation_service.cpp
+++ b/src/services/translation_service/translation_service.cpp
@@ -60,16 +60,16 @@ namespace big
 
 	std::string_view translation_service::get_translation(const std::string_view translation_key) const
 	{
-		return get_translation(rage::joaat(translation_key));
+		return get_translation(rage::joaat(translation_key), translation_key);
 	}
 
 
-	std::string_view translation_service::get_translation(const rage::joaat_t translation_key) const
+	std::string_view translation_service::get_translation(const rage::joaat_t translation_key, const std::string_view fallback) const
 	{
 		if (auto it = m_translations.find(translation_key); it != m_translations.end())
 			return it->second.c_str();
 
-		return {0, 0};
+		return fallback;
 	}
 
 	std::map<std::string, translation_entry>& translation_service::available_translations()

--- a/src/services/translation_service/translation_service.hpp
+++ b/src/services/translation_service/translation_service.hpp
@@ -23,7 +23,7 @@ namespace big
 		void init();
 
 		std::string_view get_translation(const std::string_view translation_key) const;
-		std::string_view get_translation(const rage::joaat_t translation_key) const;
+		std::string_view get_translation(const rage::joaat_t translation_key, const std::string_view fallback = { 0, 0 }) const;
 
 		std::map<std::string, translation_entry>& available_translations();
 		const std::string& current_language_pack();


### PR DESCRIPTION
Issue introduce when we added support for translations in commands.