### PR TITLE
refactor(Metrics): filter out "bad" metrics

### DIFF
--- a/src/gta/json_serializer.hpp
+++ b/src/gta/json_serializer.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+namespace rage
+{
+    #pragma pack(push, 1)
+    class json_serializer
+    {
+        uint32_t unk0;   // 0x00
+        uint32_t unk1;   // 0x00
+        char* buffer;    // 0x08
+        uint32_t curlen; // 0x10
+        uint32_t maxlen; // 0x14
+        uint32_t unk4;   // 0x18
+        uint8_t flags;   // 0x1C
+
+    public:
+        json_serializer(char* _buffer, uint32_t _length) :
+            buffer(_buffer),
+            maxlen(_length)
+        {
+            unk0
+                = 0;
+                unk1   = 0;
+                curlen = 0;
+                unk4   = 1;
+                flags  = 0;
+        }
+
+        inline char* get_string() const
+        {
+            return buffer;
+        }
+    };
+    static_assert(sizeof(json_serializer) == 0x1D); // size is actually 0x20
+    #pragma pack(pop)
+}

--- a/src/hooking.hpp
+++ b/src/hooking.hpp
@@ -5,6 +5,7 @@
 #include "gta/enums.hpp"
 #include "gta/fwddec.hpp"
 #include "gta/script_thread.hpp"
+#include "gta/json_serializer.hpp"
 #include "vmt_hook.hpp"
 #include "vtable_hook.hpp"
 #include "call_hook.hpp"
@@ -128,7 +129,8 @@ namespace big
 
 		static int nt_query_virtual_memory(void* _this, HANDLE handle, PVOID base_addr, int info_class, MEMORY_BASIC_INFORMATION* info, int size, size_t* return_len);
 		static int queue_dependency(void* a1, int a2, void* dependency);
-		static bool prepare_metric_for_sending(rage::datBitBuffer* bit_buffer, int unk, int time, rage::rlMetric* metric);
+
+		static bool prepare_metric_for_sending(rage::json_serializer* bit_buffer, int unk, int time, rage::rlMetric* metric);
 		static bool http_start_request(void* request, const char* uri);
 
 		static bool received_array_update(rage::netArrayHandlerBase* array, CNetGamePlayer* sender, rage::datBitBuffer* buffer, int size, int16_t cycle);

--- a/src/hooks/info/prepare_metric_for_sending.cpp
+++ b/src/hooks/info/prepare_metric_for_sending.cpp
@@ -3,41 +3,52 @@
 
 namespace big
 {
-	const auto bad_metrics = std::to_array<const std::string>({
+	const auto bad_metrics = std::unordered_set<std::string>({
+	    "REPORTER",
+	    "REPORT_INVALIDMODEL",
+	    "MEM_NEW",
+	    "DEBUGGER_ATTACH",
 	    "DIG",
+	    "XP_LOSS",
 	    "AWARD_XP",
 	    "CF",
 	    "CC",
 	    "CNR",
 	    "SCRIPT",
+	    "CHEAT",
 	    "AUX_DEUX",
+	    "WEATHER",
 	    "HARDWARE_OS",
 	    "HARDWARE_GPU",
 	    "HARDWARE_MOBO",
 	    "HARDWARE_MEM",
-	    "HARDWARE_MEM",
+	    "HARDWARE_CPU",
 	    "PCSETTINGS",
 	    "CASH_CREATED",
 	    "DR_PS",
 	    "UVC",
 	    "W_L",
 	    "ESVCS",
+	    "IDLEKICK",
 	    "GSCB",
 	    "GSINV",
 	    "GSCW",
 	    "GSINT",
 	    "EARN",
 	    "GARAGE_TAMPER",
-	    "TAMPER",
+	    "LAST_VEH",
+	    "FAIL_SERV",
+	    "CCF_UPDATE",
+	    "CODE_CRC",
+	    "COLLECTIBLE",
+	    "FIRST_VEH",
 	});
 
 	bool hooks::prepare_metric_for_sending(rage::json_serializer* serializer, int unk, int time, rage::rlMetric* metric)
 	{
 		const auto ret = g_hooking->get_original<prepare_metric_for_sending>()(serializer, unk, time, metric);
 
-		const auto is_bad_metric = std::find_if(bad_metrics.begin(), bad_metrics.end(), [metric](auto bad_metric) {
-			return metric->get_name() == bad_metric;
-		}) != bad_metrics.end();
+		const auto is_bad_metric = bad_metrics.contains(metric->get_name());
 		if (is_bad_metric)
 		{
 			LOG(WARNING) << "BAD METRIC: " << metric->get_name() << "; DATA: " << serializer->get_string();


### PR DESCRIPTION
Thinking about adding the "bad metric" log behind a toggle to prevent users from worrying about the log.