### PR TITLE
refactor!: Modify command argument handling and move `on_` method to bool_command

### DIFF
--- a/src/backend/backend.cpp
+++ b/src/backend/backend.cpp
@@ -19,6 +19,8 @@ namespace big
 {
 	void backend::loop()
 	{
+		for (auto& command : g_bool_commands)
+			command->refresh();
 		for (auto& command : g_looped_commands)
 			command->refresh();
 

--- a/src/backend/backend.cpp
+++ b/src/backend/backend.cpp
@@ -21,8 +21,6 @@ namespace big
 	{
 		for (auto& command : g_bool_commands)
 			command->refresh();
-		for (auto& command : g_looped_commands)
-			command->refresh();
 
 		register_script_patches();
 

--- a/src/backend/bool_command.cpp
+++ b/src/backend/bool_command.cpp
@@ -9,6 +9,7 @@ namespace big
 	    m_toggle(toggle),
 	    m_show_notify(show_notify)
 	{
+		g_bool_commands.push_back(this);
 	}
 
 	void bool_command::execute(const command_arguments& args, const std::shared_ptr<command_context> ctx)

--- a/src/backend/bool_command.cpp
+++ b/src/backend/bool_command.cpp
@@ -11,7 +11,7 @@ namespace big
 	{
 	}
 
-	void bool_command::execute(const std::vector<uint64_t>& args, const std::shared_ptr<command_context> ctx)
+	void bool_command::execute(const command_arguments& args, const std::shared_ptr<command_context> ctx)
 	{
 		if (args.size() == 0)
 		{
@@ -32,15 +32,15 @@ namespace big
 		}
 		else
 		{
-			m_toggle = args[0];
+			m_toggle = args.get<bool>(0);
 		}
 
 		this->refresh();
 	}
 
-	std::optional<std::vector<uint64_t>> bool_command::parse_args(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx)
+	std::optional<command_arguments> bool_command::parse_args(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx)
 	{
-		std::vector<uint64_t> result;
+		command_arguments result(1);
 
 		if (args.size() == 0)
 			return result;
@@ -53,13 +53,13 @@ namespace big
 
 		if (args[0] == "yes" || args[0] == "on" || args[0] == "enable" || args[0] == "true")
 		{
-			result.push_back(1);
+			result.push(true);
 			return result;
 		}
 
 		if (args[0] == "no" || args[0] == "off" || args[0] == "disable" || args[0] == "false")
 		{
-			result.push_back(0);
+			result.push(false);
 			return result;
 		}
 

--- a/src/backend/bool_command.hpp
+++ b/src/backend/bool_command.hpp
@@ -5,6 +5,8 @@ namespace big
 {
 	class bool_command : public command
 	{
+		bool m_last_enabled = false;
+
 	protected:
 		bool& m_toggle;
 		bool m_show_notify;
@@ -18,14 +20,11 @@ namespace big
 			return m_toggle;
 		}
 
-		virtual void refresh(){};
-		virtual void enable()
-		{
-			m_toggle = true;
-		};
-		virtual void disable()
-		{
-			m_toggle = false;
-		};
+		virtual void on_enable(){};
+		virtual void on_disable(){};
+		virtual void refresh();
+
+		virtual void enable();
+		virtual void disable();
 	};
 }

--- a/src/backend/bool_command.hpp
+++ b/src/backend/bool_command.hpp
@@ -10,8 +10,8 @@ namespace big
 	protected:
 		bool& m_toggle;
 		bool m_show_notify;
-		virtual void execute(const std::vector<uint64_t>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>()) override;
-		virtual std::optional<std::vector<uint64_t>> parse_args(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>()) override;
+		virtual void execute(const command_arguments& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>()) override;
+		virtual std::optional<command_arguments> parse_args(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>()) override;
 
 	public:
 		bool_command(const std::string& name, const std::string& label, const std::string& description, bool& toggle, bool show_notify = true);

--- a/src/backend/bool_command.hpp
+++ b/src/backend/bool_command.hpp
@@ -27,4 +27,6 @@ namespace big
 		virtual void enable();
 		virtual void disable();
 	};
+
+	inline std::vector<bool_command*> g_bool_commands;
 }

--- a/src/backend/command.cpp
+++ b/src/backend/command.cpp
@@ -51,7 +51,7 @@ namespace big
 		}
 	}
 
-	void command::call(const std::vector<uint64_t>& args, const std::shared_ptr<command_context> ctx)
+	void command::call(const command_arguments& args, const std::shared_ptr<command_context> ctx)
 	{
 		if (m_num_args.has_value() && args.size() != m_num_args.value())
 		{
@@ -103,7 +103,7 @@ namespace big
 		return g_commands[command];
 	}
 
-	void command::call(rage::joaat_t command, const std::vector<uint64_t>& args, const std::shared_ptr<command_context> ctx)
+	void command::call(rage::joaat_t command, const command_arguments& args, const std::shared_ptr<command_context> ctx)
 	{
 		g_commands[command]->call(args, ctx);
 	}

--- a/src/backend/command.cpp
+++ b/src/backend/command.cpp
@@ -51,7 +51,7 @@ namespace big
 		}
 	}
 
