### PR TITLE
enhance persist_car_service

### DIFF
--- a/src/core/data/lsc_types.hpp
+++ b/src/core/data/lsc_types.hpp
@@ -186,6 +186,7 @@ static const std::map<std::string, std::vector<int>> lsc_tire_smoke_rgb = {
     {"Red", {TIRESMOKE_COLOR_RED}},
     {"Pink", {TIRESMOKE_COLOR_PINK}},
     {"Brown", {TIRESMOKE_COLOR_BROWN}},
+    {"Patriot", {TIRESMOKE_COLOR_PATRIOT}},
 };
 
 static const std::map<std::string, std::vector<int>> lsc_neon_rgb = {

--- a/src/services/vehicle/model_attachment.hpp
+++ b/src/services/vehicle/model_attachment.hpp
@@ -11,7 +11,7 @@ namespace big
 		Vector3 rotation;
 		bool has_collision;
 		bool is_visible;
-		bool is_invincible;
+		// bool is_invincible;
 	};
 
 	static void to_json(nlohmann::json& j, const model_attachment& attachment)
@@ -25,7 +25,7 @@ namespace big
 		    {"rotation_z", attachment.rotation.z},
 		    {"has_collision", attachment.has_collision},
 		    {"is_visible", attachment.is_visible},
-		    {"is_invincible", attachment.is_invincible}
+		    // {"is_invincible", attachment.is_invincible}
 
 		};
 	};
@@ -44,6 +44,6 @@ namespace big
 
 		set_from_key_or_default(j, "has_collision", attachment.has_collision);
 		set_from_key_or_default(j, "is_visible", attachment.is_visible, true);
-		set_from_key_or_default(j, "is_invincible", attachment.is_invincible);
+		// set_from_key_or_default(j, "is_invincible", attachment.is_invincible);
 	}
 };

--- a/src/services/vehicle/model_attachment.hpp
+++ b/src/services/vehicle/model_attachment.hpp
@@ -11,7 +11,6 @@ namespace big
 		Vector3 rotation;
 		bool has_collision;
 		bool is_visible;
-		// bool is_invincible;
 	};
 
 	static void to_json(nlohmann::json& j, const model_attachment& attachment)
@@ -25,8 +24,6 @@ namespace big
 		    {"rotation_z", attachment.rotation.z},
 		    {"has_collision", attachment.has_collision},
 		    {"is_visible", attachment.is_visible},
-		    // {"is_invincible", attachment.is_invincible}
-
 		};
 	};
 
@@ -44,6 +41,5 @@ namespace big
 
 		set_from_key_or_default(j, "has_collision", attachment.has_collision);
 		set_from_key_or_default(j, "is_visible", attachment.is_visible, true);
-		// set_from_key_or_default(j, "is_invincible", attachment.is_invincible);
 	}
 };

--- a/src/services/vehicle/persist_car_service.cpp
+++ b/src/services/vehicle/persist_car_service.cpp
@@ -154,7 +154,6 @@ namespace big
 
 				ENTITY::SET_ENTITY_VISIBLE(object, attachment.is_visible, 0);
 				ENTITY::SET_ENTITY_COLLISION(object, attachment.has_collision, true);
-				// ENTITY::SET_ENTITY_INVINCIBLE(object, attachment.is_invincible);
 			}
 		}
 
@@ -183,7 +182,6 @@ namespace big
 
 			ENTITY::SET_ENTITY_VISIBLE(vehicle_to_attach, attachment.is_visible, 0);
 			ENTITY::SET_ENTITY_COLLISION(vehicle_to_attach, attachment.has_collision, true);
-			// ENTITY::SET_ENTITY_INVINCIBLE(vehicle_to_attach, attachment.is_invincible);
 			VEHICLE::SET_VEHICLE_IS_CONSIDERED_BY_PLAYER(vehicle_to_attach, false);
 		}
 
@@ -231,12 +229,6 @@ namespace big
 			bool has_collision = vehicle_json[has_collision_key];
 			ENTITY::SET_ENTITY_COLLISION(vehicle, has_collision, true);
 		}
