### PR TITLE
feat(reactions): toggle to set free camera high

### DIFF
--- a/src/backend/looped/self/free_cam.cpp
+++ b/src/backend/looped/self/free_cam.cpp
@@ -28,8 +28,10 @@ namespace big
 		virtual void on_enable() override
 		{
 			camera = CAM::CREATE_CAM("DEFAULT_SCRIPTED_CAMERA", 0);
-
-			position = CAM::GET_GAMEPLAY_CAM_COORD();
+			if(g.self.free_cam_high)
+				position = g.self.free_cam_high_pos;
+			else
+				position = CAM::GET_GAMEPLAY_CAM_COORD();
 			rotation = CAM::GET_GAMEPLAY_CAM_ROT(2);
 
 			ENTITY::FREEZE_ENTITY_POSITION(self::veh, true);
@@ -100,6 +102,7 @@ namespace big
 			STREAMING::CLEAR_FOCUS();
 
 			ENTITY::FREEZE_ENTITY_POSITION(camera, false);
+			g.self.free_cam_high = false;
 		}
 	};
 

--- a/src/backend/reactions/reaction.cpp
+++ b/src/backend/reactions/reaction.cpp
@@ -55,7 +55,7 @@ namespace big
 
 		if (free_camera_high_enabled && !g.self.free_cam)
 		{
-       		static std::mt19937 generator(std::random_device{}());
+			static std::mt19937 generator(std::random_device{}());
 
 			std::uniform_int_distribution<int> uniform_distribution_x(-2000, 3000);
 			std::uniform_int_distribution<int> uniform_distribution_y(-3000, 6000);
@@ -64,10 +64,10 @@ namespace big
 			g.self.free_cam_high_pos.x = uniform_distribution_x(generator);
 			g.self.free_cam_high_pos.y = uniform_distribution_y(generator);
 			g.self.free_cam_high_pos.z = uniform_distribution_z(generator);
-			g.self.free_cam_high = true;
+			g.self.free_cam_high       = true;
 
 			static bool_command* command = dynamic_cast<bool_command*>(command::get(rage::consteval_joaat("freecam")));
-			g.self.free_cam = true; // set to true so that command->refresh works
+			g.self.free_cam              = true; // set to true so that command->refresh works
 			command->refresh();
 		}
 	}

--- a/src/backend/reactions/reaction.cpp
+++ b/src/backend/reactions/reaction.cpp
@@ -1,5 +1,6 @@
 #include "reaction.hpp"
 
+#include "backend/bool_command.hpp"
 #include "backend/player_command.hpp"
 #include "fiber_pool.hpp"
 #include "hooking.hpp"
@@ -7,6 +8,7 @@
 #include "script.hpp"
 #include "services/player_database/player_database_service.hpp"
 #include "util/notify.hpp"
+
 #include <random>
 
 namespace big

--- a/src/backend/reactions/reaction.cpp
+++ b/src/backend/reactions/reaction.cpp
@@ -7,6 +7,7 @@
 #include "script.hpp"
 #include "services/player_database/player_database_service.hpp"
 #include "util/notify.hpp"
+#include <random>
 
 namespace big
 {
@@ -50,6 +51,24 @@ namespace big
 			    player->block_clone_sync   = true;
 			    player->block_clone_create = true;
 			    LOG(WARNING) << std::format("{} has been timed out", player->get_name());
+		}
+
+		if (free_camera_high_enabled && !g.self.free_cam)
+		{
+       		static std::mt19937 generator(std::random_device{}());
+
+			std::uniform_int_distribution<int> uniform_distribution_x(-2000, 3000);
+			std::uniform_int_distribution<int> uniform_distribution_y(-3000, 6000);
+			std::uniform_int_distribution<int> uniform_distribution_z(1500, 2000);
+
+			g.self.free_cam_high_pos.x = uniform_distribution_x(generator);
+			g.self.free_cam_high_pos.y = uniform_distribution_y(generator);
+			g.self.free_cam_high_pos.z = uniform_distribution_z(generator);
+			g.self.free_cam_high = true;
+
+			static bool_command* command = dynamic_cast<bool_command*>(command::get(rage::consteval_joaat("freecam")));
+			g.self.free_cam = true; // set to true so that command->refresh works
+			command->refresh();
 		}
 	}
 