-	void command::call(const command_arguments& args, const std::shared_ptr<command_context> ctx)
+	void command::call(command_arguments& args, const std::shared_ptr<command_context> ctx)
 	{
 		if (m_num_args.has_value() && args.size() != m_num_args.value())
 		{
@@ -68,6 +68,7 @@ namespace big
 			return;
 		}
 
+		args.reset_idx();
 		if (m_fiber_pool)
 			g_fiber_pool->queue_job([this, args, ctx] {
 				execute(args, ctx);
@@ -103,7 +104,7 @@ namespace big
 		return g_commands[command];
 	}
 
-	void command::call(rage::joaat_t command, const command_arguments& args, const std::shared_ptr<command_context> ctx)
+	void command::call(rage::joaat_t command, command_arguments& args, const std::shared_ptr<command_context> ctx)
 	{
 		g_commands[command]->call(args, ctx);
 	}

--- a/src/backend/command.hpp
+++ b/src/backend/command.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "command_arguments.hpp"
 #include "context/command_context.hpp"
 #include "context/default_command_context.hpp"
 #include "core/enums.hpp"
@@ -17,10 +18,10 @@ namespace big
 		std::optional<uint8_t> m_num_args;
 		bool m_fiber_pool;
 
-		virtual void execute(const std::vector<uint64_t>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>()) = 0;
-		virtual std::optional<std::vector<uint64_t>> parse_args(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>())
+		virtual void execute(const command_arguments& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>()) = 0;
+		virtual std::optional<command_arguments> parse_args(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>())
 		{
-			return std::vector<uint64_t>();
+			return {0};
 		};
 		virtual CommandAccessLevel get_access_level()
 		{
@@ -54,13 +55,13 @@ namespace big
 			return m_num_args;
 		}
 
-		void call(const std::vector<uint64_t>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>());
+		void call(const command_arguments& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>());
 		void call(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>());
 		static std::vector<command*> get_suggestions(std::string, int limit = 7);
 
 		static command* get(rage::joaat_t command);
 
-		static void call(rage::joaat_t command, const std::vector<uint64_t>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>());
+		static void call(rage::joaat_t command, const command_arguments& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>());
 		static void call(rage::joaat_t command, const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>());
 
 		static bool process(const std::string& text, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>(), bool use_best_suggestion = false);

--- a/src/backend/command.hpp
+++ b/src/backend/command.hpp
@@ -55,13 +55,13 @@ namespace big
 			return m_num_args;
 		}
 
-		void call(const command_arguments& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>());
+		void call(command_arguments& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>());
 		void call(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>());
 		static std::vector<command*> get_suggestions(std::string, int limit = 7);
 
 		static command* get(rage::joaat_t command);
 
-		static void call(rage::joaat_t command, const command_arguments& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>());
+		static void call(rage::joaat_t command, command_arguments& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>());
 		static void call(rage::joaat_t command, const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>());
 
 		static bool process(const std::string& text, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>(), bool use_best_suggestion = false);

--- a/src/backend/command_arguments.hpp
+++ b/src/backend/command_arguments.hpp
@@ -56,7 +56,7 @@ namespace big
         {
             if (m_idx >= m_argument_count)
             {
-                throw std::runtime_error("Attempted to pop argument beyond allocated argument size.");
+                throw std::runtime_error("Attempted to shift argument beyond allocated argument size.");
             }
 
             return reinterpret_cast<const T&>(m_argument_data[m_idx++]);
@@ -68,7 +68,7 @@ namespace big
         {
             if (m_idx >= m_argument_count)
             {
-                throw std::runtime_error("Attempted to pop argument beyond allocated argument size.");
+                throw std::runtime_error("Attempted to shift argument beyond allocated argument size.");
             }
 
             return static_cast<const T>(m_argument_data[m_idx++]);

--- a/src/backend/command_arguments.hpp
+++ b/src/backend/command_arguments.hpp
@@ -1,0 +1,113 @@
+#pragma once
+#include <concepts>
+#include <stdexcept>
+#include <type_traits>
+
+namespace big
+{
+    template<typename T>
+    concept ArgumentLimit = sizeof(T) <= sizeof(uint64_t);
+
+    class command_arguments 
+    {
+    private:
+        const std::size_t m_argument_count;
+        std::vector<uint64_t> m_argument_data;
+        std::size_t m_idx;
+
+    public:
+        command_arguments(std::size_t argument_count = 0) :
+            m_argument_count(argument_count),
+            m_argument_data(),
+            m_idx(0)
+        {
+            m_argument_data.reserve(argument_count);
+        }
+
+        command_arguments(std::size_t argument_count, const command_arguments& other) :
+            command_arguments(argument_count)
+        {
+            std::copy_n(other.m_argument_data.begin(), std::min(argument_count, other.m_argument_data.size()), m_argument_data.begin());
+        }
+
+        command_arguments(const std::vector<uint64_t>& vec) :
+            command_arguments(vec.size())
+        {
+            m_argument_data = vec;
+        }
+
+        template<typename T = uint64_t>
+            requires ArgumentLimit<T>
+        T get(std::size_t idx) const
+        {
+            return reinterpret_cast<const T&>(m_argument_data[idx]);
+        }
+
+        template<typename T = uint64_t>
+            requires ArgumentLimit<T>
+        std::enable_if_t<std::is_pointer_v<T>, T> get(std::size_t idx) const
+        {
+            return static_cast<T>(m_argument_data[idx]);
+        }
+
+        template<typename T = uint64_t>
+            requires ArgumentLimit<T>
+        T pop()
+        {
+            if (m_idx >= m_argument_count)
+            {
+                throw std::runtime_error("Attempted to pop argument beyond allocated argument size.");
+            }
+
+            return reinterpret_cast<const T&>(m_argument_data[m_idx++]);
+        }
+
+        template<typename T = uint64_t>
+            requires ArgumentLimit<T>
+        std::enable_if_t<std::is_pointer_v<T>, const T> pop() const
+        {
+            if (m_idx >= m_argument_count)
+            {
+                throw std::runtime_error("Attempted to pop argument beyond allocated argument size.");
+            }
+
+            return static_cast<T>(m_argument_data[m_idx++]);
+        }
+
+        template<typename T = uint64_t>
+            requires ArgumentLimit<T>
+        void push(T arg)
+        {
+            if (m_idx >= m_argument_count)
+            {
+                throw std::runtime_error("Attempted to push argument beyond allocated argument size.");
+            }
+
+            m_argument_data.push_back(reinterpret_cast<uint64_t&>(arg));
+            m_idx++;
+        }
+
+        template<typename T = uint64_t>
+            requires ArgumentLimit<T>
+        void set(std::size_t idx, T arg)
+        {
+            if (idx >= m_argument_count)
+            {
+                throw std::runtime_error("Attempted to set argument beyond allocated argument size.");
+            }
+
+            m_argument_data[idx] = reinterpret_cast<uint64_t&>(arg);
+        }
+
+        void reset()
+        {
+            m_idx = 0;
+        }
+
+        std::size_t size() const
+        {
+            return m_argument_data.size();
+        }
+
+    };
+}

--- a/src/backend/commands/misc/recovery.cpp
+++ b/src/backend/commands/misc/recovery.cpp
@@ -12,7 +12,7 @@ namespace big
 			return CommandAccessLevel::NONE;
 		}
 
-		virtual void execute(const std::vector<uint64_t>&, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments&, const std::shared_ptr<command_context> ctx)
 		{
 			ctx->report_error("Money and recovery options are not supported in YimMenu to keep Rockstar/Take Two happy. You can try Kiddion's Modest Menu (free) instead, but make sure to only get it from UnknownCheats.me, the rest are scams and may contain malware");
 		}

--- a/src/backend/commands/player/kick/bail_kick.cpp
+++ b/src/backend/commands/player/kick/bail_kick.cpp
@@ -16,7 +16,7 @@ namespace big
 			return CommandAccessLevel::TOXIC;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			const size_t arg_count  = 3;
 			int64_t args[arg_count] = {(int64_t)eRemoteEvent::NetworkBail,

--- a/src/backend/commands/player/kick/breakup_kick.cpp
+++ b/src/backend/commands/player/kick/breakup_kick.cpp
@@ -18,7 +18,7 @@ namespace big
 			return CommandAccessLevel::TOXIC;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			if (!g_player_service->get_self()->is_host() || !player->get_net_data())
 				return;

--- a/src/backend/commands/player/kick/complaint_kick.cpp
+++ b/src/backend/commands/player/kick/complaint_kick.cpp
@@ -17,7 +17,7 @@ namespace big
 			return CommandAccessLevel::TOXIC;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			if (gta_util::get_network()->m_game_session_ptr->is_host())
 			{

--- a/src/backend/commands/player/kick/end_session_kick.cpp
+++ b/src/backend/commands/player/kick/end_session_kick.cpp
@@ -15,7 +15,7 @@ namespace big
 			return CommandAccessLevel::TOXIC;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			if (!scripts::force_host(RAGE_JOAAT("freemode")))
 			{

--- a/src/backend/commands/player/kick/host_kick.cpp
+++ b/src/backend/commands/player/kick/host_kick.cpp
@@ -12,7 +12,7 @@ namespace big
 			return CommandAccessLevel::TOXIC;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			if (!g_player_service->get_self()->is_host())
 			{

--- a/src/backend/commands/player/kick/null_function_kick.cpp
+++ b/src/backend/commands/player/kick/null_function_kick.cpp
@@ -14,7 +14,7 @@ namespace big
 			return CommandAccessLevel::TOXIC;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			const size_t arg_count  = 15;
 			int64_t args[arg_count] = {(int64_t)eRemoteEvent::InteriorControl, (int64_t)self::id, (int64_t)(int)-1};

--- a/src/backend/commands/player/kick/oom_kick.cpp
+++ b/src/backend/commands/player/kick/oom_kick.cpp
@@ -18,7 +18,7 @@ namespace big
 			return CommandAccessLevel::TOXIC;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			packet msg{};
 

--- a/src/backend/commands/player/kick/script_host_kick.cpp
+++ b/src/backend/commands/player/kick/script_host_kick.cpp
@@ -15,7 +15,7 @@ namespace big
 			return CommandAccessLevel::TOXIC;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			if (!scripts::force_host(RAGE_JOAAT("freemode")))
 			{

--- a/src/backend/commands/player/misc/clear_wanted_level.cpp
+++ b/src/backend/commands/player/misc/clear_wanted_level.cpp
@@ -14,7 +14,7 @@ namespace big
 			return CommandAccessLevel::FRIENDLY;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			globals::clear_wanted_player(player->id());
 		}

--- a/src/backend/commands/player/misc/enter_interior.cpp
+++ b/src/backend/commands/player/misc/enter_interior.cpp
@@ -13,7 +13,7 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			int id = player->id();
 			if (scr_globals::gpbd_fm_1.as<GPBD_FM*>()->Entries[id].PropertyData.Index != -1)

--- a/src/backend/commands/player/misc/give_ammo.cpp
+++ b/src/backend/commands/player/misc/give_ammo.cpp
@@ -15,7 +15,7 @@ namespace big
 			return CommandAccessLevel::FRIENDLY;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			g_pickup_service->give_player_health(player->id());
 		}

--- a/src/backend/commands/player/misc/give_armor.cpp
+++ b/src/backend/commands/player/misc/give_armor.cpp
@@ -15,7 +15,7 @@ namespace big
 			return CommandAccessLevel::FRIENDLY;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			g_pickup_service->give_armour(player->id());
 		}

--- a/src/backend/commands/player/misc/give_health.cpp
+++ b/src/backend/commands/player/misc/give_health.cpp
@@ -15,7 +15,7 @@ namespace big
 			return CommandAccessLevel::FRIENDLY;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			g_pickup_service->give_player_health(player->id());
 		}

--- a/src/backend/commands/player/misc/join_ceo.cpp
+++ b/src/backend/commands/player/misc/join_ceo.cpp
@@ -10,7 +10,7 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			scr_functions::join_ceo({player->id(), 0, false, false});
 		}

--- a/src/backend/commands/player/misc/steal_identity.cpp
+++ b/src/backend/commands/player/misc/steal_identity.cpp
@@ -9,7 +9,7 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			ped::steal_identity(PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id()));
 		}

--- a/src/backend/commands/player/misc/steal_outfit.cpp
+++ b/src/backend/commands/player/misc/steal_outfit.cpp
@@ -9,7 +9,7 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			ped::steal_outfit(PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id()));
 		}

--- a/src/backend/commands/player/toxic/ceo_kick.cpp
+++ b/src/backend/commands/player/toxic/ceo_kick.cpp
@@ -16,7 +16,7 @@ namespace big
 			return CommandAccessLevel::AGGRESSIVE;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			auto leader = scr_globals::gpbd_fm_3.as<GPBD_FM_3*>()->Entries[player->id()].BossGoon.Boss;
 

--- a/src/backend/commands/player/toxic/explode_player.cpp
+++ b/src/backend/commands/player/toxic/explode_player.cpp
@@ -14,7 +14,7 @@ namespace big
 			return CommandAccessLevel::AGGRESSIVE;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			toxic::blame_explode_player(player, player, EXP_TAG_SUBMARINE_BIG, 9999.0f, true, false, 9999.0f);
 		}

--- a/src/backend/commands/player/toxic/force_into_mission.cpp
+++ b/src/backend/commands/player/toxic/force_into_mission.cpp
@@ -14,7 +14,7 @@ namespace big
 			return CommandAccessLevel::AGGRESSIVE;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			const size_t arg_count  = 3;
 			int64_t args[arg_count] = {(int64_t)eRemoteEvent::ForceMission, (int64_t)self::id, 0};

--- a/src/backend/commands/player/toxic/give_all_weapons.cpp
+++ b/src/backend/commands/player/toxic/give_all_weapons.cpp
@@ -15,7 +15,7 @@ namespace big
 			return CommandAccessLevel::FRIENDLY;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			for (auto& weapon : g_gta_data_service->weapons())
 				WEAPON::GIVE_WEAPON_TO_PED(PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id()), weapon.second.m_hash, 9999, FALSE, FALSE);