-
-		// if (!vehicle_json[is_invincible_key].is_null())
-		// {
-		// 	bool is_invincible = vehicle_json[is_invincible_key];
-		// 	ENTITY::SET_ENTITY_INVINCIBLE(vehicle, is_invincible);
-		// }
 
 		if (!vehicle_json[custom_secondary_color_key].is_null())
 		{
@@ -363,7 +355,6 @@ namespace big
 		bool has_collision          = ENTITY::GET_ENTITY_COLLISION_DISABLED(object);
 		bool is_visible             = ENTITY::IS_ENTITY_VISIBLE(object);
 		CObject* cobject            = (CObject*)g_pointers->m_gta.m_handle_to_ptr(vehicle);
-		// bool is_invincible          = misc::has_bit_set(&(int&)cobject->m_damage_bits, 8);
 
 		Vector3 rotation;
 		rotation.x = (object_rotation.x - vehicle_rotation.x);
@@ -473,10 +464,8 @@ namespace big
 		bool has_collision                  = ENTITY::GET_ENTITY_COLLISION_DISABLED(vehicle);
 		bool is_visible                     = ENTITY::IS_ENTITY_VISIBLE(vehicle);
 		CVehicle* cvehicle                  = (CVehicle*)g_pointers->m_gta.m_handle_to_ptr(vehicle);
-		// bool is_invincible                  = misc::has_bit_set(&(int&)cvehicle->m_damage_bits, 8);
 		vehicle_json[has_collision_key]     = !has_collision;
 		vehicle_json[is_visible_key]        = is_visible;
-		// vehicle_json[is_invincible_key]     = is_invincible;
 		vehicle_json[wheel_color_key]       = wheel_color;
 		vehicle_json[tire_can_burst]        = VEHICLE::GET_VEHICLE_TYRES_CAN_BURST(vehicle);
 		vehicle_json[drift_tires]           = VEHICLE::GET_DRIFT_TYRES_SET(vehicle);

--- a/src/services/vehicle/persist_car_service.cpp
+++ b/src/services/vehicle/persist_car_service.cpp
@@ -203,6 +203,12 @@ namespace big
 
 		VEHICLE::SET_VEHICLE_DIRT_LEVEL(vehicle, 0.0f);
 		VEHICLE::SET_VEHICLE_MOD_KIT(vehicle, 0);
+
+		if (!vehicle_json[tire_can_burst].is_null())
+			VEHICLE::SET_VEHICLE_TYRES_CAN_BURST(vehicle, vehicle_json[tire_can_burst]);
+		else
+			VEHICLE::SET_VEHICLE_TYRES_CAN_BURST(vehicle, false);
+
 		VEHICLE::SET_VEHICLE_COLOURS(vehicle, vehicle_json[primary_color_key], vehicle_json[secondary_color_key]);
 
 		if (!vehicle_json[custom_primary_color_key].is_null())
@@ -234,9 +240,6 @@ namespace big
 			std::vector<int> secondary_custom_color = vehicle_json[custom_secondary_color_key];
 			VEHICLE::SET_VEHICLE_CUSTOM_SECONDARY_COLOUR(vehicle, secondary_custom_color[0], secondary_custom_color[1], secondary_custom_color[2]);
 		}
-
-		if (!vehicle_json[tire_can_burst].is_null())
-			VEHICLE::SET_VEHICLE_TYRES_CAN_BURST(vehicle, vehicle_json[tire_can_burst]);
 
 		VEHICLE::SET_VEHICLE_WINDOW_TINT(vehicle, vehicle_json[vehicle_window_tint_key]);
 

--- a/src/services/vehicle/persist_car_service.cpp
+++ b/src/services/vehicle/persist_car_service.cpp
@@ -154,7 +154,7 @@ namespace big
 
 				ENTITY::SET_ENTITY_VISIBLE(object, attachment.is_visible, 0);
 				ENTITY::SET_ENTITY_COLLISION(object, attachment.has_collision, true);
-				ENTITY::SET_ENTITY_INVINCIBLE(object, attachment.is_invincible);
+				// ENTITY::SET_ENTITY_INVINCIBLE(object, attachment.is_invincible);
 			}
 		}
 
@@ -183,7 +183,7 @@ namespace big
 
 			ENTITY::SET_ENTITY_VISIBLE(vehicle_to_attach, attachment.is_visible, 0);
 			ENTITY::SET_ENTITY_COLLISION(vehicle_to_attach, attachment.has_collision, true);
-			ENTITY::SET_ENTITY_INVINCIBLE(vehicle_to_attach, attachment.is_invincible);
+			// ENTITY::SET_ENTITY_INVINCIBLE(vehicle_to_attach, attachment.is_invincible);
 			VEHICLE::SET_VEHICLE_IS_CONSIDERED_BY_PLAYER(vehicle_to_attach, false);
 		}
 
