### PR TITLE
fix lua gui: imgui Separator between modules instead of same line which is non sense

### DIFF
--- a/src/lua/lua_manager.cpp
+++ b/src/lua/lua_manager.cpp
@@ -50,7 +50,7 @@ namespace big
 		{
 			if (const auto it = module->m_gui.find(tab_hash); it != module->m_gui.end())
 			{
-				ImGui::SameLine();
+				ImGui::Separator();
 
 				for (const auto& element : it->second)
 					element->draw();


### PR DESCRIPTION
Fix #1670 