### PR TITLE
fix(lua): fix script array iterator being potentially invalidated while iterating

### DIFF
--- a/src/lua/lua_module.cpp
+++ b/src/lua/lua_module.cpp
@@ -231,8 +231,11 @@ namespace big
 	{
 		std::lock_guard guard(m_registered_scripts_mutex);
 
-		for (auto& script : m_registered_scripts)
+		const auto script_count = m_registered_scripts.size();
+		for (size_t i = 0; i < script_count; i++)
 		{
+			const auto script = m_registered_scripts[i].get();
+
 			if (script->is_enabled())
 			{
 				script->tick();


### PR DESCRIPTION
Due to new scripts that could be added and the vector getting reallocated due to it.