### PR TITLE
Various fixes for Vehicle Extras.

### DIFF
--- a/src/services/vehicle/persist_car_service.cpp
+++ b/src/services/vehicle/persist_car_service.cpp
@@ -219,10 +219,9 @@ namespace big
 		VEHICLE::SET_VEHICLE_EXTRA_COLOURS(vehicle, vehicle_json[pearlescent_color_key], vehicle_json[wheel_color_key]);
 
 		std::map<int, bool> vehicle_extras = vehicle_json[vehicle_extras_key];
-		for (int i = 0; i <= 20; i++)
+		for (const auto& [extra, extra_enabled] : vehicle_extras)
 		{
-			if (VEHICLE::DOES_EXTRA_EXIST(vehicle, i))
-				VEHICLE::SET_VEHICLE_EXTRA(vehicle, i, vehicle_extras[i]);
+			VEHICLE::SET_VEHICLE_EXTRA(vehicle, extra, !extra_enabled);
 		}
 
 		if (!vehicle_json[vehicle_livery_key].is_null())
@@ -446,10 +445,12 @@ namespace big
 		vehicle_json[wheel_color_key]       = wheel_color;
 
 		std::map<int, bool> vehicle_extras;
-		for (int i = 0; i <= 20; i++)
+		for (int extra_iterator = 0; extra_iterator <= 14; extra_iterator++)
 		{
-			if (VEHICLE::DOES_EXTRA_EXIST(vehicle, i))
-				vehicle_extras[i] = !VEHICLE::IS_VEHICLE_EXTRA_TURNED_ON(vehicle, i);
+			if (VEHICLE::DOES_EXTRA_EXIST(vehicle, extra_iterator))
+			{
+				vehicle_extras[extra_iterator] = VEHICLE::IS_VEHICLE_EXTRA_TURNED_ON(vehicle, extra_iterator);
+			}
 		}
 
 		vehicle_json[vehicle_extras_key] = vehicle_extras;

--- a/src/services/vehicle/persist_car_service.cpp
+++ b/src/services/vehicle/persist_car_service.cpp
@@ -221,7 +221,7 @@ namespace big
 		std::map<int, bool> vehicle_extras = vehicle_json[vehicle_extras_key];
 		for (const auto& [extra, extra_enabled] : vehicle_extras)
 		{
-			VEHICLE::SET_VEHICLE_EXTRA(vehicle, extra, !extra_enabled);
+			VEHICLE::SET_VEHICLE_EXTRA(vehicle, extra, extra_enabled);
 		}
 
 		if (!vehicle_json[vehicle_livery_key].is_null())
@@ -449,7 +449,7 @@ namespace big
 		{
 			if (VEHICLE::DOES_EXTRA_EXIST(vehicle, extra_iterator))
 			{
-				vehicle_extras[extra_iterator] = VEHICLE::IS_VEHICLE_EXTRA_TURNED_ON(vehicle, extra_iterator);
+				vehicle_extras[extra_iterator] = !VEHICLE::IS_VEHICLE_EXTRA_TURNED_ON(vehicle, extra_iterator);
 			}
 		}
 

--- a/src/util/vehicle.hpp
+++ b/src/util/vehicle.hpp
@@ -563,21 +563,6 @@ namespace big::vehicle
 		return owned_mods;
 	}
 
-	inline std::map<int, bool> get_vehicle_extras(Vehicle vehicle)
-	{
-		std::map<int, bool> extras;
-
-		for (int i = 0; i <= 20; i++)
-		{
-			if (VEHICLE::DOES_EXTRA_EXIST(vehicle, i))
-			{
-				extras[i] = VEHICLE::IS_VEHICLE_EXTRA_TURNED_ON(vehicle, i);
-			}
-		}
-
-		return extras;
-	}
-
 	inline void teleport_into_vehicle(Vehicle veh)
 	{
 		PED::SET_PED_INTO_VEHICLE(self::ped, veh, -1);

--- a/src/views/vehicle/view_lsc.cpp
+++ b/src/views/vehicle/view_lsc.cpp
@@ -62,7 +62,6 @@ namespace big
 				Hash model = ENTITY::GET_ENTITY_MODEL(player_vehicle);
 
 				owned_mods = vehicle::get_owned_mods_from_vehicle(player_vehicle);
-				vehicle_extras = vehicle::get_vehicle_extras(player_vehicle);
 				VEHICLE::SET_VEHICLE_MOD_KIT(player_vehicle, 0);
 
 				std::map<int, std::string> tmp_slot_display_names;
@@ -282,22 +281,30 @@ namespace big
 			}
 			ImGui::EndListBox();
 		}
+		ImGui::EndGroup();
 
+		ImGui::SeparatorText("Vehicle Extras");
+		ImGui::BeginGroup();
 		int item_counter = 0;
