### PR TITLE
fix(mobile): PV summon timer

### DIFF
--- a/src/core/scr_globals.hpp
+++ b/src/core/scr_globals.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "script_global.hpp"
+#include "script_local.hpp"
 
 namespace big::scr_globals
 {
@@ -29,10 +30,10 @@ namespace big::scr_globals
 	static inline script_global in_multiplayer(78689); // g_bInMultiplayer
 	static inline script_global transition_state(1574996);
 
-	static inline script_global vehicle_global  = script_global(1586488);
-	static inline script_global mechanic_global = script_global(2794162);
+	static inline script_global vehicle_global(1586488);
+	static inline script_global mechanic_global(2794162);
 
-	static inline script_global spawn_global = script_global(2694613);
+	static inline script_global spawn_global(2694613);
 
 	static inline script_global offradar_time(2672524);
 }
@@ -65,5 +66,12 @@ namespace big::scr_locals
 	namespace fmmc_launcher
 	{
 		constexpr static auto broadcast_idx = 11629;
+	}
+
+	namespace fm_mobile
+	{
+		// first uLocal_ in this function call
+		// func_\d+\((&.Local_\d+(, )?){9}\);
+		inline static script_local mobile(18717);
 	}
 }

--- a/src/script_local.cpp
+++ b/src/script_local.cpp
@@ -17,6 +17,22 @@ namespace big
 	{
 	}
 
+	script_local::script_local(std::size_t index) :
+		m_index(index),
+		m_stack(nullptr)
+	{
+	}
+
+	script_local script_local::set(rage::scrThread* thread)
+	{
+		return script_local(thread, m_index);
+	}
+
+	script_local script_local::set(void* stack)
+	{
+		return script_local(stack, m_index);
+	}
+
 	script_local script_local::at(std::ptrdiff_t index)
 	{
 		return script_local(m_stack, m_index + index);

--- a/src/script_local.hpp
+++ b/src/script_local.hpp
@@ -8,6 +8,10 @@ namespace big
 	public:
 		explicit script_local(rage::scrThread* thread, std::size_t index);
 		explicit script_local(PVOID stack, std::size_t index);
+		explicit script_local(std::size_t index);
+
+		script_local set(rage::scrThread* thread);
+		script_local set(void* stack);
 
 		script_local at(std::ptrdiff_t index);
 		script_local at(std::ptrdiff_t index, std::size_t size);

--- a/src/util/mobile.hpp
+++ b/src/util/mobile.hpp
@@ -142,7 +142,7 @@ namespace big::mobile
 				// \(func_\d{3}\(&\(uParam0->f_\d{3}\), \d+000, 0\) \|\| func
 				// or if you prefer a string "VD_FAIL4"
 				// or if you really prefer an image https://i.imgur.com/K8vMILe.png
-				*script_local(freemode_thread, 18717).at(176).as<int*>() = 0; // spawn vehicle instantly
+				*scr_locals::fm_mobile::mobile.set(freemode_thread).at(176).as<int*>() = 0; // spawn vehicle instantly
 			}
 
 			// blocking call till vehicle is delivered
@@ -150,7 +150,7 @@ namespace big::mobile
 
 			if (g.clone_pv.spawn_inside)
 			{
-				big::vehicle::bring(get_personal_vehicle(), self::pos, true);
+				vehicle::bring(get_personal_vehicle(), self::pos, true);
 			}
 		}
 	}

--- a/src/util/mobile.hpp
+++ b/src/util/mobile.hpp
@@ -137,7 +137,13 @@ namespace big::mobile
 
 			GtaThread* freemode_thread = gta_util::find_script_thread(RAGE_JOAAT("freemode"));
 			if (freemode_thread)
-				*script_local(freemode_thread, 18630).at(176).as<int*>() = 0; // spawn vehicle instantly
+			{
+				// regex to find this shit easily
+				// \(func_\d{3}\(&\(uParam0->f_\d{3}\), \d+000, 0\) \|\| func
+				// or if you prefer a string "VD_FAIL4"
+				// or if you really prefer an image https://i.imgur.com/K8vMILe.png
+				*script_local(freemode_thread, 18717).at(176).as<int*>() = 0; // spawn vehicle instantly
+			}
 
 			// blocking call till vehicle is delivered
 			notify::busy_spinner("Delivering vehicle...", scr_globals::mechanic_global.at(985).as<int*>(), -1);


### PR DESCRIPTION
- Modified the `script_local` class to support instantiation without `rage::scrThread` or `stack`.
- Updated PV summon offset
- Moved freemode timer offset to `scr_globals.hpp`

- [x] Test if it works as intended