@@ -31,7 +31,7 @@ namespace big
 			return CommandAccessLevel::FRIENDLY;
 		}
 
-		virtual void execute(const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			g_player_service->iterate([](auto& plyr) {
 				for (auto& weapon : g_gta_data_service->weapons())

--- a/src/backend/commands/player/toxic/kick_from_interior.cpp
+++ b/src/backend/commands/player/toxic/kick_from_interior.cpp
@@ -23,7 +23,7 @@ namespace big
 			return CommandAccessLevel::AGGRESSIVE;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			if (scr_globals::gpbd_fm_1.as<GPBD_FM*>()->Entries[player->id()].PropertyData.Index != -1)
 			{

--- a/src/backend/commands/player/toxic/kick_from_vehicle.cpp
+++ b/src/backend/commands/player/toxic/kick_from_vehicle.cpp
@@ -14,7 +14,7 @@ namespace big
 			return CommandAccessLevel::AGGRESSIVE;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			auto vehicle = player->get_current_vehicle();
 

--- a/src/backend/commands/player/toxic/kill_player.cpp
+++ b/src/backend/commands/player/toxic/kill_player.cpp
@@ -13,7 +13,7 @@ namespace big
 			return CommandAccessLevel::AGGRESSIVE;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			if (!player->get_ped())
 				return;

--- a/src/backend/commands/player/toxic/ragdoll_player.cpp
+++ b/src/backend/commands/player/toxic/ragdoll_player.cpp
@@ -13,7 +13,7 @@ namespace big
 			return CommandAccessLevel::AGGRESSIVE;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			if (auto ped = player->get_ped())
 				if (auto net_object = ped->m_net_object)

--- a/src/backend/commands/player/toxic/remove_all_weapons.cpp
+++ b/src/backend/commands/player/toxic/remove_all_weapons.cpp
@@ -14,7 +14,7 @@ namespace big
 			return CommandAccessLevel::AGGRESSIVE;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			for (auto& [_, weapon] : g_gta_data_service->weapons())
 				WEAPON::REMOVE_WEAPON_FROM_PED(PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id()), weapon.m_hash);

--- a/src/backend/commands/player/toxic/send_fake_ban_message.cpp
+++ b/src/backend/commands/player/toxic/send_fake_ban_message.cpp
@@ -16,7 +16,7 @@ namespace big
 			return CommandAccessLevel::AGGRESSIVE;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			const size_t arg_count  = 8;
 			int64_t args[arg_count] = {(int64_t)eRemoteEvent::SendTextLabelSMS, self::id};

--- a/src/backend/commands/player/toxic/send_sext.cpp
+++ b/src/backend/commands/player/toxic/send_sext.cpp
@@ -20,7 +20,7 @@ namespace big
 			return CommandAccessLevel::AGGRESSIVE;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			const size_t arg_count  = 8;
 			int64_t args[arg_count] = {(int64_t)eRemoteEvent::SendTextLabelSMS, self::id};

--- a/src/backend/commands/player/toxic/send_to_apartment.cpp
+++ b/src/backend/commands/player/toxic/send_to_apartment.cpp
@@ -9,20 +9,15 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual std::optional<std::vector<uint64_t>> parse_args_p(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx)
-		{
-			return std::vector<uint64_t>{(uint64_t)std::atoi(args[0].c_str())};
-		}
-
 		virtual CommandAccessLevel get_access_level()
 		{
 			return CommandAccessLevel::AGGRESSIVE;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			const size_t arg_count = 9;
-			int64_t args[arg_count] = {(int64_t)eRemoteEvent::Teleport, self::id, (int64_t)player->id(), (int64_t)(int)-1, 1, (int64_t)_args[0], 1, 1, 1};
+			int64_t args[arg_count] = {(int64_t)eRemoteEvent::Teleport, self::id, (int64_t)player->id(), (int64_t)(int)-1, 1, (int64_t)_args.get<int64_t>(0), 1, 1, 1};
 
 			g_pointers->m_gta.m_trigger_script_event(1, args, arg_count, 1 << player->id());
 		}

--- a/src/backend/commands/player/toxic/send_to_interior.cpp
+++ b/src/backend/commands/player/toxic/send_to_interior.cpp
@@ -8,24 +8,19 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual std::optional<std::vector<uint64_t>> parse_args_p(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx)
-		{
-			return std::vector<uint64_t>{(uint64_t)std::atoi(args[0].c_str())};
-		}
-
 		virtual CommandAccessLevel get_access_level()
 		{
 			return CommandAccessLevel::AGGRESSIVE;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			float max   = 1e+38f;
 			auto coords = ENTITY::GET_ENTITY_COORDS(PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id()), FALSE);
 			const size_t arg_count  = 15;
 			int64_t args[arg_count] = {(int64_t)eRemoteEvent::InteriorControl,
 			    (int64_t)self::id,
-			    (int64_t)(int)_args[0],
+			    (int64_t)_args.get<int>(0),
 			    (int64_t)self::id,
 			    (int64_t) false,
 			    (int64_t) true, // true means enter sender interior

--- a/src/backend/commands/player/toxic/send_to_warehouse.cpp
+++ b/src/backend/commands/player/toxic/send_to_warehouse.cpp
@@ -9,20 +9,15 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual std::optional<std::vector<uint64_t>> parse_args_p(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx)
-		{
-			return std::vector<uint64_t>{(uint64_t)std::atoi(args[0].c_str())};
-		}
-
 		virtual CommandAccessLevel get_access_level()
 		{
 			return CommandAccessLevel::AGGRESSIVE;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			const size_t arg_count = 6;
-			int64_t args[arg_count] = {(int64_t)eRemoteEvent::TeleportToWarehouse, self::id, (int64_t)player->id(), 1, (int64_t)_args[0]};
+			int64_t args[arg_count] = {(int64_t)eRemoteEvent::TeleportToWarehouse, self::id, (int64_t)player->id(), 1, (int64_t)_args.get<int>(0)};
 
 			g_pointers->m_gta.m_trigger_script_event(1, args, arg_count, 1 << player->id());
 		}

--- a/src/backend/commands/player/toxic/set_wanted_level.cpp
+++ b/src/backend/commands/player/toxic/set_wanted_level.cpp
@@ -13,17 +13,19 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual std::optional<std::vector<uint64_t>> parse_args_p(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx)
+		virtual std::optional<command_arguments> parse_args_p(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx)
 		{
-			uint64_t level = std::atoi(args[0].c_str());
+			const auto level = std::atoi(args[0].c_str());
 
 			if (level < 0 || level > 5)
 			{
-				ctx->report_error(std::format("Wanted level {} is invalid", level));
+				ctx->report_error(std::format("Wanted level {} is invalid [0 - 5]", level));
 				return std::nullopt;
 			}
 
-			return std::vector<uint64_t>{level};
+			command_arguments result(1);
+			result.push(level);
+			return result;
 		}
 
 		virtual CommandAccessLevel get_access_level()
@@ -31,33 +33,34 @@ namespace big
 			return CommandAccessLevel::AGGRESSIVE;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
+			const auto wanted_level = _args.get<int>(0);
 			if (player->id() == self::id)
 			{
-				PLAYER::SET_PLAYER_WANTED_LEVEL(self::id, _args[0], FALSE);
+				PLAYER::SET_PLAYER_WANTED_LEVEL(self::id, wanted_level, FALSE);
 			}
 			else
 			{
 				int id = player->id();
 
-				if (PLAYER::GET_PLAYER_WANTED_LEVEL(id) > _args[0])
+				if (PLAYER::GET_PLAYER_WANTED_LEVEL(id) > wanted_level)
 				{
 					// clear existing wanted
 					globals::clear_wanted_player(id);
 
-					for (int i = 0; PLAYER::GET_PLAYER_WANTED_LEVEL(id) > _args[0] && i < 3600; i++)
+					for (int i = 0; PLAYER::GET_PLAYER_WANTED_LEVEL(id) > wanted_level && i < 3600; i++)
 						script::get_current()->yield(1ms);
 				}
 
-				if (_args[0] > 0)
+				if (wanted_level > 0)
 				{
 					auto& gpbd = scr_globals::globalplayer_bd.as<GlobalPlayerBD*>()->Entries[self::id];
 
 					gpbd.RemoteWantedLevelPlayer = id;
-					gpbd.RemoteWantedLevelAmount = _args[0];
+					gpbd.RemoteWantedLevelAmount = wanted_level;
 
-					for (int i = 0; PLAYER::GET_PLAYER_WANTED_LEVEL(id) < _args[0] && i < 3600; i++)
+					for (int i = 0; PLAYER::GET_PLAYER_WANTED_LEVEL(id) < wanted_level && i < 3600; i++)
 						script::get_current()->yield(1ms);
 
 					gpbd.RemoteWantedLevelPlayer = -1;

--- a/src/backend/commands/player/toxic/show_transaction_error.cpp
+++ b/src/backend/commands/player/toxic/show_transaction_error.cpp
@@ -16,7 +16,7 @@ namespace big
 			return CommandAccessLevel::AGGRESSIVE;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			const size_t arg_count  = 8;
 			int64_t args[arg_count] = {(int64_t)eRemoteEvent::TransactionError,

--- a/src/backend/commands/player/toxic/start_script.cpp
+++ b/src/backend/commands/player/toxic/start_script.cpp
@@ -18,7 +18,7 @@ namespace big
 			return CommandAccessLevel::AGGRESSIVE;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			const size_t arg_count  = 25;
 			int64_t args[arg_count] = {(int64_t)eRemoteEvent::StartScriptBegin, (int64_t)self::id};

--- a/src/backend/commands/player/toxic/trigger_ceo_raid.cpp
+++ b/src/backend/commands/player/toxic/trigger_ceo_raid.cpp
@@ -13,7 +13,7 @@ namespace big
 			return CommandAccessLevel::AGGRESSIVE;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			const size_t arg_count  = 3;
 			int64_t args[arg_count] = {(int64_t)eRemoteEvent::TriggerCEORaid, (int64_t)self::id, 0};

--- a/src/backend/commands/player/toxic/turn_into_beast.cpp
+++ b/src/backend/commands/player/toxic/turn_into_beast.cpp
@@ -15,7 +15,7 @@ namespace big
 			return CommandAccessLevel::AGGRESSIVE;
 		}
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			auto id = player->id();
 
@@ -81,7 +81,7 @@ namespace big
 			return CommandAccessLevel::AGGRESSIVE;
 		}
 
-		virtual void execute(const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			scripts::start_launcher_script(47);
 

--- a/src/backend/commands/player/troll/bring.cpp
+++ b/src/backend/commands/player/troll/bring.cpp
@@ -10,7 +10,7 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			teleport::bring_player(player);
 		}
@@ -20,7 +20,7 @@ namespace big
 	{
 		using command::command;
 
-		virtual void execute(const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			for (auto& player : g_player_service->players())
 				g_fiber_pool->queue_job([player]() {

--- a/src/backend/commands/player/troll/set_bounty.cpp
+++ b/src/backend/commands/player/troll/set_bounty.cpp
@@ -10,7 +10,7 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			troll::set_bounty_on_player(player, 10000, g.session.anonymous_bounty);
 		}

--- a/src/backend/commands/player/troll/teleport.cpp
+++ b/src/backend/commands/player/troll/teleport.cpp
@@ -10,7 +10,7 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			teleport::to_player(player->id());
 		}

--- a/src/backend/commands/player/troll/teleport_into_vehicle.cpp
+++ b/src/backend/commands/player/troll/teleport_into_vehicle.cpp
@@ -9,7 +9,7 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			Vehicle veh =
 			    PED::GET_VEHICLE_PED_IS_IN(PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(g_player_service->get_selected()->id()), false);

--- a/src/backend/commands/player/vehicle/boost_vehicle.cpp
+++ b/src/backend/commands/player/vehicle/boost_vehicle.cpp
@@ -9,7 +9,7 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			Ped ped = PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id());
 			if (!PED::IS_PED_IN_ANY_VEHICLE(ped, true))

--- a/src/backend/commands/player/vehicle/burst_tyres.cpp
+++ b/src/backend/commands/player/vehicle/burst_tyres.cpp
@@ -9,7 +9,7 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			Ped ped = PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id());
 

--- a/src/backend/commands/player/vehicle/close_doors.cpp
+++ b/src/backend/commands/player/vehicle/close_doors.cpp
@@ -8,7 +8,7 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			Ped ped = PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id());
 

--- a/src/backend/commands/player/vehicle/downgrade_vehicle.cpp
+++ b/src/backend/commands/player/vehicle/downgrade_vehicle.cpp
@@ -9,7 +9,7 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			Ped ped         = PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id());
 			Vehicle vehicle = PED::GET_VEHICLE_PED_IS_IN(ped, false);

--- a/src/backend/commands/player/vehicle/flip_180.cpp
+++ b/src/backend/commands/player/vehicle/flip_180.cpp
@@ -9,7 +9,7 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			Ped player_ped           = PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id());
 			Vehicle vehicle          = PED::GET_VEHICLE_PED_IS_IN(player_ped, false);

--- a/src/backend/commands/player/vehicle/flying_vehicle.cpp
+++ b/src/backend/commands/player/vehicle/flying_vehicle.cpp
@@ -9,7 +9,7 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			Entity ent = PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id());
 

--- a/src/backend/commands/player/vehicle/kill_engine.cpp
+++ b/src/backend/commands/player/vehicle/kill_engine.cpp
@@ -8,7 +8,7 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			Ped ped = PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id());
 			if (!PED::IS_PED_IN_ANY_VEHICLE(ped, true))

