### PR TITLE
fix(gui): dont draw two gui separators at the top for lua only tab.

### DIFF
--- a/src/lua/lua_manager.cpp
+++ b/src/lua/lua_manager.cpp
@@ -46,14 +46,22 @@ namespace big
 	{
 		std::lock_guard guard(m_module_lock);
 
+		bool add_separator = false;
 		for (const auto& module : m_modules)
 		{
 			if (const auto it = module->m_gui.find(tab_hash); it != module->m_gui.end())
 			{
-				ImGui::Separator();
+				if (add_separator)
+				{
+					ImGui::Separator();
+					add_separator = false;
+				}
 
 				for (const auto& element : it->second)
+				{
 					element->draw();
+					add_separator = true;
+				}
 			}
 		}
 	}

--- a/src/lua/lua_manager.cpp
+++ b/src/lua/lua_manager.cpp
@@ -47,6 +47,7 @@ namespace big
 		std::lock_guard guard(m_module_lock);
 
 		bool add_separator = false;
+
 		for (const auto& module : m_modules)
 		{
 			if (const auto it = module->m_gui.find(tab_hash); it != module->m_gui.end())

--- a/src/views/core/view_active_view.cpp
+++ b/src/views/core/view_active_view.cpp
@@ -36,7 +36,10 @@ namespace big
 			ImGui::Separator();
 
 			if (selected->func)
+			{
 				selected->func();
+				ImGui::Separator();
+			}
 
 			if (g_lua_manager)
 				g_lua_manager->draw_gui(selected->hash);

--- a/src/views/core/view_active_view.cpp
+++ b/src/views/core/view_active_view.cpp
@@ -11,8 +11,8 @@ namespace big
 	{
 		const auto selected = g_gui_service->get_selected();
 
-		if (selected->func == nullptr &&
-			(g_lua_manager && !g_lua_manager->has_gui_to_draw(selected->hash)))
+		bool has_lua_gui_to_draw = g_lua_manager && g_lua_manager->has_gui_to_draw(selected->hash);
+		if (selected->func == nullptr && !has_lua_gui_to_draw)
 		{
 			return;
 		}
@@ -38,7 +38,9 @@ namespace big
 			if (selected->func)
 			{
 				selected->func();
-				ImGui::Separator();
+
+				if (has_lua_gui_to_draw)
+					ImGui::Separator();
 			}
 
 			if (g_lua_manager)

--- a/src/views/core/view_active_view.cpp
+++ b/src/views/core/view_active_view.cpp
@@ -11,8 +11,8 @@ namespace big
 	{
 		const auto selected = g_gui_service->get_selected();
 
-		bool has_lua_gui_to_draw = g_lua_manager && g_lua_manager->has_gui_to_draw(selected->hash);
-		if (selected->func == nullptr && !has_lua_gui_to_draw)
+		if (selected->func == nullptr &&
+			(g_lua_manager && !g_lua_manager->has_gui_to_draw(selected->hash)))
 		{
 			return;
 		}
@@ -39,6 +39,7 @@ namespace big
 			{
 				selected->func();
 
+				const auto has_lua_gui_to_draw = g_lua_manager && g_lua_manager->has_gui_to_draw(selected->hash);
 				if (has_lua_gui_to_draw)
 					ImGui::Separator();
 			}


### PR DESCRIPTION
Fix #1675