### PR TITLE
Fixed Selected Teleport not showing up in hotkeys menu.

### DIFF
--- a/src/backend/commands/spawn/spawn_vehicle.cpp
+++ b/src/backend/commands/spawn/spawn_vehicle.cpp
@@ -38,7 +38,7 @@ namespace big
 			        PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(ctx->get_sender()->id()));
 			const auto spawn_heading = ENTITY::GET_ENTITY_HEADING(PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(ctx->get_sender()->id()));
 
-			const auto veh = vehicle::spawn(hash, spawn_location, spawn_heading);
+			auto veh = vehicle::spawn(hash, spawn_location, spawn_heading);
 
 			if (veh == 0)
 			{
@@ -55,6 +55,7 @@ namespace big
 				{
 					vehicle::teleport_into_vehicle(veh);
 				}
+				ENTITY::SET_ENTITY_AS_NO_LONGER_NEEDED(&veh);
 			}
 		}
 	};

--- a/src/backend/looped/vehicle/keep_vehicle_repaired.cpp
+++ b/src/backend/looped/vehicle/keep_vehicle_repaired.cpp
@@ -17,6 +17,14 @@ namespace big
 			}
 			if (VEHICLE::GET_DOES_VEHICLE_HAVE_DAMAGE_DECALS(veh))
 			{
+				for (int i = 0; i < 6; i++)
+				{
+					if (VEHICLE::IS_VEHICLE_DOOR_DAMAGED(veh, i))
+					{
+						VEHICLE::SET_VEHICLE_FIXED(veh);
+					}
+				}
+
 				if (VEHICLE::IS_VEHICLE_BUMPER_BOUNCING(veh, TRUE) || VEHICLE::GET_VEHICLE_NUM_OF_BROKEN_OFF_PARTS(veh) > 0)
 				{
 					VEHICLE::SET_VEHICLE_FIXED(veh);

--- a/src/core/settings.hpp
+++ b/src/core/settings.hpp
@@ -457,7 +457,7 @@ namespace big
 				int clear_wanted            = 0;
 				int random_ped_components   = 0;
 
-				NLOHMANN_DEFINE_TYPE_INTRUSIVE(hotkeys, editing_menu_toggle, menu_toggle, teleport_waypoint, teleport_objective, teleport_pv, noclip, vehicle_flymode, bringvehicle, invis, heal, fill_inventory, skip_cutscene, freecam, superrun, superjump, beastjump, invisveh, localinvisveh, fill_ammo, fast_quit, cmd_excecutor, repairpv, open_vehicle_controller, clear_wanted, random_ped_components)
+				NLOHMANN_DEFINE_TYPE_INTRUSIVE(hotkeys, editing_menu_toggle, menu_toggle, teleport_waypoint, teleport_objective, teleport_selected, teleport_pv, noclip, vehicle_flymode, bringvehicle, invis, heal, fill_inventory, skip_cutscene, freecam, superrun, superjump, beastjump, invisveh, localinvisveh, fill_ammo, fast_quit, cmd_excecutor, repairpv, open_vehicle_controller, clear_wanted, random_ped_components)
 			} hotkeys{};
 
 			NLOHMANN_DEFINE_TYPE_INTRUSIVE(settings, hotkeys, dev_dlc)

--- a/src/util/entity.hpp
+++ b/src/util/entity.hpp
@@ -27,16 +27,23 @@ namespace big::entity
 		PED::RESET_PED_VISIBLE_DAMAGE(player_ped);
 	}
 
+	bool take_control_of(Entity ent, int timeout = 300);
 	inline void delete_entity(Entity ent)
 	{
 		if (!ENTITY::DOES_ENTITY_EXIST(ent))
 			return;
+		if (!take_control_of(ent))
+		{
+			LOG(VERBOSE) << "Failed to take control of entity before deleting";
+			return;
+		}
 
 		ENTITY::DETACH_ENTITY(ent, 1, 1);
-		ENTITY::SET_ENTITY_VISIBLE(ent, false, false);
-		NETWORK::NETWORK_SET_ENTITY_ONLY_EXISTS_FOR_PARTICIPANTS(ent, true);
-		ENTITY::SET_ENTITY_COORDS_NO_OFFSET(ent, 0, 0, 0, 0, 0, 0);
-		ENTITY::SET_ENTITY_AS_MISSION_ENTITY(ent, 1, 1);
+		ENTITY::SET_ENTITY_COORDS_NO_OFFSET(ent, 7000.f, 7000.f, 15.f, 0, 0, 0);
+		if (!ENTITY::IS_ENTITY_A_MISSION_ENTITY(ent))
+		{
+			ENTITY::SET_ENTITY_AS_MISSION_ENTITY(ent, true, true);
+		}
 		ENTITY::DELETE_ENTITY(&ent);
 	}
 