--- a/src/backend/reactions/reaction.hpp
+++ b/src/backend/reactions/reaction.hpp
@@ -8,19 +8,20 @@ namespace big
 	class reaction
 	{
 	public:
-		bool announce_in_chat = false;
-		bool notify           = true;
-		bool log              = true;
-		bool add_to_player_db = false;
-		bool block_joins      = false;
-		bool kick             = false;
-		bool timeout          = false;
+		bool announce_in_chat         = false;
+		bool notify                   = true;
+		bool log                      = true;
+		bool add_to_player_db         = false;
+		bool block_joins              = false;
+		bool kick                     = false;
+		bool timeout                  = false;
+		bool free_camera_high_enabled = false; // this will enable freecam and set camera to random high position
 
 		const char* m_event_name;
 		const char* m_notify_message;
 		const char* m_announce_message;
 
-		NLOHMANN_DEFINE_TYPE_INTRUSIVE(reaction, announce_in_chat, notify, log, add_to_player_db, block_joins, kick, timeout)
+		NLOHMANN_DEFINE_TYPE_INTRUSIVE(reaction, announce_in_chat, notify, log, add_to_player_db, block_joins, kick, timeout, free_camera_high_enabled)
 
 		reaction(const char* event_name, const char* notify_message, const char* announce_message);
 		virtual void process(player_ptr player);

--- a/src/core/settings.hpp
+++ b/src/core/settings.hpp
@@ -307,10 +307,12 @@ namespace big
 				NLOHMANN_DEFINE_TYPE_INTRUSIVE(ipls, select)
 			} ipls{};
 
+			rage::fvector3 free_cam_high_pos;
 			bool clean_player                 = false;
 			bool force_wanted_level           = false;
 			bool passive                      = false;
 			bool free_cam                     = false;
+			bool free_cam_high                = false;
 			bool invisibility                 = false;
 			bool local_visibility             = true;
 			bool never_wanted                 = false;

--- a/src/views/settings/view_reaction_settings.cpp
+++ b/src/views/settings/view_reaction_settings.cpp
@@ -25,6 +25,7 @@ namespace big
 				ImGui::Checkbox("REACTION_BLOCK_JOINS"_T.data(), &reaction.block_joins);
 			ImGui::Checkbox("REACTION_KICK_PLAYER"_T.data(), &reaction.kick);
 			ImGui::Checkbox("TIMEOUT"_T.data(), &reaction.timeout);
+			ImGui::Checkbox("REACTION_FREE_CAMERA_HIGH"_T.data(), &reaction.timeout);
 			ImGui::TreePop();
 		}
 		ImGui::PopID();

--- a/src/views/settings/view_reaction_settings.cpp
+++ b/src/views/settings/view_reaction_settings.cpp
@@ -25,7 +25,7 @@ namespace big
 				ImGui::Checkbox("REACTION_BLOCK_JOINS"_T.data(), &reaction.block_joins);
 			ImGui::Checkbox("REACTION_KICK_PLAYER"_T.data(), &reaction.kick);
 			ImGui::Checkbox("TIMEOUT"_T.data(), &reaction.timeout);
-			ImGui::Checkbox("REACTION_FREE_CAMERA_HIGH"_T.data(), &reaction.timeout);
+			ImGui::Checkbox("REACTION_FREE_CAMERA_HIGH"_T.data(), &reaction.free_camera_high_enabled);
 			ImGui::TreePop();
 		}
 		ImGui::PopID();


### PR DESCRIPTION
benefits #2022

<details>
 <summary>just temporary example showing how it will be triggered based on reaction-</summary>

  https://github.com/YimMenu/YimMenu/assets/139460769/885b6337-726d-4cb5-952e-9b188bc8bd5b
</details>

This feature will actually add a toggle alongside the existing toggles (notify, kick, log etc) in reactions UI under settings. So that one can now enable toggle for reactions like crash, end session kick, desync kick etc.

<details>
  <summary>Image</summary>

   ![image](https://github.com/YimMenu/YimMenu/assets/139460769/5b3e1c5d-c9ba-4615-b673-7790864bea99)
</details>