### PR TITLE
fix(player_command): memory leak

### DIFF
--- a/src/backend/player_command.cpp
+++ b/src/backend/player_command.cpp
@@ -92,7 +92,7 @@ namespace big
 			result.push(plyr_id);
 		}
 
-		new_args.resize(args.size() - 1);
+		new_args.reserve(args.size() - 1);
 		std::copy(++args.begin(), args.end(), new_args.begin());
 		// for (int i = 1; i < args.size(); i++)
 		// 	new_args.push_back(args[i]);

--- a/src/backend/player_command.cpp
+++ b/src/backend/player_command.cpp
@@ -92,6 +92,7 @@ namespace big
 			result.push(plyr_id);
 		}
 
+		new_args.resize(args.size() - 1);
 		std::copy(++args.begin(), args.end(), new_args.begin());
 		// for (int i = 1; i < args.size(); i++)
 		// 	new_args.push_back(args[i]);


### PR DESCRIPTION
Fix the undefined behavior brought about by memory leaks when dealing with more than one parameter (e.g., /wanted).