### PR TITLE
enforce utf8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ file(GLOB_RECURSE SRC_MAIN
 
 if (MSVC)
   add_compile_options(/bigobj)
+  add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
+  add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
 else ()
   add_compile_options(-Wa,-mbig-obj)
 endif ()


### PR DESCRIPTION
std format currently throw if the string literal encoding of the user that compiles the project is not utf8 compatible so might aswell enforce it.

most contributors already are using a utf8 compatible string literal encoding anyway, for checking you can use this piece of code

https://www.fileformat.info/info/unicode/char/1234/index.htm
<html>
<body>
<!--StartFragment-->

UTF-8 (hex) | 0xE1 0x88 0xB4 (e188b4)
-- | --


<!--EndFragment-->
</body>
</html>

```cpp
constexpr bool is_utf8()
{
	constexpr char const* s = "\u1234";

	return (unsigned char)s[0] == 0xE1 && (unsigned char)s[1] == 0x88 && (unsigned char)s[2] == 0xB4 && (unsigned char)s[3] == 0x00;
}

static constexpr bool hover_me = is_utf8();
```