### PR TITLE
Fixed regression issue with rocket boosting

### DIFF
--- a/src/backend/looped/vehicle/boost_behavior.cpp
+++ b/src/backend/looped/vehicle/boost_behavior.cpp
@@ -36,22 +36,19 @@ namespace big
 			{
 				if (PAD::IS_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_VEH_ROCKET_BOOST) || PAD::IS_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_VEH_FLY_BOOST))
 				{
-					if (is_rocket)
+					if (is_rocket && vehicle->m_boost_state)
 					{
-						if (vehicle->m_boost_state)
-						{
-							vehicle->m_boost_allow_recharge = true;
-							vehicle->m_boost                = 3.f;
-						}
-						else if (vehicle->m_boost_state)
-						{
-							vehicle->m_boost_state = false;
-						}
+						vehicle->m_boost_allow_recharge = true;
+						vehicle->m_boost                = 3.f;
 					}
-					else
+					else if (is_kers)
 					{
 						vehicle->m_kers_boost = vehicle->m_kers_boost_max - 0.01f;
 					}
+				}
+				else if (is_rocket && vehicle->m_boost_state)
+				{
+					vehicle->m_boost_state = false;
 				}
 			}
 		}


### PR DESCRIPTION
Fixed a regression scenario for hold for boost when using rocket boosted cars not having the boost stop when you let go of the boost key. 