### PR TITLE
(fix) max_vehicle/spawn_maxed still apply HSW mods

### DIFF
--- a/src/util/vehicle.hpp
+++ b/src/util/vehicle.hpp
@@ -594,7 +594,7 @@ namespace big::vehicle
 
 				for (int mod = count - 1; mod >= -1; mod--)
 				{
-					if (VEHICLE::IS_VEHICLE_MOD_GEN9_EXCLUSIVE(veh, slot, mod))
+					if (!VEHICLE::IS_VEHICLE_MOD_GEN9_EXCLUSIVE(veh, slot, mod))
 					{
 						continue;
 					}


### PR DESCRIPTION
lmk if it was left on purpose