@@ -102,7 +109,7 @@ namespace big::entity
 		return !net_object || !net_object->m_next_owner_id && (net_object->m_control_id == -1);
 	}
 
-	inline bool take_control_of(Entity ent, int timeout = 300)
+	inline bool take_control_of(Entity ent, int timeout)
 	{
 		if (!*g_pointers->m_gta.m_is_session_started)
 			return true;

--- a/src/util/vehicle.hpp
+++ b/src/util/vehicle.hpp
@@ -168,7 +168,7 @@ namespace big::vehicle
 
 	inline Vehicle spawn(Hash hash, Vector3 location, float heading, bool is_networked = true, bool script_veh = false)
 	{
-		for (uint8_t i = 0; !STREAMING::HAS_MODEL_LOADED(hash) && i < 100; i++)
+		for (int i = 0; !STREAMING::HAS_MODEL_LOADED(hash) && i < 100; i++)
 		{
 			STREAMING::REQUEST_MODEL(hash);
 			script::get_current()->yield();

--- a/src/views/settings/view_hotkey_settings.cpp
+++ b/src/views/settings/view_hotkey_settings.cpp
@@ -11,10 +11,12 @@ namespace big
 		if (ImGui::Hotkey("Menu Toggle", &g.settings.hotkeys.menu_toggle))
 			g.settings.hotkeys.editing_menu_toggle = true; // make our menu reappear
 
-		if (ImGui::Hotkey("Teleport to waypoint", &g.settings.hotkeys.teleport_waypoint))
+		if (ImGui::Hotkey("Teleport to Waypoint", &g.settings.hotkeys.teleport_waypoint))
 			g_hotkey_service->update_hotkey("waypoint", g.settings.hotkeys.teleport_waypoint);
-		if (ImGui::Hotkey("Teleport to objective", &g.settings.hotkeys.teleport_objective))
+		if (ImGui::Hotkey("Teleport to Objective", &g.settings.hotkeys.teleport_objective))
 			g_hotkey_service->update_hotkey("objective", g.settings.hotkeys.teleport_objective);
+		if (ImGui::Hotkey("Teleport to Selected", &g.settings.hotkeys.teleport_selected))
+			g_hotkey_service->update_hotkey("highlighttp", g.settings.hotkeys.teleport_selected);
 		if (ImGui::Hotkey("Teleport into PV", &g.settings.hotkeys.teleport_pv))
 			g_hotkey_service->update_hotkey("pvtp", g.settings.hotkeys.teleport_pv);
 

--- a/src/views/vehicle/spawn/view_pv.cpp
+++ b/src/views/vehicle/spawn/view_pv.cpp
@@ -149,6 +149,8 @@ namespace big
 										vehicle::teleport_into_vehicle(veh);
 									}
 								}
+								// cleanup clones
+								ENTITY::SET_ENTITY_AS_NO_LONGER_NEEDED(&veh);
 							}
 							else
 							{

--- a/src/views/vehicle/view_spawn_vehicle.cpp
+++ b/src/views/vehicle/view_spawn_vehicle.cpp
@@ -151,7 +151,7 @@ namespace big
 							    vehicle::get_spawn_location(g.spawn_vehicle.spawn_inside, vehicle.m_hash);
 							const auto spawn_heading = ENTITY::GET_ENTITY_HEADING(self::ped);
 
-							const auto veh = vehicle::spawn(vehicle.m_hash, spawn_location, spawn_heading);
+							auto veh = vehicle::spawn(vehicle.m_hash, spawn_location, spawn_heading);
 
 							if (veh == 0)
 							{
@@ -173,6 +173,7 @@ namespace big
 							}
 
 							g_model_preview_service->stop_preview();
+							ENTITY::SET_ENTITY_AS_NO_LONGER_NEEDED(&veh);
 						});
 						ImGui::PopID();
 


### PR DESCRIPTION
Added check for IS_VEHICLE_DOOR_DAMAGED in keep_vehicle_repaired.
Fixed Selected Teleport not showing up in hotkeys menu.
Added Yim's Vehicle cleanup code from the halted PR.