@@ -203,7 +203,6 @@ namespace big
 
 		VEHICLE::SET_VEHICLE_DIRT_LEVEL(vehicle, 0.0f);
 		VEHICLE::SET_VEHICLE_MOD_KIT(vehicle, 0);
-		VEHICLE::SET_VEHICLE_TYRES_CAN_BURST(vehicle, false);
 		VEHICLE::SET_VEHICLE_COLOURS(vehicle, vehicle_json[primary_color_key], vehicle_json[secondary_color_key]);
 
 		if (!vehicle_json[custom_primary_color_key].is_null())
@@ -224,17 +223,20 @@ namespace big
 			ENTITY::SET_ENTITY_COLLISION(vehicle, has_collision, true);
 		}
 
-		if (!vehicle_json[is_invincible_key].is_null())
-		{
-			bool is_invincible = vehicle_json[is_invincible_key];
-			ENTITY::SET_ENTITY_INVINCIBLE(vehicle, is_invincible);
-		}
+		// if (!vehicle_json[is_invincible_key].is_null())
+		// {
+		// 	bool is_invincible = vehicle_json[is_invincible_key];
+		// 	ENTITY::SET_ENTITY_INVINCIBLE(vehicle, is_invincible);
+		// }
 
 		if (!vehicle_json[custom_secondary_color_key].is_null())
 		{
 			std::vector<int> secondary_custom_color = vehicle_json[custom_secondary_color_key];
 			VEHICLE::SET_VEHICLE_CUSTOM_SECONDARY_COLOUR(vehicle, secondary_custom_color[0], secondary_custom_color[1], secondary_custom_color[2]);
 		}
+
+		if (!vehicle_json[tire_can_burst].is_null())
+			VEHICLE::SET_VEHICLE_TYRES_CAN_BURST(vehicle, vehicle_json[tire_can_burst]);
 
 		VEHICLE::SET_VEHICLE_WINDOW_TINT(vehicle, vehicle_json[vehicle_window_tint_key]);
 
@@ -355,14 +357,14 @@ namespace big
 		bool has_collision          = ENTITY::GET_ENTITY_COLLISION_DISABLED(object);
 		bool is_visible             = ENTITY::IS_ENTITY_VISIBLE(object);
 		CObject* cobject            = (CObject*)g_pointers->m_gta.m_handle_to_ptr(vehicle);
-		bool is_invincible          = misc::has_bit_set(&(int&)cobject->m_damage_bits, 8);
+		// bool is_invincible          = misc::has_bit_set(&(int&)cobject->m_damage_bits, 8);
 
 		Vector3 rotation;
 		rotation.x = (object_rotation.x - vehicle_rotation.x);
 		rotation.y = (object_rotation.y - vehicle_rotation.y);
 		rotation.z = (object_rotation.z - vehicle_rotation.z);
 
-		model_attachment attachment = {ENTITY::GET_ENTITY_MODEL(object), location, rotation, !has_collision, is_visible, is_invincible};
+		model_attachment attachment = {ENTITY::GET_ENTITY_MODEL(object), location, rotation, !has_collision, is_visible};
 
 		return attachment;
 	}
@@ -465,11 +467,12 @@ namespace big
 		bool has_collision                  = ENTITY::GET_ENTITY_COLLISION_DISABLED(vehicle);
 		bool is_visible                     = ENTITY::IS_ENTITY_VISIBLE(vehicle);
 		CVehicle* cvehicle                  = (CVehicle*)g_pointers->m_gta.m_handle_to_ptr(vehicle);
-		bool is_invincible                  = misc::has_bit_set(&(int&)cvehicle->m_damage_bits, 8);
+		// bool is_invincible                  = misc::has_bit_set(&(int&)cvehicle->m_damage_bits, 8);
 		vehicle_json[has_collision_key]     = !has_collision;
 		vehicle_json[is_visible_key]        = is_visible;
-		vehicle_json[is_invincible_key]     = is_invincible;
+		// vehicle_json[is_invincible_key]     = is_invincible;
 		vehicle_json[wheel_color_key]       = wheel_color;
