### PR TITLE
Fixed hotkeys triggering while Social Club overlay is active.

### DIFF
--- a/src/gta_pointers.hpp
+++ b/src/gta_pointers.hpp
@@ -335,6 +335,8 @@ namespace big
 
 		functions::decal_manager_remove m_decal_manager_remove;
 		PVOID m_decal_manager;
+
+		bool* m_is_social_club_overlay_active;
 	};
 #pragma pack(pop)
 	static_assert(sizeof(gta_pointers) % 8 == 0, "Pointers are not properly aligned");

--- a/src/pointers.cpp
+++ b/src/pointers.cpp
@@ -1640,6 +1640,15 @@ namespace big
                 g_pointers->m_gta.m_decal_manager = ptr.add(3).rip().as<PVOID>();
                 g_pointers->m_gta.m_decal_manager_remove = ptr.add(0xC).rip().as<functions::decal_manager_remove>();
             }
+        },
+        // Is Social Club Overlay Active
+        {
+            "ISCOA",
+            "88 1D ? ? ? ? E8 ? ? ? ? 33 F6",
+            [](memory::handle ptr)
+            {
+                g_pointers->m_gta.m_is_social_club_overlay_active = ptr.add(2).rip().as<bool*>();
+            }
         }
         >(); // don't leave a trailing comma at the end
 

--- a/src/services/hotkey/hotkey_service.cpp
+++ b/src/services/hotkey/hotkey_service.cpp
@@ -88,7 +88,7 @@ namespace big
 		if (g.cmd_executor.enabled)
 			return;
 
-		if (g_gui->is_open() || HUD::IS_PAUSE_MENU_ACTIVE() || SCRIPT::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH(RAGE_JOAAT("cellphone_flashhand")) > 0 || HUD::IS_MP_TEXT_CHAT_TYPING())
+		if (g_gui->is_open() || *g_pointers->m_gta.m_is_social_club_overlay_active || SCRIPT::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH(RAGE_JOAAT("cellphone_flashhand")) > 0 || HUD::IS_MP_TEXT_CHAT_TYPING())
 			return;
 
 		if (state == eKeyState::RELEASE || state == eKeyState::DOWN)


### PR DESCRIPTION
Added Social Club check to hotkeys.
Removed IS_PAUSE_MENU_ACTIVE check from hotkeys to facilitate teleporting to waypoints.