--- a/src/backend/commands/player/vehicle/lock_doors.cpp
+++ b/src/backend/commands/player/vehicle/lock_doors.cpp
@@ -9,7 +9,7 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			int lockStatus = VEHICLE::GET_VEHICLE_DOOR_LOCK_STATUS(player->id());
 			Ped ped        = PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id());

--- a/src/backend/commands/player/vehicle/open_doors.cpp
+++ b/src/backend/commands/player/vehicle/open_doors.cpp
@@ -9,7 +9,7 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			Ped ped = PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id());
 			if (!PED::IS_PED_IN_ANY_VEHICLE(ped, true))

--- a/src/backend/commands/player/vehicle/remote_control_vehicle.cpp
+++ b/src/backend/commands/player/vehicle/remote_control_vehicle.cpp
@@ -9,7 +9,7 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			Vehicle veh = PED::GET_VEHICLE_PED_IS_IN(PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id()), FALSE);
 			if (veh == 0)

--- a/src/backend/commands/player/vehicle/smash_windows.cpp
+++ b/src/backend/commands/player/vehicle/smash_windows.cpp
@@ -9,7 +9,7 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			Ped ped = PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id());
 			if (PED::IS_PED_IN_ANY_VEHICLE(ped, false))

--- a/src/backend/commands/player/vehicle/stop_vehicle.cpp
+++ b/src/backend/commands/player/vehicle/stop_vehicle.cpp
@@ -8,7 +8,7 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			Ped ped = PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id());
 			if (!PED::IS_PED_IN_ANY_VEHICLE(ped, true))

--- a/src/backend/commands/player/vehicle/unlock_doors.cpp
+++ b/src/backend/commands/player/vehicle/unlock_doors.cpp
@@ -8,7 +8,7 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			if (PED::IS_PED_IN_ANY_VEHICLE(player->id(), false))
 			{

--- a/src/backend/commands/player/vehicle/upgrade_vehicle.cpp
+++ b/src/backend/commands/player/vehicle/upgrade_vehicle.cpp
@@ -10,7 +10,7 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			Ped ped         = PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id());
 			Vehicle vehicle = PED::GET_VEHICLE_PED_IS_IN(ped, false);

--- a/src/backend/commands/player/vehicle/window_tint.cpp
+++ b/src/backend/commands/player/vehicle/window_tint.cpp
@@ -10,7 +10,7 @@ namespace big
 	{
 		using player_command::player_command;
 
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& _args, const std::shared_ptr<command_context> ctx)
+		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx)
 		{
 			Ped ped = PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id());
 