+		vehicle_json[tire_can_burst]        = VEHICLE::GET_VEHICLE_TYRES_CAN_BURST(vehicle);
 
 		std::map<int, bool> vehicle_extras;
 		for (int extra_iterator = 0; extra_iterator <= 14; extra_iterator++)

--- a/src/services/vehicle/persist_car_service.cpp
+++ b/src/services/vehicle/persist_car_service.cpp
@@ -209,6 +209,9 @@ namespace big
 		else
 			VEHICLE::SET_VEHICLE_TYRES_CAN_BURST(vehicle, false);
 
+		if (!vehicle_json[drift_tires].is_null())
+			VEHICLE::SET_DRIFT_TYRES(vehicle, vehicle_json[drift_tires]);
+
 		VEHICLE::SET_VEHICLE_COLOURS(vehicle, vehicle_json[primary_color_key], vehicle_json[secondary_color_key]);
 
 		if (!vehicle_json[custom_primary_color_key].is_null())
@@ -476,6 +479,7 @@ namespace big
 		// vehicle_json[is_invincible_key]     = is_invincible;
 		vehicle_json[wheel_color_key]       = wheel_color;
 		vehicle_json[tire_can_burst]        = VEHICLE::GET_VEHICLE_TYRES_CAN_BURST(vehicle);
+		vehicle_json[drift_tires]           = VEHICLE::GET_DRIFT_TYRES_SET(vehicle);
 
 		std::map<int, bool> vehicle_extras;
 		for (int extra_iterator = 0; extra_iterator <= 14; extra_iterator++)

--- a/src/services/vehicle/persist_car_service.hpp
+++ b/src/services/vehicle/persist_car_service.hpp
@@ -20,7 +20,6 @@ namespace big
 		static constexpr auto model_attachments_key = "model_attachments";
 
 		static constexpr auto vehicle_attachments_key = "vehicle_attachments";
-		// static constexpr auto is_invincible_key       = "is_invincible";
 		static constexpr auto is_visible_key    = "is_visible";
 		static constexpr auto has_collision_key = "has_collision";
 

--- a/src/services/vehicle/persist_car_service.hpp
+++ b/src/services/vehicle/persist_car_service.hpp
@@ -44,6 +44,7 @@ namespace big
 		static constexpr auto wheel_color_key      = "wheel_color";
 		static constexpr auto tire_smoke_color_key = "tire_smoke_color";
 		static constexpr auto tire_can_burst       = "tire_can_burst";
+		static constexpr auto drift_tires          = "drift_tires";
 
 		static constexpr auto convertable_state_key = "convertable_state";
 

--- a/src/services/vehicle/persist_car_service.hpp
+++ b/src/services/vehicle/persist_car_service.hpp
@@ -20,9 +20,9 @@ namespace big
 		static constexpr auto model_attachments_key = "model_attachments";
 
 		static constexpr auto vehicle_attachments_key = "vehicle_attachments";
-		static constexpr auto is_invincible_key       = "is_invincible";
-		static constexpr auto is_visible_key          = "is_visible";
-		static constexpr auto has_collision_key       = "has_collision";
+		// static constexpr auto is_invincible_key       = "is_invincible";
+		static constexpr auto is_visible_key    = "is_visible";
+		static constexpr auto has_collision_key = "has_collision";
 
 		static constexpr auto vehicle_model_hash_key = "vehicle_model_hash";
 
@@ -43,6 +43,7 @@ namespace big
 		static constexpr auto wheel_type_key       = "wheel_type";
 		static constexpr auto wheel_color_key      = "wheel_color";
 		static constexpr auto tire_smoke_color_key = "tire_smoke_color";
+		static constexpr auto tire_can_burst       = "tire_can_burst";
 
 		static constexpr auto convertable_state_key = "convertable_state";
 


### PR DESCRIPTION
- comment out is_invincible key from persist_car_service (**Fixes**) - This will prevent spawning vehicles as invincible. Invincible vehicles are those which will not be destroyed even if you have god mod disabled.
- add Patriot smoke option to LSC smoke colors (This is a missing option so it is a kind of **enhancement**).
- add tire_can_burst key to persist_car_service (**enhance**) - Previouly all cars spawned via `persist_car_service` had non-burstible tires. This change will effect new cars. Old saved cars will still spawn with  non-burstible tires.
- [add drift_tires key](https://github.com/YimMenu/YimMenu/pull/2394#discussion_r1390262614 ) (**enhance**) - Stores the drift ability for newly saved vehicles.