### PR TITLE
Rework Keep Vehicle Repaired to remove damage decals properly.

### DIFF
--- a/src/backend/looped/vehicle/keep_vehicle_repaired.cpp
+++ b/src/backend/looped/vehicle/keep_vehicle_repaired.cpp
@@ -25,7 +25,15 @@ namespace big
 					}
 				}
 
-				if (VEHICLE::IS_VEHICLE_BUMPER_BOUNCING(veh, TRUE) || VEHICLE::GET_VEHICLE_NUM_OF_BROKEN_OFF_PARTS(veh) > 0)
+				for (int i = 0; i <= 14; i++)
+				{
+					if (VEHICLE::DOES_EXTRA_EXIST(veh, i) && VEHICLE::IS_VEHICLE_EXTRA_TURNED_ON(veh, i) && VEHICLE::IS_EXTRA_BROKEN_OFF(veh, i))
+					{
+						VEHICLE::SET_VEHICLE_FIXED(veh);
+					}
+				}
+
+				if (VEHICLE::IS_VEHICLE_BUMPER_BOUNCING(veh, TRUE) || VEHICLE::IS_VEHICLE_BUMPER_BOUNCING(veh, FALSE) || VEHICLE::GET_VEHICLE_NUM_OF_BROKEN_LOOSEN_PARTS(veh) > 0)
 				{
 					VEHICLE::SET_VEHICLE_FIXED(veh);
 				}

--- a/src/backend/looped/vehicle/keep_vehicle_repaired.cpp
+++ b/src/backend/looped/vehicle/keep_vehicle_repaired.cpp
@@ -43,8 +43,15 @@ namespace big
 
 				g_pointers->m_gta.m_decal_manager_remove(g_pointers->m_gta.m_decal_manager, g_pointers->m_gta.m_handle_to_ptr(veh), -1, 0, 0x0001E000);
 
-				VEHICLE::SET_VEHICLE_DEFORMATION_FIXED(veh);
-				VEHICLE::SET_VEHICLE_DIRT_LEVEL(veh, 0.f);
+				if (!g.vehicle.god_mode)
+				{
+					VEHICLE::SET_VEHICLE_DEFORMATION_FIXED(veh);
+				}
+
+				if (!g.vehicle.keep_vehicle_clean)
+				{
+					VEHICLE::SET_VEHICLE_DIRT_LEVEL(veh, 0.f);
+				}
 			}
 		}
 	};

--- a/src/backend/looped/vehicle/keep_vehicle_repaired.cpp
+++ b/src/backend/looped/vehicle/keep_vehicle_repaired.cpp
@@ -33,13 +33,7 @@ namespace big
 				if (!VEHICLE::IS_VEHICLE_WINDOW_INTACT(veh, 7)) //Rear window
 					VEHICLE::FIX_VEHICLE_WINDOW(veh, 7);
 
-				int clan_logo_counter = GRAPHICS::DOES_VEHICLE_HAVE_CREW_EMBLEM(veh, 0) * 10;
-				GRAPHICS::REMOVE_DECALS_FROM_VEHICLE(veh);
-				while (clan_logo_counter-- > 0 && !GRAPHICS::DOES_VEHICLE_HAVE_CREW_EMBLEM(veh, 0))
-				{
-					vehicle_helper::add_clan_logo_to_vehicle(veh, self::ped);
-					script::get_current()->yield(10ms);
-				}
+				g_pointers->m_gta.m_decal_manager_remove(g_pointers->m_gta.m_decal_manager, g_pointers->m_gta.m_handle_to_ptr(veh), -1, 0, 0x0001E000);
 
 				VEHICLE::SET_VEHICLE_DEFORMATION_FIXED(veh);
 				VEHICLE::SET_VEHICLE_DIRT_LEVEL(veh, 0.f);

--- a/src/backend/looped/vehicle/seatbelt.cpp
+++ b/src/backend/looped/vehicle/seatbelt.cpp
@@ -9,14 +9,14 @@ namespace big
 
 		virtual void on_tick() override
 		{
-			PED::SET_PED_CONFIG_FLAG(self::ped, 32, true);
-			PED::SET_PED_CAN_BE_KNOCKED_OFF_VEHICLE(self::ped, true);
+			PED::SET_PED_CONFIG_FLAG(self::ped, 32, false);
+			PED::SET_PED_CAN_BE_KNOCKED_OFF_VEHICLE(self::ped, false);
 		}
 
 		virtual void on_disable() override
 		{
-			PED::SET_PED_CONFIG_FLAG(self::ped, 32, false);
-			PED::SET_PED_CAN_BE_KNOCKED_OFF_VEHICLE(self::ped, false);
+			PED::SET_PED_CONFIG_FLAG(self::ped, 32, true);
+			PED::SET_PED_CAN_BE_KNOCKED_OFF_VEHICLE(self::ped, true);
 		}
 	};
 

