### PR TITLE
Persist Outfit changes.

### DIFF
--- a/src/backend/looped/self/persist_outfit.cpp
+++ b/src/backend/looped/self/persist_outfit.cpp
@@ -11,7 +11,7 @@ namespace big
 		if (g.self.persist_outfit.empty())
 			return; //Off
 
-		if (g_local_player == nullptr || g_local_player->m_player_info == nullptr || g_local_player->m_player_info->m_game_state == eGameState::InMPCutscene || STREAMING::IS_PLAYER_SWITCH_IN_PROGRESS() || DLC::GET_IS_LOADING_SCREEN_ACTIVE())
+		if (g_local_player == nullptr || PED::IS_PED_DEAD_OR_DYING(self::ped, TRUE) || STREAMING::IS_PLAYER_SWITCH_IN_PROGRESS() || DLC::GET_IS_LOADING_SCREEN_ACTIVE())
 			return; //Dead or Loading
 
 		if (PED::GET_PED_DRAWABLE_VARIATION(self::ped, 5) == 0 && PED::GET_PED_DRAWABLE_VARIATION(self::ped, 4) >= 14 && PED::GET_PED_DRAWABLE_VARIATION(self::ped, 4) <= 18)

--- a/src/core/settings.hpp
+++ b/src/core/settings.hpp
@@ -355,7 +355,7 @@ namespace big
 			// do not save below entries
 			bool dance_mode = false;
 
-			NLOHMANN_DEFINE_TYPE_INTRUSIVE(self, ipls, ptfx_effects, clean_player, force_wanted_level, free_cam, invisibility, local_visibility, never_wanted, no_ragdoll, noclip, off_radar, super_run, no_collision, unlimited_oxygen, no_water_collision, wanted_level, god_mode, part_water, proof_bullet, proof_fire, proof_collision, proof_melee, proof_explosion, proof_steam, proof_drown, proof_water, proof_mask, mobile_radio, fast_respawn, auto_tp, super_jump, beast_jump, healthregen, healthregenrate, hud, superman, custom_weapon_stop, persist_outfit)
+			NLOHMANN_DEFINE_TYPE_INTRUSIVE(self, ipls, ptfx_effects, clean_player, force_wanted_level, free_cam, invisibility, local_visibility, never_wanted, no_ragdoll, noclip, off_radar, super_run, no_collision, unlimited_oxygen, no_water_collision, wanted_level, god_mode, part_water, proof_bullet, proof_fire, proof_collision, proof_melee, proof_explosion, proof_steam, proof_drown, proof_water, proof_mask, mobile_radio, fast_respawn, auto_tp, super_jump, beast_jump, healthregen, healthregenrate, hud, superman, custom_weapon_stop, persist_outfit, persist_outfits_mis)
 		} self{};
 
 		struct session

--- a/src/services/outfit/outfit_service.cpp
+++ b/src/services/outfit/outfit_service.cpp
@@ -42,11 +42,8 @@ namespace big
 				if (id == 0)
 				{
 					//Prevent player ped from taking helmet off.
-					PED::SET_PED_HELMET_PROP_INDEX(self::ped, drawable_id, 0);
-					PED::SET_PED_HELMET_TEXTURE_INDEX(self::ped, texture_id);
 					PED::SET_PED_CONFIG_FLAG(self::ped, 34, true);
-					if (!PED::IS_PED_ON_ANY_BIKE(self::ped))
-						PED::SET_PED_CONFIG_FLAG(self::ped, 36, true);
+					PED::SET_PED_CONFIG_FLAG(self::ped, 36, true);
 				}
 			}
 		}


### PR DESCRIPTION
Fixed self_persist_outfit checking if the player was in a cutscene instead of if the player was dead.
1st attempt to fix the player trying to take off his helmet if it was added by persist outfit.