### PR TITLE
feat(anticheat): add bonus http blocker

### DIFF
--- a/src/gta_pointers.hpp
+++ b/src/gta_pointers.hpp
@@ -212,6 +212,8 @@ namespace big
 		PVOID m_queue_dependency;
 		PVOID m_interval_check_func;
 
+		PVOID m_http_start_request;
+
 		PVOID m_send_session_matchmaking_attributes;
 
 		PVOID m_serialize_take_off_ped_variation_task;

--- a/src/hooking.cpp
+++ b/src/hooking.cpp
@@ -106,6 +106,7 @@ namespace big
 
 		detour_hook_helper::add<hooks::queue_dependency>("QD", g_pointers->m_gta.m_queue_dependency);
 		detour_hook_helper::add<hooks::prepare_metric_for_sending>("PMFS", g_pointers->m_gta.m_prepare_metric_for_sending);
+		detour_hook_helper::add<hooks::http_start_request>("HSR", g_pointers->m_gta.m_http_start_request);
 
 		detour_hook_helper::add<hooks::fragment_physics_crash_2>("FPC2", g_pointers->m_gta.m_fragment_physics_crash_2);
 

--- a/src/hooking.hpp
+++ b/src/hooking.hpp
@@ -128,6 +128,7 @@ namespace big
 		static int nt_query_virtual_memory(void* _this, HANDLE handle, PVOID base_addr, int info_class, MEMORY_BASIC_INFORMATION* info, int size, size_t* return_len);
 		static void queue_dependency(void* dependency);
 		static bool prepare_metric_for_sending(rage::datBitBuffer* bit_buffer, int unk, int time, rage::rlMetric* metric);
+		static bool http_start_request(void* request, const char* uri);
 
 		static bool received_array_update(rage::netArrayHandlerBase* array, CNetGamePlayer* sender, rage::datBitBuffer* buffer, int size, int16_t cycle);
 

--- a/src/hooks/misc/http_start_request.cpp
+++ b/src/hooks/misc/http_start_request.cpp
@@ -1,0 +1,18 @@
+#include "hooking.hpp"
+#include "logger/stack_trace.hpp"
+#include "pointers.hpp"
+#include "util/string_conversions.hpp"
+
+namespace big
+{
+    bool hooks::http_start_request(void* request, const char* uri)
+    {
+        if(strstr(uri, "Bonus"))
+        {
+            // This is for worst case scenario where a report does slip through the cracks...
+            // Lets make it go somewhere it doesn't matter -- don't let the reports reach their servers!
+            uri = "https://www.google.com";
+        }
+        return g_hooking->get_original<hooks::http_start_request>()(request, uri);
+    }
+}

--- a/src/pointers.cpp
+++ b/src/pointers.cpp
@@ -979,6 +979,15 @@ namespace big
                 g_pointers->m_gta.m_prepare_metric_for_sending = ptr.as<PVOID>();
             }
         },
+        // HTTP Start Request
+        {
+            "HSR",
+            "48 89 5C 24 ? 48 89 74 24 ? 57 48 83 EC 20 48 8B D9 48 81 C1 ? ? ? ? 48 8B F2 33 FF E8",
+            [](memory::handle ptr)
+            {
+                g_pointers->m_gta.m_http_start_request = ptr.as<PVOID>();
+            }
+        },
         // Send Packet
         {
             "SP",


### PR DESCRIPTION
I'm not going to act like this is some revolutionary new code, however it is still quite effective.
This prevents certain anticheat reports going through to R*'s servers in the case that it does happen... can never be too safe.
First time I saw this technique in use was in Impulse, so credit goes to them I guess. Kept them UD for a few years.