-		for (auto& [extra, extra_enabled] : vehicle_extras)
+		for (int extra = MOD_EXTRA_1; extra >= MOD_EXTRA_14; extra--)
 		{
-			if (item_counter % 5 == 0)
-				ImGui::SameLine();
-			auto name = std::format("Extra #{}", extra);
-			if (ImGui::Checkbox(name.c_str(), &extra_enabled))
+			if (owned_mods.find(extra) != owned_mods.end()) //
 			{
-				g_fiber_pool->queue_job([extra, extra_enabled] {
-					VEHICLE::SET_VEHICLE_EXTRA(player_vehicle, extra, !extra_enabled);
-				});
+				if ((item_counter % 5) != 0)
+					ImGui::SameLine();
+				int gta_extra_id = (extra - MOD_EXTRA_0) * -1;
+				auto name        = std::format("Extra #{}", gta_extra_id);
+				bool is_extra_enabled = owned_mods[extra] == 1;
+				if (ImGui::Checkbox(name.c_str(), &is_extra_enabled))
+				{
+					owned_mods[extra] = is_extra_enabled;
+					g_fiber_pool->queue_job([gta_extra_id, is_extra_enabled] {
+						VEHICLE::SET_VEHICLE_EXTRA(player_vehicle, gta_extra_id, !is_extra_enabled);
+					});
+				}
+				item_counter++;
 			}
-			item_counter++;
 		}
-
 		ImGui::EndGroup();
 
 		if (selected_slot != -1)

--- a/src/views/vehicle/view_lsc.cpp
+++ b/src/views/vehicle/view_lsc.cpp
@@ -18,7 +18,6 @@ namespace big
 		static std::map<int, int32_t> owned_mods;
 		static std::map<int, std::string> slot_display_names;
 		static std::map<int, std::map<int, std::string>> mod_display_names;
-		static std::map<int, bool> vehicle_extras;
 		static std::map<std::string, std::vector<int>> front_wheel_map;
 		static std::map<std::string, std::vector<int>> rear_wheel_map;
 
@@ -286,9 +285,9 @@ namespace big
 		ImGui::SeparatorText("Vehicle Extras");
 		ImGui::BeginGroup();
 		int item_counter = 0;
-		for (int extra = MOD_EXTRA_1; extra >= MOD_EXTRA_14; extra--)
+		for (int extra = MOD_EXTRA_0; extra >= MOD_EXTRA_14; extra--)
 		{
-			if (owned_mods.find(extra) != owned_mods.end()) //
+			if (owned_mods.find(extra) != owned_mods.end())
 			{
 				if ((item_counter % 5) != 0)
 					ImGui::SameLine();

--- a/src/views/vehicle/view_lsc.cpp
+++ b/src/views/vehicle/view_lsc.cpp
@@ -282,30 +282,6 @@ namespace big
 		}
 		ImGui::EndGroup();
 
-		ImGui::SeparatorText("Vehicle Extras");
-		ImGui::BeginGroup();
-		int item_counter = 0;
-		for (int extra = MOD_EXTRA_0; extra >= MOD_EXTRA_14; extra--)
-		{
-			if (owned_mods.find(extra) != owned_mods.end())
-			{
-				if ((item_counter % 5) != 0)
-					ImGui::SameLine();
-				int gta_extra_id = (extra - MOD_EXTRA_0) * -1;
-				auto name        = std::format("Extra #{}", gta_extra_id);
-				bool is_extra_enabled = owned_mods[extra] == 1;
-				if (ImGui::Checkbox(name.c_str(), &is_extra_enabled))
-				{
-					owned_mods[extra] = is_extra_enabled;
-					g_fiber_pool->queue_job([gta_extra_id, is_extra_enabled] {
-						VEHICLE::SET_VEHICLE_EXTRA(player_vehicle, gta_extra_id, !is_extra_enabled);
-					});
-				}
-				item_counter++;
-			}
-		}
-		ImGui::EndGroup();
-
 		if (selected_slot != -1)
 		{
 			auto wheel_stock_mod = &front_wheel_stock_mod;
@@ -448,6 +424,36 @@ namespace big
 
 				ImGui::EndGroup();
 			}
+		}
+
+		int item_counter = 0;
+		for (int extra = MOD_EXTRA_0; extra >= MOD_EXTRA_14; extra--)
+		{
+			if (owned_mods.find(extra) != owned_mods.end())
+			{
+				if (item_counter == 0)
+				{
+					ImGui::SeparatorText("Vehicle Extras");
+					ImGui::BeginGroup();
+				}
+				if ((item_counter % 5) != 0)
+					ImGui::SameLine();
+				int gta_extra_id      = (extra - MOD_EXTRA_0) * -1;
+				auto name             = std::format("Extra #{}", gta_extra_id);
+				bool is_extra_enabled = owned_mods[extra] == 1;
+				if (ImGui::Checkbox(name.c_str(), &is_extra_enabled))
+				{
+					owned_mods[extra] = is_extra_enabled;
+					g_fiber_pool->queue_job([gta_extra_id, is_extra_enabled] {
+						VEHICLE::SET_VEHICLE_EXTRA(player_vehicle, gta_extra_id, !is_extra_enabled);
+					});
+				}
+				item_counter++;
+			}
+		}
+		if (item_counter != 0)
+		{
+			ImGui::EndGroup();
 		}
 
 		ImGui::SeparatorText("NEON_LIGHT_OPTIONS"_T.data());


### PR DESCRIPTION
Fixed vehicle extras missing the first extra, added it to its own group and used the existing owned_mods map.
Fixed persist_car_service iterating until 20 mods instead of the maximum 14, refactored SET_VEHICLE_EXTRA to use the map as an indicator if the extra exists.