### PR TITLE
fix(MultiKick): Crash when calling CNetGamePlayer::is_host

### DIFF
--- a/src/backend/commands/player/kick/multi_kick.cpp
+++ b/src/backend/commands/player/kick/multi_kick.cpp
@@ -25,7 +25,7 @@ namespace big
 			if (g_player_service->get_self()->is_host())
 				dynamic_cast<player_command*>(command::get(RAGE_JOAAT("hostkick")))->call(player, {});
 
-			if (player && !player->is_host() && !g_player_service->get_self()->is_host())
+			if (player && !g_player_service->get_self()->is_host() && player->is_valid() && !player->is_host())
 				dynamic_cast<player_command*>(command::get(RAGE_JOAAT("desync")))->call(player, {});
 
 			if (g_player_service->get_self()->is_host())


### PR DESCRIPTION
Joined around 20+ sessions without crashing (or creating a stack trace).

Closes #2099 
Closes #2091 
Closes #1973 