--- a/src/backend/commands/self/ammo.cpp
+++ b/src/backend/commands/self/ammo.cpp
@@ -8,7 +8,7 @@ namespace big
 	{
 		using command::command;
 
-		virtual void execute(const std::vector<uint64_t>&, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments&, const std::shared_ptr<command_context> ctx)
 		{
 			for (const auto& [_, weapon] : g_gta_data_service->weapons())
 			{

--- a/src/backend/commands/self/clean_player.cpp
+++ b/src/backend/commands/self/clean_player.cpp
@@ -8,7 +8,7 @@ namespace big
 	{
 		using command::command;
 
-		virtual void execute(const std::vector<uint64_t>&, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments&, const std::shared_ptr<command_context> ctx)
 		{
 			entity::clean_ped(self::ped);
 		}

--- a/src/backend/commands/self/clearwanted.cpp
+++ b/src/backend/commands/self/clearwanted.cpp
@@ -7,7 +7,7 @@ namespace big
 	{
 		using command::command;
 
-		virtual void execute(const std::vector<uint64_t>&, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments&, const std::shared_ptr<command_context> ctx)
 		{
 			if(g_local_player && g_local_player !=nullptr && !g.self.force_wanted_level)
 			{

--- a/src/backend/commands/self/fill_inventory.cpp
+++ b/src/backend/commands/self/fill_inventory.cpp
@@ -8,7 +8,7 @@ namespace big
 	{
 		using command::command;
 
-		virtual void execute(const std::vector<uint64_t>&, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments&, const std::shared_ptr<command_context> ctx)
 		{
 			std::string mpPrefix = local_player::get_mp_prefix();
 			STATS::STAT_SET_INT(rage::joaat(mpPrefix + "NO_BOUGHT_YUM_SNACKS"), 30, true);

--- a/src/backend/commands/self/heal.cpp
+++ b/src/backend/commands/self/heal.cpp
@@ -7,7 +7,7 @@ namespace big
 	{
 		using command::command;
 
-		virtual void execute(const std::vector<uint64_t>&, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments&, const std::shared_ptr<command_context> ctx)
 		{
 			ENTITY::SET_ENTITY_HEALTH(self::ped, PED::GET_PED_MAX_HEALTH(self::ped), 0);
 			PED::SET_PED_ARMOUR(self::ped, PLAYER::GET_PLAYER_MAX_ARMOUR(self::id));

--- a/src/backend/commands/self/repair_vehicle.cpp
+++ b/src/backend/commands/self/repair_vehicle.cpp
@@ -7,7 +7,7 @@ namespace big
         class repairpv : command
         {
                 using command::command;
-                virtual void execute(const std::vector<uint64_t>&, const std::shared_ptr<command_context> ctx)
+                virtual void execute(const command_arguments&, const std::shared_ptr<command_context> ctx)
                 {
                         vehicle::repair(self::veh);
                 }

--- a/src/backend/commands/self/request_services.cpp
+++ b/src/backend/commands/self/request_services.cpp
@@ -8,7 +8,7 @@ namespace big
 	{
 		using command::command;
 
-		virtual void execute(const std::vector<uint64_t>&, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments&, const std::shared_ptr<command_context> ctx)
 		{
 			mobile::merry_weather::request_boat_pickup();
 		}
@@ -18,7 +18,7 @@ namespace big
 	{
 		using command::command;
 
-		virtual void execute(const std::vector<uint64_t>&, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments&, const std::shared_ptr<command_context> ctx)
 		{
 			mobile::ceo_abilities::request_ballistic_armor();
 		}
@@ -28,7 +28,7 @@ namespace big
 	{
 		using command::command;
 
-		virtual void execute(const std::vector<uint64_t>&, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments&, const std::shared_ptr<command_context> ctx)
 		{
 			mobile::services::request_avenger();
 		}
@@ -38,7 +38,7 @@ namespace big
 	{
 		using command::command;
 
-		virtual void execute(const std::vector<uint64_t>&, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments&, const std::shared_ptr<command_context> ctx)
 		{
 			mobile::services::request_kosatka();
 		}
@@ -48,7 +48,7 @@ namespace big
 	{
 		using command::command;
 
-		virtual void execute(const std::vector<uint64_t>&, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments&, const std::shared_ptr<command_context> ctx)
 		{
 			mobile::services::request_mobile_operations_center();
 		}
@@ -58,7 +58,7 @@ namespace big
 	{
 		using command::command;
 
-		virtual void execute(const std::vector<uint64_t>&, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments&, const std::shared_ptr<command_context> ctx)
 		{
 			mobile::services::request_terrorbyte();
 		}
@@ -68,7 +68,7 @@ namespace big
 	{
 		using command::command;
 
-		virtual void execute(const std::vector<uint64_t>&, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments&, const std::shared_ptr<command_context> ctx)
 		{
 			mobile::services::request_acidlab();
 		}
@@ -78,7 +78,7 @@ namespace big
 	{
 		using command::command;
 
-		virtual void execute(const std::vector<uint64_t>&, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments&, const std::shared_ptr<command_context> ctx)
 		{
 			mobile::services::request_acidlab_bike();
 		}
@@ -88,7 +88,7 @@ namespace big
 	{
 		using command::command;
 
-		virtual void execute(const std::vector<uint64_t>&, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments&, const std::shared_ptr<command_context> ctx)
 		{
 			mobile::mobile_misc::request_taxi();
 		}

--- a/src/backend/commands/self/skip_cutscene.cpp
+++ b/src/backend/commands/self/skip_cutscene.cpp
@@ -7,7 +7,7 @@ namespace big
 	{
 		using command::command;
 
-		virtual void execute(const std::vector<uint64_t>&, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments&, const std::shared_ptr<command_context> ctx)
 		{
 			CUTSCENE::STOP_CUTSCENE_IMMEDIATELY();
 		}

--- a/src/backend/commands/self/suicide.cpp
+++ b/src/backend/commands/self/suicide.cpp
@@ -7,7 +7,7 @@ namespace big
 	{
 		using command::command;
 
-		virtual void execute(const std::vector<uint64_t>&, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments&, const std::shared_ptr<command_context> ctx)
 		{
 			ENTITY::SET_ENTITY_HEALTH(self::ped, 0, 0);
 		}

--- a/src/backend/commands/session/wipe_session.cpp
+++ b/src/backend/commands/session/wipe_session.cpp
@@ -8,7 +8,7 @@ namespace big
 	class empty_session : command
 	{
 		using command::command;
-		virtual void execute(const std::vector<uint64_t>&, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments&, const std::shared_ptr<command_context> ctx)
 		{
 			g_player_service->iterate([](const player_entry& player) {
 				auto mgr = *g_pointers->m_gta.m_network_player_mgr;

--- a/src/backend/commands/system/fast_quit.cpp
+++ b/src/backend/commands/system/fast_quit.cpp
@@ -6,7 +6,7 @@ namespace big
 	{
 		using command::command;
 
-		virtual void execute(const std::vector<uint64_t>&, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments&, const std::shared_ptr<command_context> ctx)
 		{
 			exit(0);
 		}

--- a/src/backend/commands/teleport/bring_personal_vehicle.cpp
+++ b/src/backend/commands/teleport/bring_personal_vehicle.cpp
@@ -9,7 +9,7 @@ namespace big
 	{
 		using command::command;
 
-		virtual void execute(const std::vector<uint64_t>&, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments&, const std::shared_ptr<command_context> ctx)
 		{
 			Vehicle veh = mobile::mechanic::get_personal_vehicle();
 			vehicle::bring(veh, self::pos);

--- a/src/backend/commands/teleport/teleport_to_highlighted_blip.cpp
+++ b/src/backend/commands/teleport/teleport_to_highlighted_blip.cpp
@@ -8,7 +8,7 @@ namespace big
 	{
 		using command::command;
 
-		virtual void execute(const std::vector<std::uint64_t>&, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments&, const std::shared_ptr<command_context> ctx)
 		{
 			teleport::to_highlighted_blip();
 		}

--- a/src/backend/commands/teleport/teleport_to_last_vehicle.cpp
+++ b/src/backend/commands/teleport/teleport_to_last_vehicle.cpp
@@ -8,7 +8,7 @@ namespace big
 	{
 		using command::command;
 
-		virtual void execute(const std::vector<uint64_t>&, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments&, const std::shared_ptr<command_context> ctx)
 		{
 			if (g_local_player && g_local_player->m_vehicle)
 			{

--- a/src/backend/commands/teleport/teleport_to_objective.cpp
+++ b/src/backend/commands/teleport/teleport_to_objective.cpp
@@ -8,7 +8,7 @@ namespace big
 	{
 		using command::command;
 
-		virtual void execute(const std::vector<uint64_t>&, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments&, const std::shared_ptr<command_context> ctx)
 		{
 			teleport::to_objective();
 		}

--- a/src/backend/commands/teleport/teleport_to_personal_vehicle.cpp
+++ b/src/backend/commands/teleport/teleport_to_personal_vehicle.cpp
@@ -9,7 +9,7 @@ namespace big
 	{
 		using command::command;
 
-		virtual void execute(const std::vector<uint64_t>&, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments&, const std::shared_ptr<command_context> ctx)
 		{
 			Vehicle veh = mobile::mechanic::get_personal_vehicle();
 			teleport::into_vehicle(veh);

--- a/src/backend/commands/teleport/teleport_to_waypoint.cpp
+++ b/src/backend/commands/teleport/teleport_to_waypoint.cpp
@@ -8,7 +8,7 @@ namespace big
 	{
 		using command::command;
 
-		virtual void execute(const std::vector<uint64_t>&, const std::shared_ptr<command_context> ctx)
+		virtual void execute(const command_arguments&, const std::shared_ptr<command_context> ctx)
 		{
 			teleport::to_waypoint();
 		}

--- a/src/backend/float_command.cpp
+++ b/src/backend/float_command.cpp
@@ -10,14 +10,14 @@ namespace big
 	{
 	}
 
-    void float_command::execute(const std::vector<uint64_t>& args, const std::shared_ptr<command_context> ctx)
+    void float_command::execute(const command_arguments& args, const std::shared_ptr<command_context> ctx)
     {
-        m_value = reinterpret_cast<const float&>(args[0]);
+        m_value = args.get<float>(0);
     }
 
-	std::optional<std::vector<uint64_t>> float_command::parse_args(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx)
+	std::optional<command_arguments> float_command::parse_args(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx)
 	{
-		std::vector<uint64_t> result;
+		command_arguments result(1);
 		float value = std::atof(args[0].c_str());
 
 		if (value < m_lower_bound || value > m_upper_bound)
@@ -26,7 +26,7 @@ namespace big
 			return std::nullopt;
 		}
 
-		result.push_back(reinterpret_cast<uint32_t&>(value));
+		result.push(value);
 		return result;
 	}
 }

--- a/src/backend/float_command.cpp
+++ b/src/backend/float_command.cpp
@@ -1,0 +1,32 @@
+#include "float_command.hpp"
+
+namespace big
+{
+	float_command::float_command(const std::string& name, const std::string& label, const std::string& description, float& value, float lower_bound, float upper_bound) :
+	    command(name, label, description, 1),
+	    m_value(value),
+	    m_lower_bound(lower_bound),
+	    m_upper_bound(upper_bound)
+	{
+	}
+
+    void float_command::execute(const std::vector<uint64_t>& args, const std::shared_ptr<command_context> ctx)
+    {
+        m_value = reinterpret_cast<const float&>(args[0]);
+    }
+
+	std::optional<std::vector<uint64_t>> float_command::parse_args(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx)
+	{
+		std::vector<uint64_t> result;
+		float value = std::atof(args[0].c_str());
+
+		if (value < m_lower_bound || value > m_upper_bound)
+		{
+			ctx->report_error(std::format("Value {} is not between {} and {} in command {}", value, m_lower_bound, m_upper_bound, m_name));
+			return std::nullopt;
+		}
+
+		result.push_back(reinterpret_cast<uint32_t&>(value));
+		return result;
+	}
+}

--- a/src/backend/float_command.hpp
+++ b/src/backend/float_command.hpp
@@ -1,0 +1,31 @@
+#pragma once
+#include "command.hpp"
+
+namespace big
+{
+	class float_command : public command
+	{
+	protected:
+		float& m_value;
+		const float m_lower_bound;
+		const float m_upper_bound;
+
+		virtual void execute(const std::vector<uint64_t>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>()) override;
+		virtual std::optional<std::vector<uint64_t>> parse_args(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>()) override;
+
+	public:
+		float_command(const std::string& name, const std::string& label, const std::string& description, float& value, float lower_bound, float upper_bound);
+		inline float& get_value()
+		{
+			return m_value;
+		}
+		inline float get_lower_bound()
+		{
+			return m_lower_bound;
+		}
+		inline float get_upper_bound()
+		{
+			return m_upper_bound;
+		}
+	};
+}

--- a/src/backend/float_command.hpp
+++ b/src/backend/float_command.hpp
@@ -10,8 +10,8 @@ namespace big
 		const float m_lower_bound;
 		const float m_upper_bound;
 
-		virtual void execute(const std::vector<uint64_t>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>()) override;
-		virtual std::optional<std::vector<uint64_t>> parse_args(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>()) override;
+		virtual void execute(const command_arguments& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>()) override;
+		virtual std::optional<command_arguments> parse_args(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>()) override;
 
 	public:
 		float_command(const std::string& name, const std::string& label, const std::string& description, float& value, float lower_bound, float upper_bound);

--- a/src/backend/int_command.cpp
+++ b/src/backend/int_command.cpp
@@ -10,14 +10,14 @@ namespace big
 	{
 	}
 
-	void int_command::execute(const std::vector<uint64_t>& args, const std::shared_ptr<command_context> ctx)
+	void int_command::execute(const command_arguments& args, const std::shared_ptr<command_context> ctx)
 	{
-		m_value = args[0];
+		m_value = args.get<int>(0);
 	}
 
-	std::optional<std::vector<uint64_t>> int_command::parse_args(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx)
+	std::optional<command_arguments> int_command::parse_args(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx)
 	{
-		std::vector<uint64_t> result;
+		command_arguments result(1);
 		int value = std::atoi(args[0].c_str());
 
 		if (value < m_lower_bound || value > m_upper_bound)
@@ -26,7 +26,7 @@ namespace big
 			return std::nullopt;
 		}
 
-		result.push_back(value);
+		result.push(value);
 		return result;
 	}
 }

--- a/src/backend/int_command.hpp
+++ b/src/backend/int_command.hpp
@@ -10,8 +10,8 @@ namespace big
 		int m_lower_bound;
 		int m_upper_bound;
 
-		virtual void execute(const std::vector<uint64_t>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>()) override;
-		virtual std::optional<std::vector<uint64_t>> parse_args(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>()) override;
+		virtual void execute(const command_arguments& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>()) override;
+		virtual std::optional<command_arguments> parse_args(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>()) override;
 
 	public:
 		int_command(const std::string& name, const std::string& label, const std::string& description, int& value, int lower_bound, int upper_bound);

--- a/src/backend/looped/hud/hud_color_override.cpp
+++ b/src/backend/looped/hud/hud_color_override.cpp
@@ -1,11 +1,11 @@
-#include "backend/looped_command.hpp"
+#include "backend/bool_command.hpp"
 #include "natives.hpp"
 
 namespace big
 {
-	class hudcolor_looped : looped_command
+	class hudcolor : bool_command
 	{
-		using looped_command::looped_command;
+		using bool_command::bool_command;
 
 		virtual void on_enable() override
 		{
@@ -31,10 +31,6 @@ namespace big
 			}
 		}
 
-		virtual void on_tick() override
-		{
-		}
-
 		virtual void on_disable() override
 		{
 			for (int i = 0; i < hud_colors.size(); i++)
@@ -45,5 +41,5 @@ namespace big
 		}
 	};
 
-	hudcolor_looped g_hudcolor_looped("hudcolor", "Override HUD Color", "Override HUD colors", g.self.hud.color_override);
+	hudcolor g_hudcolor_looped("hudcolor", "Override HUD Color", "Override HUD colors", g.self.hud.color_override);
 }

--- a/src/backend/looped/self/free_cam.cpp
+++ b/src/backend/looped/self/free_cam.cpp
@@ -20,6 +20,11 @@ namespace big
 		Vector3 position;
 		Vector3 rotation;
 
+		inline bool can_update_location()
+		{
+			return !(g.cmd_executor.enabled || g.self.noclip);
+		}
+
 		virtual void on_enable() override
 		{
 			camera = CAM::CREATE_CAM("DEFAULT_SCRIPTED_CAMERA", 0);
@@ -44,24 +49,27 @@ namespace big
 
 			Vector3 vecChange = {0.f, 0.f, 0.f};
 
-			// Left Shift
-			if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_SPRINT))
-				vecChange.z += speed / 2;
-			// Left Control
-			if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_DUCK))
-				vecChange.z -= speed / 2;
-			// Forward
-			if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_MOVE_UP_ONLY))
-				vecChange.y += speed;
-			// Backward
-			if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_MOVE_DOWN_ONLY))
-				vecChange.y -= speed;
-			// Left
-			if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_MOVE_LEFT_ONLY))
-				vecChange.x -= speed;
-			// Right
-			if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_MOVE_RIGHT_ONLY))
-				vecChange.x += speed;
+			if (can_update_location())
+			{
+				// Left Shift
+				if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_SPRINT))
+					vecChange.z += speed / 2;
+				// Left Control
+				if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_DUCK))
+					vecChange.z -= speed / 2;
+				// Forward
+				if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_MOVE_UP_ONLY))
+					vecChange.y += speed;
+				// Backward
+				if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_MOVE_DOWN_ONLY))
+					vecChange.y -= speed;
+				// Left
+				if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_MOVE_LEFT_ONLY))
+					vecChange.x -= speed;
+				// Right
+				if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_MOVE_RIGHT_ONLY))
+					vecChange.x += speed;
+			}
 
 			if (vecChange.x == 0.f && vecChange.y == 0.f && vecChange.z == 0.f)
 				mult = 0.f;

--- a/src/backend/looped/self/noclip.cpp
+++ b/src/backend/looped/self/noclip.cpp
@@ -19,6 +19,11 @@ namespace big
 		Entity m_entity;
 		float m_speed_multiplier;
 
+		inline bool can_update_location()
+		{
+			return !(g.cmd_executor.enabled || g.self.free_cam);
+		}
+
 		virtual void on_tick() override
 		{
 			if (g_orbital_drone_service.initialized())
@@ -41,24 +46,27 @@ namespace big
 
 			Vector3 vel{};
 
-			// Left Shift
-			if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_SPRINT))
-				vel.z += speed / 2;
-			// Left Control
-			if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_DUCK))
-				vel.z -= speed / 2;
-			// Forward
-			if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_MOVE_UP_ONLY))
-				vel.y += speed;
-			// Backward
-			if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_MOVE_DOWN_ONLY))
-				vel.y -= speed;
-			// Left
-			if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_MOVE_LEFT_ONLY))
-				vel.x -= speed;
-			// Right
-			if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_MOVE_RIGHT_ONLY))
-				vel.x += speed;
+			if (can_update_location())
+			{
+				// Left Shift
+				if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_SPRINT))
+					vel.z += speed / 2;
+				// Left Control
+				if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_DUCK))
+					vel.z -= speed / 2;
+				// Forward
+				if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_MOVE_UP_ONLY))
+					vel.y += speed;
+				// Backward
+				if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_MOVE_DOWN_ONLY))
+					vel.y -= speed;
+				// Left
+				if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_MOVE_LEFT_ONLY))
+					vel.x -= speed;
+				// Right
+				if (PAD::IS_DISABLED_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_MOVE_RIGHT_ONLY))
+					vel.x += speed;
+			}
 
 			auto rot = CAM::GET_GAMEPLAY_CAM_ROT(2);
 			ENTITY::SET_ENTITY_ROTATION(ent, 0.f, rot.y, rot.z, 2, 0);