--- a/src/function_types.hpp
+++ b/src/function_types.hpp
@@ -31,6 +31,7 @@ namespace rage
 	enum class eThreadState : uint32_t;
 	class netArrayHandlerBase;
 	class fwRefAwareBase;
+	class fwEntity;
 	class netGameEvent;
 	class netEventMgr;
 }
@@ -179,4 +180,6 @@ namespace big::functions
 	using delete_ped     = bool (*)(CPed* ped);
 	using delete_vehicle = bool (*)(CVehicle* veh);
 	using delete_object  = bool (*)(CObject* object, bool unk);
+
+	using decal_manager_remove = void(*)(PVOID manager, rage::fwEntity*, DWORD a3, DWORD64 a4, DWORD ignore_bitset);
 }

--- a/src/gta_pointers.hpp
+++ b/src/gta_pointers.hpp
@@ -332,6 +332,9 @@ namespace big
 		functions::delete_ped m_delete_ped;
 		functions::delete_vehicle m_delete_vehicle;
 		functions::delete_object m_delete_object;
+
+		functions::decal_manager_remove m_decal_manager_remove;
+		PVOID m_decal_manager;
 	};
 #pragma pack(pop)
 	static_assert(sizeof(gta_pointers) % 8 == 0, "Pointers are not properly aligned");

--- a/src/pointers.cpp
+++ b/src/pointers.cpp
@@ -1631,22 +1631,14 @@ namespace big
                 g_pointers->m_gta.m_activate_special_ability_patch = ptr.as<PVOID>();
             }
         },
-        // CDecalManager static instance
+        // ClearDecals
         {
             "DCLMGR",
-            "48 83 CB FF 48 8D 0D",
+            "48 8D 0D ? ? ? ? 41 83 C8 FF E8 ? ? ? ? 4C",
             [](memory::handle ptr)
             {
-                g_pointers->m_gta.m_decal_manager = ptr.add(7).rip().as<PVOID>();
-            }
-        },
-        // CDecalManager::Remove
-        {
-            "DCLMGRRM",
-            "E8 ? ? ? ? 4C 8B 76 10 ",
-            [](memory::handle ptr)
-            {
-                g_pointers->m_gta.m_decal_manager_remove = ptr.add(1).rip().as<functions::decal_manager_remove>();
+                g_pointers->m_gta.m_decal_manager = ptr.add(3).rip().as<PVOID>();
+                g_pointers->m_gta.m_decal_manager_remove = ptr.add(0xC).rip().as<functions::decal_manager_remove>();
             }
         }
         >(); // don't leave a trailing comma at the end

--- a/src/pointers.cpp
+++ b/src/pointers.cpp
@@ -1630,6 +1630,24 @@ namespace big
             {
                 g_pointers->m_gta.m_activate_special_ability_patch = ptr.as<PVOID>();
             }
+        },
+        // CDecalManager static instance
+        {
+            "DCLMGR",
+            "48 83 CB FF 48 8D 0D",
+            [](memory::handle ptr)
+            {
+                g_pointers->m_gta.m_decal_manager = ptr.add(7).rip().as<PVOID>();
+            }
+        },
+        // CDecalManager::Remove
+        {
+            "DCLMGRRM",
+            "E8 ? ? ? ? 4C 8B 76 10 ",
+            [](memory::handle ptr)
+            {
+                g_pointers->m_gta.m_decal_manager_remove = ptr.add(1).rip().as<functions::decal_manager_remove>();
+            }
         }
         >(); // don't leave a trailing comma at the end
 

--- a/src/services/vehicle/persist_car_service.cpp
+++ b/src/services/vehicle/persist_car_service.cpp
@@ -188,6 +188,8 @@ namespace big
 
 		const auto vehicle = big::vehicle::spawn(vehicle_hash, pos, ENTITY::GET_ENTITY_HEADING(ped));
 
+		script::get_current()->yield(); //This is needed to wait for the engine to instantiate things like the radio station so it won't overwrite it on the next frame.
+
 		VEHICLE::SET_VEHICLE_DIRT_LEVEL(vehicle, 0.0f);
 		VEHICLE::SET_VEHICLE_MOD_KIT(vehicle, 0);
 		VEHICLE::SET_VEHICLE_TYRES_CAN_BURST(vehicle, false);


### PR DESCRIPTION
Keep Vehicle Repaired now uses CDecalManager to remove damage decals which allows it to ignore clan and livery decals.