### PR TITLE
feat(ScriptGlobal): Allow for constexpr offset calculation

### DIFF
--- a/src/core/scr_globals.hpp
+++ b/src/core/scr_globals.hpp
@@ -4,38 +4,38 @@
 
 namespace big::scr_globals
 {
-	static inline script_global gsbd(2648711);
-	static inline script_global gsbd_fm(1835504);
-	static inline script_global gsbd_kicking(1885447);
-	static inline script_global gsbd_fm_events(1924276);
-	static inline script_global gsbd_block_c(2652364);
-	static inline script_global gsbd_property_instances(1944302);
+	static inline const script_global gsbd(2648711);
+	static inline const script_global gsbd_fm(1835504);
+	static inline const script_global gsbd_kicking(1885447);
+	static inline const script_global gsbd_fm_events(1924276);
+	static inline const script_global gsbd_block_c(2652364);
+	static inline const script_global gsbd_property_instances(1944302);
 
-	static inline script_global globalplayer_bd(2657704);
-	static inline script_global gpbd_fm_3(1895156);
-	static inline script_global gpbd_fm_1(1853988);
+	static inline const script_global globalplayer_bd(2657704);
+	static inline const script_global gpbd_fm_3(1895156);
+	static inline const script_global gpbd_fm_1(1853988);
 
-	static inline script_global launcher_global(2756336);
+	static inline const script_global launcher_global(2756336);
 
-	static inline script_global sp(113810); // check flow_controller
-	static inline script_global mission_definition(91601); // standard_global_init (66, "agency_heist1", "AH1", 230, 1, 1, -1, -1, 8192)
+	static inline const script_global sp(113810); // check flow_controller
+	static inline const script_global mission_definition(91601); // standard_global_init (66, "agency_heist1", "AH1", 230, 1, 1, -1, -1, 8192)
 
 	// creator globals usually remain the same after updates
-	static inline script_global creator_job_metadata(4718592);
-	static inline script_global terminate_creator(1574607); // NETWORK::NETWORK_BAIL(1, 0, 0); fm_*_creator
-	static inline script_global switch_struct(1574632);
-	static inline script_global mission_creator_radar_follows_camera(2621443);
-	static inline script_global mission_creator_exited(1574530);
+	static inline const script_global creator_job_metadata(4718592);
+	static inline const script_global terminate_creator(1574607); // NETWORK::NETWORK_BAIL(1, 0, 0); fm_*_creator
+	static inline const script_global switch_struct(1574632);
+	static inline const script_global mission_creator_radar_follows_camera(2621443);
+	static inline const script_global mission_creator_exited(1574530);
 
-	static inline script_global in_multiplayer(78689); // g_bInMultiplayer
-	static inline script_global transition_state(1574996);
+	static inline const script_global in_multiplayer(78689); // g_bInMultiplayer
+	static inline const script_global transition_state(1574996);
 
-	static inline script_global vehicle_global(1586488);
-	static inline script_global mechanic_global(2794162);
+	static inline const script_global vehicle_global(1586488);
+	static inline const script_global mechanic_global(2794162);
 
-	static inline script_global spawn_global(2694613);
+	static inline const script_global spawn_global(2694613);
 
-	static inline script_global offradar_time(2672524);
+	static inline const script_global offradar_time(2672524);
 }
 
 namespace big::scr_locals

--- a/src/script_global.cpp
+++ b/src/script_global.cpp
@@ -5,22 +5,7 @@
 
 namespace big
 {
-	script_global::script_global(std::size_t index) :
-	    m_index(index)
-	{
-	}
-
-	script_global script_global::at(std::ptrdiff_t index)
-	{
-		return script_global(m_index + index);
-	}
-
-	script_global script_global::at(std::ptrdiff_t index, std::size_t size)
-	{
-		return script_global(m_index + 1 + (index * size));
-	}
-
-	void* script_global::get()
+	void* script_global::get() const
 	{
 		return g_pointers->m_gta.m_script_globals[m_index >> 0x12 & 0x3F] + (m_index & 0x3FFFF);
 	}

--- a/src/script_global.hpp
+++ b/src/script_global.hpp
@@ -6,25 +6,35 @@ namespace big
 	class script_global
 	{
 	public:
-		explicit script_global(std::size_t index);
+		constexpr script_global(std::size_t index) :
+			m_index(index)
+		{
+		}
 
-		script_global at(std::ptrdiff_t index);
-		script_global at(std::ptrdiff_t index, std::size_t size);
+		constexpr script_global at(std::ptrdiff_t index) const
+		{
+			return m_index + index;
+		}
+		constexpr script_global at(std::ptrdiff_t index, std::size_t size) const
+		{
+			return m_index + 1 + (index * size);
+		}
 
 		template<typename T>
-		std::enable_if_t<std::is_pointer_v<T>, T> as()
+		std::enable_if_t<std::is_pointer_v<T>, T> as() const
 		{
 			return static_cast<T>(get());
 		}
 
 		template<typename T>
-		std::enable_if_t<std::is_lvalue_reference_v<T>, T> as()
+		std::enable_if_t<std::is_lvalue_reference_v<T>, T> as() const
 		{
 			return *static_cast<std::add_pointer_t<std::remove_reference_t<T>>>(get());
 		}
 
 	private:
-		void* get();
+		void* get() const;
 		std::size_t m_index;
+
 	};
 }


### PR DESCRIPTION
No changes to existing code is required, all offset calculations are made by the compiler at compile time.
If compiler can't figure it out at compile time it'll fall back to the old behaviour of doing the arithmetic's at runtime.
 
### Example Code VS Compiled Binary
Code:
![image](https://github.com/YimMenu/YimMenu/assets/24669514/3032cc3d-9934-4a07-b4b7-e3afbbf7249b)

How it gets compiled:
![image](https://github.com/YimMenu/YimMenu/assets/24669514/975e4b00-e3fd-49f8-9b5d-8e0c91301893)