--- a/src/backend/looped/vehicle/no_collision.cpp
+++ b/src/backend/looped/vehicle/no_collision.cpp
@@ -1,21 +1,16 @@
-#include "backend/looped_command.hpp"
+#include "backend/bool_command.hpp"
 #include "pointers.hpp"
 #include "util/vehicle.hpp"
 
 namespace big
 {
-	class veh_no_collision : looped_command
+	class veh_no_collision : bool_command
 	{
-		using looped_command::looped_command;
+		using bool_command::bool_command;
 
 		virtual void on_enable() override
 		{
 			vehicle::disable_collisions::m_patch->apply();
-		}
-
-		virtual void on_tick() override
-		{
-
 		}
 
 		virtual void on_disable() override

--- a/src/backend/looped/vehicle/unlimited_weapons.cpp
+++ b/src/backend/looped/vehicle/unlimited_weapons.cpp
@@ -1,4 +1,4 @@
-#include "backend/looped_command.hpp"
+#include "backend/bool_command.hpp"
 #include "pointers.hpp"
 
 namespace big

--- a/src/backend/looped/world/nearby/combative.cpp
+++ b/src/backend/looped/world/nearby/combative.cpp
@@ -1,19 +1,15 @@
-#include "backend/looped_command.hpp"
+#include "backend/bool_command.hpp"
 #include "natives.hpp"
 
 namespace big
 {
-	class combative : looped_command
+	class combative : bool_command
 	{
-		using looped_command::looped_command;
+		using bool_command::bool_command;
 
 		virtual void on_enable() override
 		{
 			MISC::SET_RIOT_MODE_ENABLED(true);
-		}
-
-		virtual void on_tick() override
-		{
 		}
 
 		virtual void on_disable() override

--- a/src/backend/looped_command.cpp
+++ b/src/backend/looped_command.cpp
@@ -1,54 +1,10 @@
 #include "looped_command.hpp"
 
-#include "fiber_pool.hpp"
-
 namespace big
 {
 	looped_command::looped_command(const std::string& name, const std::string& label, const std::string& description, bool& toggle) :
 	    bool_command(name, label, description, toggle)
 	{
 		g_looped_commands.push_back(this);
-	}
-
-	void looped_command::enable()
-	{
-		if (!m_toggle)
-		{
-			m_toggle       = true;
-			m_last_enabled = true;
-			g_fiber_pool->queue_job([this] {
-				on_enable();
-			});
-		}
-	}
-
-	void looped_command::disable()
-	{
-		if (m_toggle)
-		{
-			m_toggle       = false;
-			m_last_enabled = false;
-			g_fiber_pool->queue_job([this] {
-				disable();
-			});
-		}
-	}
-
-	void looped_command::refresh()
-	{
-		if (m_toggle && !m_last_enabled)
-		{
-			m_last_enabled = true;
-			g_fiber_pool->queue_job([this] {
-				on_enable();
-			});
-		}
-		else if (!m_toggle && m_last_enabled)
-		{
-			m_last_enabled = false;
-			g_fiber_pool->queue_job([this] {
-				on_disable();
-			});
-		}
 	}
 }

--- a/src/backend/looped_command.hpp
+++ b/src/backend/looped_command.hpp
@@ -5,18 +5,10 @@ namespace big
 {
 	class looped_command : public bool_command
 	{
-		bool m_last_enabled = false;
-
 	public:
 		looped_command(const std::string& name, const std::string& label, const std::string& description, bool& toggle);
 
-		virtual void on_enable(){};
-		virtual void on_disable(){};
 		virtual void on_tick() = 0;
-
-		virtual void refresh() override;
-		virtual void enable() override;
-		virtual void disable() override;
 	};
 
 	inline std::vector<looped_command*> g_looped_commands;

--- a/src/backend/player_command.hpp
+++ b/src/backend/player_command.hpp
@@ -11,8 +11,8 @@ namespace big
 		player_command* m_parent;
 
 	protected:
-		virtual void execute(const std::vector<uint64_t>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>()) override;
-		virtual std::optional<std::vector<uint64_t>> parse_args(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>()) override;
+		virtual void execute(const command_arguments& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>()) override;
+		virtual std::optional<command_arguments> parse_args(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>()) override;
 
 	public:
 		player_all_component(player_command* parent, const std::string& name, const std::string& label, const std::string& description, std::optional<uint8_t> num_args);
@@ -24,16 +24,16 @@ namespace big
 		std::unique_ptr<player_all_component> m_all_component;
 
 	protected:
-		virtual void execute(const std::vector<uint64_t>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>()) override;
-		virtual void execute(player_ptr player, const std::vector<uint64_t>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>()) = 0;
-		virtual std::optional<std::vector<uint64_t>> parse_args(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>()) override;
-		virtual std::optional<std::vector<uint64_t>> parse_args_p(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>())
+		virtual void execute(const command_arguments& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>()) override;
+		virtual void execute(player_ptr player, const command_arguments& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>()) = 0;
+		virtual std::optional<command_arguments> parse_args(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>()) override;
+		virtual std::optional<command_arguments> parse_args_p(const std::vector<std::string>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>())
 		{
-			return std::vector<uint64_t>();
+			return {0};
 		};
 
 	public:
-		void call(player_ptr player, const std::vector<uint64_t>& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>());
+		void call(player_ptr player, const command_arguments& args, const std::shared_ptr<command_context> ctx = std::make_shared<default_command_context>());
 		player_command(const std::string& name, const std::string& label, const std::string& description, std::optional<uint8_t> num_args, bool make_all_version = true);
 	};
 }

--- a/src/gui/components/components.hpp
+++ b/src/gui/components/components.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "backend/command.hpp"
+#include "backend/float_command.hpp"
 #include "backend/int_command.hpp"
 #include "backend/looped_command.hpp"
 #include "backend/player_command.hpp"
@@ -89,6 +90,22 @@ namespace big
 				return ImGui::Text("INVALID COMMAND");
 
 			ImGui::SliderInt(label_override.value_or(command->get_label()).data(),
+			    &command->get_value(),
+			    command->get_lower_bound(),
+			    command->get_upper_bound());
+
+			if (ImGui::IsItemHovered())
+				ImGui::SetTooltip(command->get_description().c_str());
+		}
+
+		template<template_str cmd_str>
+		static void command_float_slider(std::optional<const std::string_view> label_override = std::nullopt)
+		{
+			static float_command* command = (float_command*)command::get(rage::consteval_joaat(cmd_str.value));
+			if (command == nullptr)
+				return ImGui::Text("INVALID COMMAND");
+
+			ImGui::SliderFloat(label_override.value_or(command->get_label()).data(),
 			    &command->get_value(),
 			    command->get_lower_bound(),
 			    command->get_upper_bound());

--- a/src/gui/components/components.hpp
+++ b/src/gui/components/components.hpp
@@ -45,7 +45,10 @@ namespace big
 				return ImGui::Text("INVALID COMMAND");
 
 			if (ImGui::Button(label_override.value_or(command->get_label()).data()))
-				command->call(args);
+			{
+				command_arguments _args(args);
+				command->call(_args);
+			}
 			if (ImGui::IsItemHovered())
 				ImGui::SetTooltip(command->get_description().c_str());
 		}

--- a/src/gui/components/components.hpp
+++ b/src/gui/components/components.hpp
@@ -23,8 +23,8 @@ namespace big
 		static void title(const std::string_view);
 		static void nav_item(std::pair<tabs, navigation_struct>&, int);
 
-		static void input_text_with_hint(const std::string_view label, const std::string_view hint, char* buf, size_t buf_size, ImGuiInputTextFlags_ flag = ImGuiInputTextFlags_None, std::function<void()> cb = nullptr);
-		static void input_text_with_hint(const std::string_view label, const std::string_view hint, std::string* buf, ImGuiInputTextFlags_ flag = ImGuiInputTextFlags_None, std::function<void()> cb = nullptr);
+		static bool input_text_with_hint(const std::string_view label, const std::string_view hint, char* buf, size_t buf_size, ImGuiInputTextFlags_ flag = ImGuiInputTextFlags_None, std::function<void()> cb = nullptr);
+		static bool input_text_with_hint(const std::string_view label, const std::string_view hint, std::string& buf, ImGuiInputTextFlags_ flag = ImGuiInputTextFlags_None, std::function<void()> cb = nullptr);
 
 		static void input_text(const std::string_view label, char* buf, size_t buf_size, ImGuiInputTextFlags_ flag = ImGuiInputTextFlags_None, std::function<void()> cb = nullptr);
 

--- a/src/gui/components/input_text_with_hint.cpp
+++ b/src/gui/components/input_text_with_hint.cpp
@@ -5,27 +5,33 @@
 
 namespace big
 {
-	void components::input_text_with_hint(const std::string_view label, const std::string_view hint, char* buf, size_t buf_size, ImGuiInputTextFlags_ flag, std::function<void()> cb)
+	bool components::input_text_with_hint(const std::string_view label, const std::string_view hint, char* buf, size_t buf_size, ImGuiInputTextFlags_ flag, std::function<void()> cb)
 	{
-		if (ImGui::InputTextWithHint(label.data(), hint.data(), buf, buf_size, flag))
-			if (cb)
-				g_fiber_pool->queue_job(std::move(cb));
+		bool returned = false;
+		if (returned = ImGui::InputTextWithHint(label.data(), hint.data(), buf, buf_size, flag); returned && cb)
+			g_fiber_pool->queue_job(std::move(cb));
 
 		if (ImGui::IsItemActive())
+		{
 			g_fiber_pool->queue_job([] {
 				PAD::DISABLE_ALL_CONTROL_ACTIONS(0);
 			});
+		}
+		return returned;
 	}
 
-	void components::input_text_with_hint(const std::string_view label, const std::string_view hint, std::string* buf, ImGuiInputTextFlags_ flag, std::function<void()> cb)
+	bool components::input_text_with_hint(const std::string_view label, const std::string_view hint, std::string& buf, ImGuiInputTextFlags_ flag, std::function<void()> cb)
 	{
-		if (ImGui::InputTextWithHint(label.data(), hint.data(), buf, flag))
-			if (cb)
-				g_fiber_pool->queue_job(std::move(cb));
+		bool returned = false;
+		if (returned = ImGui::InputTextWithHint(label.data(), hint.data(), &buf, flag); returned && cb)
+			g_fiber_pool->queue_job(std::move(cb));
 
 		if (ImGui::IsItemActive())
+		{
 			g_fiber_pool->queue_job([] {
 				PAD::DISABLE_ALL_CONTROL_ACTIONS(0);
 			});
+		}
+		return returned;
 	}
 }

--- a/src/lua/bindings/command.cpp
+++ b/src/lua/bindings/command.cpp
@@ -18,7 +18,7 @@ namespace lua::command
 	// Call a menu command.
 	static void call(const std::string& command_name, std::optional<sol::table> _args)
 	{
-		const auto args = convert_sequence<uint64_t>(_args.value_or(sol::table()));
+		big::command_arguments args = convert_sequence<uint64_t>(_args.value_or(sol::table()));
 
 		const auto command = big::command::get(rage::joaat(command_name));
 

--- a/src/services/context_menu/context_menu_service.cpp
+++ b/src/services/context_menu/context_menu_service.cpp
@@ -250,7 +250,7 @@ namespace big
 		while (g_running)
 		{
 			if (g_gui->is_open() || HUD::IS_PAUSE_MENU_ACTIVE()
-			    || (*g_pointers->m_gta.m_chat_data && (*g_pointers->m_gta.m_chat_data)->m_chat_open))
+			    || (*g_pointers->m_gta.m_chat_data && (*g_pointers->m_gta.m_chat_data)->m_chat_open) || g.cmd_executor.enabled)
 			{
 				script::get_current()->yield();
 				continue;

--- a/src/services/hotkey/hotkey.cpp
+++ b/src/services/hotkey/hotkey.cpp
@@ -21,7 +21,7 @@ namespace big
 		if (m_cooldown.has_value())
 			m_wakeup = std::chrono::high_resolution_clock::now() + m_cooldown.value();
 
-		command::get(m_command_hash)->call(std::vector<uint64_t>());
+		command::get(m_command_hash)->call({});
 	}
 
 	rage::joaat_t hotkey::name_hash() const

--- a/src/views/core/view_cmd_executor.cpp
+++ b/src/views/core/view_cmd_executor.cpp
@@ -20,7 +20,7 @@ namespace big
 
 		if (ImGui::Begin("cmd_executor", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoMouseInputs))
 		{
-			static char command_buffer[255];
+			static std::string command_buffer;
 			ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, {10.f, 15.f});
 			components::sub_title("CMD_EXECUTOR_TITLE"_T);
 
@@ -28,13 +28,14 @@ namespace big
 			ImGui::SetKeyboardFocusHere(0);
 
 			ImGui::SetNextItemWidth((screen_x * 0.5f) - 30.f);
-			components::input_text_with_hint("", "CMD_EXECUTOR_TYPE_CMD"_T, command_buffer, sizeof(command_buffer), ImGuiInputTextFlags_EnterReturnsTrue, [] {
+			if (components::input_text_with_hint("", "CMD_EXECUTOR_TYPE_CMD"_T, command_buffer, ImGuiInputTextFlags_EnterReturnsTrue))
+			{
 				if (command::process(command_buffer, std::make_shared<default_command_context>(), true))
 				{
 					g.cmd_executor.enabled = false;
-					command_buffer[0]      = 0;
+					command_buffer     = {};
 				}
-			});
+			}
 
 			components::small_text("CMD_EXECUTOR_MULTIPLE_CMDS"_T);
 			ImGui::Spacing();

--- a/src/views/debug/view_debug_animations.cpp
+++ b/src/views/debug/view_debug_animations.cpp
@@ -28,7 +28,7 @@ namespace big
 			});
 
 			ImGui::SetNextItemWidth(400);
-			components::input_text_with_hint("##dictionaryfilter", "Dictionary", &current_dict);
+			components::input_text_with_hint("##dictionaryfilter", "Dictionary", current_dict);
 
 			if (animations::has_anim_list_been_populated() && ImGui::BeginListBox("##dictionaries", ImVec2(400, 200)))
 			{

--- a/src/views/self/view_custom_teleport.cpp
+++ b/src/views/self/view_custom_teleport.cpp
@@ -70,8 +70,8 @@ namespace big
 		}
 
 		ImGui::PushItemWidth(300);
-		components::input_text_with_hint("Category", "Category", &category);
-		components::input_text_with_hint("Location name", "New location", &new_location_name);
+		components::input_text_with_hint("Category", "Category", category);
+		components::input_text_with_hint("Location name", "New location", new_location_name);
 		ImGui::PopItemWidth();
 
 		components::button("Save current location", [] {
@@ -140,7 +140,7 @@ namespace big
 		components::small_text("Double click to teleport\nShift click to delete");
 
 		ImGui::Spacing();
-		components::input_text_with_hint("##filter", "Search", &filter);
+		components::input_text_with_hint("##filter", "Search", filter);
 
 		ImGui::BeginGroup();
 		components::small_text("Categories");

--- a/src/views/self/view_weapons.cpp
+++ b/src/views/self/view_weapons.cpp
@@ -296,7 +296,7 @@ namespace big
 			ImGui::SameLine();
 			ImGui::BeginGroup();
 			static std::string input_file_name;
-			components::input_text_with_hint("Weapon Loadout Filename", "Loadout Name", &input_file_name);
+			components::input_text_with_hint("Weapon Loadout Filename", "Loadout Name", input_file_name);
 			components::button("Save Loadout", [] {
 				persist_weapons::save_weapons(input_file_name);
 				input_file_name.clear();

--- a/src/views/view_vehicle_control.cpp
+++ b/src/views/view_vehicle_control.cpp
@@ -1,3 +1,5 @@
+#include "backend/bool_command.hpp"
+#include "backend/float_command.hpp"
 #include "gta_util.hpp"
 #include "gui.hpp"
 #include "pointers.hpp"
@@ -313,31 +315,18 @@ namespace big
 		}
 	}
 
+	bool_command use_animations("vehcontroluseanims", "Use animations", "Will use animations for several vehicle operations such as:\ntoggling lights, opening/closing doors and entering seats",
+	    g.window.vehicle_control.operation_animation);
+	bool_command render_veh_dist("vehcontrolrendervehdist", "Render distance on vehicle", "Will display the distance on the controlled vehicle",
+	    g.window.vehicle_control.render_distance_on_veh);
+	float_command max_summon_dist("vehcontrolmaxsummondist", "Max summon distance", "At what range the vehicle will drive towards the summoned location as oposed to being teleported",
+	    g.window.vehicle_control.max_summon_range, 10.f, 250.f);
+
 	void render_settings_tab()
 	{
-		ImGui::Checkbox("Use animations", &g.window.vehicle_control.operation_animation);
-		if (ImGui::IsItemHovered())
-		{
-			ImGui::BeginTooltip();
-			ImGui::Text("Will use animations for several vehicle operations such as:\ntoggling lights, opening/closing doors and entering seats");
-			ImGui::EndTooltip();
-		}
-
-		ImGui::Checkbox("Render distance on vehicle", &g.window.vehicle_control.render_distance_on_veh);
-		if (ImGui::IsItemHovered())
-		{
-			ImGui::BeginTooltip();
-			ImGui::Text("Will display the distance on the controlled vehicle");
-			ImGui::EndTooltip();
-		}
-
-		ImGui::SliderFloat("Max summon distance", &g.window.vehicle_control.max_summon_range, 10.f, 250.f);
-		if (ImGui::IsItemHovered())
-		{
-			ImGui::BeginTooltip();
-			ImGui::Text("At what range the vehicle will drive towards the summoned location as oposed to being teleported");
-			ImGui::EndTooltip();
-		}
+		components::command_checkbox<"vehcontroluseanims">();
+		components::command_checkbox<"vehcontrolrendervehdist">();
+		components::command_float_slider<"vehcontrolmaxsummondist">();
 	}
 
 	void view::vehicle_control()

--- a/src/views/world/view_squad_spawner.cpp
+++ b/src/views/world/view_squad_spawner.cpp
@@ -113,8 +113,8 @@ namespace big
 
 		ImGui::PushItemWidth(250);
 
-		components::input_text_with_hint("##name", "Name", &new_template.m_name);
-		components::input_text_with_hint("##pedmodel", "Ped model", &new_template.m_ped_model);
+		components::input_text_with_hint("##name", "Name", new_template.m_name);
+		components::input_text_with_hint("##pedmodel", "Ped model", new_template.m_ped_model);
 
 		auto ped_found = std::find_if(g_gta_data_service->peds().begin(), g_gta_data_service->peds().end(), [=](const auto& pair) {
 			return pair.second.m_name == new_template.m_ped_model;
@@ -140,7 +140,7 @@ namespace big
 			}
 		}
 
-		components::input_text_with_hint("##vehmodel", "Vehicle model", &new_template.m_vehicle_model);
+		components::input_text_with_hint("##vehmodel", "Vehicle model", new_template.m_vehicle_model);
 		if (ImGui::IsItemHovered())
 			ImGui::SetTooltip("Leave empty to spawn on foot");
 
@@ -168,7 +168,7 @@ namespace big
 			}
 		}
 
-		components::input_text_with_hint("##weapmodel", "Weapon model", &new_template.m_weapon_model);
+		components::input_text_with_hint("##weapmodel", "Weapon model", new_template.m_weapon_model);
 		if (ImGui::IsItemHovered())
 			ImGui::SetTooltip("Leave empty to spawn unarmed, beware that a player can only attain 3 melee attackers at a time");
 
@@ -325,7 +325,7 @@ namespace big
 			ImGui::PopItemWidth();
 			ImGui::EndGroup();
 
-			components::input_text_with_hint("##new_template.m_description", "Description", &new_template.m_description);
+			components::input_text_with_hint("##new_template.m_description", "Description", new_template.m_description);
 
 			ImGui::TreePop();
 		}


### PR DESCRIPTION
## Changes
 - Added a `command_arguments` class to help with argument parsing
 - Moved `on_enable/on_disable` methods from `looped_command` to `bool_command`

## Fixes
 - Don't enable context menu while the cmd executor is active
 - Disable freecam and noclip movement while the other is active (as well as disable them when the cmd executor is active)

## Todo
 - [ ] ~~Re-implement arguments with `std::any`~~
 - [x] Rename pop to shift to reflect the internal functionality
 - [x] Take a large enough sample size of commands to test if they behave as expected
 - [x] Fix `bool_command::on_enable` doesn't get called on menu init