### PR TITLE
Fix(lua / script manager): Potential fix for stack overflow when yielding from lua scripts. Fix io / os lua libs being accessible.

### DIFF
--- a/src/lua/lua_module.cpp
+++ b/src/lua/lua_module.cpp
@@ -49,7 +49,17 @@ namespace big
 	    m_module_name(module_name),
 	    m_module_id(rage::joaat(module_name))
 	{
-		m_state.open_libraries();
+		m_state.open_libraries(
+			sol::lib::base,
+			sol::lib::package,
+			sol::lib::coroutine,
+		    sol::lib::string,
+		    sol::lib::math,
+			sol::lib::table,
+		    sol::lib::debug,
+			sol::lib::bit32,
+			sol::lib::utf8
+		);
 
 		const auto& scripts_folder = g_lua_manager->get_scripts_folder();
 
@@ -108,9 +118,9 @@ namespace big
 
 	void lua_module::add_folder_to_require_available_paths(const big::folder& scripts_folder)
 	{
-		const std::string package_path = m_state["package"]["path"];
-		const auto scripts_search_path = scripts_folder.get_path() / "?.lua";
-		m_state["package"]["path"] = package_path + (!package_path.empty() ? ";" : "") + scripts_search_path.string();
+			const std::string package_path = m_state["package"]["path"];
+			const auto scripts_search_path = scripts_folder.get_path() / "?.lua";
+			m_state["package"]["path"] = package_path + (!package_path.empty() ? ";" : "") + scripts_search_path.string();
 	}
 
 	void lua_module::init_lua_api()

--- a/src/lua/lua_module.cpp
+++ b/src/lua/lua_module.cpp
@@ -118,9 +118,9 @@ namespace big
 
 	void lua_module::add_folder_to_require_available_paths(const big::folder& scripts_folder)
 	{
-			const std::string package_path = m_state["package"]["path"];
-			const auto scripts_search_path = scripts_folder.get_path() / "?.lua";
-			m_state["package"]["path"] = package_path + (!package_path.empty() ? ";" : "") + scripts_search_path.string();
+		const std::string package_path = m_state["package"]["path"];
+		const auto scripts_search_path = scripts_folder.get_path() / "?.lua";
+		m_state["package"]["path"] = package_path + (!package_path.empty() ? ";" : "") + scripts_search_path.string();
 	}
 
 	void lua_module::init_lua_api()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -149,6 +149,9 @@ BOOL APIENTRY DllMain(HMODULE hmod, DWORD reason, PVOID)
 			    while (g_running)
 				    std::this_thread::sleep_for(500ms);
 
+				g_script_mgr.remove_all_scripts();
+			    LOG(INFO) << "Scripts unregistered.";
+
 			    lua_manager_instance.reset();
 			    LOG(INFO) << "Lua manager uninitialized.";
 
@@ -157,9 +160,6 @@ BOOL APIENTRY DllMain(HMODULE hmod, DWORD reason, PVOID)
 
 			    native_hooks_instance.reset();
 			    LOG(INFO) << "Dynamic native hooker uninitialized.";
-
-			    g_script_mgr.remove_all_scripts();
-			    LOG(INFO) << "Scripts unregistered.";
 
 			    // cleans up the thread responsible for saving settings
 			    g.destroy();

--- a/src/script_mgr.cpp
+++ b/src/script_mgr.cpp
@@ -38,9 +38,16 @@ namespace big
 		gta_util::execute_as_script(RAGE_JOAAT("main_persistent"), std::mem_fn(&script_mgr::tick_internal), this);
 	}
 
+	void script_mgr::ensure_main_fiber()
+	{
+		ConvertThreadToFiber(nullptr);
+
+		m_can_tick = true;
+	}
+
 	void script_mgr::tick_internal()
 	{
-		static bool ensure_main_fiber = (ConvertThreadToFiber(nullptr), true);
+		static bool ensure_it = (ensure_main_fiber(), true);
 
 		std::lock_guard lock(m_mutex);
 

--- a/src/script_mgr.hpp
+++ b/src/script_mgr.hpp
@@ -28,13 +28,21 @@ namespace big
 
 		void tick();
 
+		[[nodiscard]] inline bool can_tick() const
+		{
+			return m_can_tick;
+		}
+
 	private:
+		void ensure_main_fiber();
 		void tick_internal();
 
 	private:
 		std::recursive_mutex m_mutex;
 		script_list m_scripts;
 		script_list m_scripts_to_add;
+
+		bool m_can_tick = false;
 	};
 
 	inline script_mgr g_script_mgr;

--- a/src/services/tunables/tunables_service.cpp
+++ b/src/services/tunables/tunables_service.cpp
@@ -24,7 +24,7 @@ namespace big
 			g_thread_pool->push([this] {
 				while (!g_pointers->m_gta.m_script_globals[1])
 				{
-					if (!m_loading)
+					if (!m_loading || !g_running)
 						return;
 
 					std::this_thread::yield();

--- a/src/views/core/view_heading.cpp
+++ b/src/views/core/view_heading.cpp
@@ -24,7 +24,6 @@ namespace big
 			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.69f, 0.29f, 0.29f, 1.00f));
 			if (components::nav_button("UNLOAD"_T))
 			{
-				g_fiber_pool->reset();
 				g_fiber_pool->queue_job([] {
 					for (auto& command : g_looped_commands)
 						if (command->is_enabled())

--- a/src/views/core/view_heading.cpp
+++ b/src/views/core/view_heading.cpp
@@ -1,5 +1,6 @@
 #include "fiber_pool.hpp"
 #include "views/view.hpp"
+#include "script_mgr.hpp"
 
 namespace big
 {
@@ -24,13 +25,23 @@ namespace big
 			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.69f, 0.29f, 0.29f, 1.00f));
 			if (components::nav_button("UNLOAD"_T))
 			{
-				g_fiber_pool->queue_job([] {
-					for (auto& command : g_looped_commands)
-						if (command->is_enabled())
-							command->on_disable();
+				// allow to unload in the main title screen.
+				if (g_script_mgr.can_tick())
+				{
+					// empty the pool, we want the that job below run no matter what for clean up purposes.
+					g_fiber_pool->reset();
+					g_fiber_pool->queue_job([] {
+						for (auto& command : g_looped_commands)
+							if (command->is_enabled())
+								command->on_disable();
 
+						g_running = false;
+					});
+				}
+				else
+				{
 					g_running = false;
-				});
+				}
 			}
 			ImGui::PopStyleColor();
 		}


### PR DESCRIPTION
- Fix incorrect unload of lua scripts: first kill all scripts, then unload lua modules: because the lua scripts depend on lua state, which is stored inside lua module instance, killing the lua module first would not allow proper cleaning because of the lua state getting destroyed while the lua script might still be running.

- don't allow for io / os lua lib to be accessed for security reasons. Close #1680 

- Potential fix for C stack overflow error by using lua coroutine yielding instead of calling fiber yield directly from lua functions.

- Add back the ability to unload in the main title screen.