### PR TITLE
fix(player_command): execution failure

### DIFF
--- a/src/backend/commands/player/misc/give_ammo.cpp
+++ b/src/backend/commands/player/misc/give_ammo.cpp
@@ -17,7 +17,7 @@ namespace big
 
 		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx) override
 		{
-			g_pickup_service->give_player_health(player->id());
+			g_pickup_service->give_player_ammo(player->id());
 		}
 	};
 

--- a/src/backend/commands/player/misc/give_armor.cpp
+++ b/src/backend/commands/player/misc/give_armor.cpp
@@ -17,7 +17,7 @@ namespace big
 
 		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx) override
 		{
-			g_pickup_service->give_armour(player->id());
+			g_pickup_service->give_player_armour(player->id());
 		}
 	};
 

--- a/src/backend/player_command.cpp
+++ b/src/backend/player_command.cpp
@@ -36,7 +36,7 @@ namespace big
 		g_fiber_pool->queue_job([this, args, ctx] {
 			command_arguments new_args(m_num_args.value(), args);
 
-			if (g_player_service->get_self()->id() == args.get<int>(0))
+			if (g_player_service->get_self()->id() == args.get<uint8_t>(0))
 			{
 				execute(g_player_service->get_self(), new_args, ctx);
 				return;


### PR DESCRIPTION
Fix the issue where player_command always fails when executed with the me/self parameter.