### PR TITLE
Redesigned Persist Car to use current car

### DIFF
--- a/src/services/vehicle/persist_car_service.cpp
+++ b/src/services/vehicle/persist_car_service.cpp
@@ -191,13 +191,17 @@ namespace big
 	Vehicle persist_car_service::spawn_vehicle_json(nlohmann::json vehicle_json, Ped ped, const std::optional<Vector3>& spawn_coords)
 	{
 		const Hash vehicle_hash = vehicle_json[vehicle_model_hash_key];
-		Vector3 spawn_location = spawn_coords.has_value() ? spawn_coords.value() : vehicle::get_spawn_location(g.persist_car.spawn_inside, vehicle_hash);
+		const Vector3& spawn_location = spawn_coords.has_value() ? spawn_coords.value() : vehicle::get_spawn_location(g.persist_car.spawn_inside, vehicle_hash);
 		const float spawn_heading = ENTITY::GET_ENTITY_HEADING(self::ped);
 
-		const auto vehicle = big::vehicle::spawn(vehicle_hash, spawn_location, spawn_heading);
+		Vehicle vehicle = self::veh;
+		if (spawn_coords.has_value() || (!spawn_coords.has_value() && ENTITY::GET_ENTITY_MODEL(vehicle) != vehicle_hash))
+		{
+			vehicle = big::vehicle::spawn(vehicle_hash, spawn_location, spawn_heading);
 
-		if (spawn_location.x + spawn_location.y + spawn_location.z != 0)
-			script::get_current()->yield(); //This is needed to wait for the engine to instantiate things like the radio station so it won't overwrite it on the next frame.
+			if (spawn_location.x + spawn_location.y + spawn_location.z != 0)
+				script::get_current()->yield(); //This is needed to wait for the engine to instantiate things like the radio station so it won't overwrite it on the next frame.
+		}
 
 		VEHICLE::SET_VEHICLE_DIRT_LEVEL(vehicle, 0.0f);
 		VEHICLE::SET_VEHICLE_MOD_KIT(vehicle, 0);

--- a/src/views/vehicle/spawn/view_persist_car.cpp
+++ b/src/views/vehicle/spawn/view_persist_car.cpp
@@ -28,7 +28,7 @@ namespace big
 			{
 				g_notification_service->push_warning("PERSIST_CAR"_T.data(), "PERSIST_CAR_TO_MANY_SPAWNED"_T.data());
 			}
-			else if (g.persist_car.spawn_inside)
+			else if (g.persist_car.spawn_inside && self::veh != vehicle)
 			{
 				teleport::into_vehicle(vehicle);
 			}


### PR DESCRIPTION
Redesigned Persist Car to check if the player is already in the car they want to spawn, and just forward self::veh as if it was the vehicle spawned.