### PR TITLE
Various fixes

### DIFF
--- a/src/backend/looped/vehicle/allow_all_weapons.cpp
+++ b/src/backend/looped/vehicle/allow_all_weapons.cpp
@@ -12,7 +12,7 @@ namespace big
 {
 	void looped::vehicle_allow_all_weapons()
 	{
-		if (self::veh == 0 || g_local_player == nullptr)
+		if (g_local_player == nullptr || g_local_player->m_vehicle == nullptr)
 			return;
 
 		auto seat_info = g_pointers->m_gta.m_get_ped_seat(g_local_player->m_seat_info, g_local_player);
@@ -50,11 +50,13 @@ namespace big
 			}
 		}
 
-		CVehicleModelInfo* vehicle_model_info = static_cast<CVehicleModelInfo*>(g_local_player->m_vehicle->m_model_info);
-		vehicle_model_info->set_vehicle_model_flag(CVehicleModelInfoFlags::DRIVER_NO_DRIVE_BY, false);
-		if (PAD::IS_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_AIM))
+		if (auto vehicle_model_info = static_cast<CVehicleModelInfo*>(g_local_player->m_vehicle->m_model_info))
 		{
-			PAD::DISABLE_CONTROL_ACTION(0, (int)ControllerInputs::INPUT_VEH_FLY_MOUSE_CONTROL_OVERRIDE, 1);
+			vehicle_model_info->set_vehicle_model_flag(CVehicleModelInfoFlags::DRIVER_NO_DRIVE_BY, false);
+			if (PAD::IS_CONTROL_PRESSED(0, (int)ControllerInputs::INPUT_AIM))
+			{
+				PAD::DISABLE_CONTROL_ACTION(0, (int)ControllerInputs::INPUT_VEH_FLY_MOUSE_CONTROL_OVERRIDE, 1);
+			}	
 		}
 	}
 }

--- a/src/views/self/view_weapons.cpp
+++ b/src/views/self/view_weapons.cpp
@@ -206,7 +206,12 @@ namespace big
 			ImGui::PushItemWidth(300);
 			if (ImGui::BeginCombo("GUI_TAB_WEAPONS"_T.data(), selected_weapon.c_str()))
 			{
-				for (auto& weapon : g_gta_data_service->weapons())
+				std::map<std::string, weapon_item> sorted_map;
+				for (const auto& [_, weapon] : g_gta_data_service->weapons())
+				{
+					sorted_map.emplace(weapon.m_display_name, weapon);
+				}
+				for (const auto& weapon : sorted_map)
 				{
 					bool is_selected = weapon.second.m_hash == selected_weapon_hash;
 					if (weapon.second.m_display_name != "NULL" && ImGui::Selectable(weapon.second.m_display_name.c_str(), is_selected, ImGuiSelectableFlags_None))
@@ -358,16 +363,21 @@ namespace big
 					ImGui::PushItemWidth(300);
 					if (ImGui::BeginCombo("GUI_TAB_WEAPONS"_T.data(), weapon.m_display_name.c_str()))
 					{
-						for (auto& weapon : g_gta_data_service->weapons())
+						std::map<std::string, weapon_item> sorted_map;
+						for (const auto& [_, weapon_iter] : g_gta_data_service->weapons())
 						{
-							if (weapon.second.m_display_name == "NULL")
+							sorted_map.emplace(weapon_iter.m_display_name, weapon_iter);
+						}
+						for (const auto& [_, weapon_iter] : g_gta_data_service->weapons())
+						{
+							if (weapon_iter.m_display_name == "NULL")
 							{
 								continue;
 							}
-							bool is_selected = weapon.second.m_hash == weapon_hash;
-							if (ImGui::Selectable(weapon.second.m_display_name.c_str(), is_selected, ImGuiSelectableFlags_None))
+							bool is_selected = weapon_iter.m_hash == weapon_hash;
+							if (ImGui::Selectable(weapon_iter.m_display_name.c_str(), is_selected, ImGuiSelectableFlags_None))
 							{
-								weapon_hash = weapon.second.m_hash;
+								weapon_hash = weapon_iter.m_hash;
 							}
 							if (is_selected)
 							{


### PR DESCRIPTION
Added sanity checks to vehicle_allow_all_weapons() to prevent an EXCEPTION_ACCESS_VIOLATION on m_vehicle when first entering it.
Made the weapons lists in Self->Weapons->Ammunation and Weapon Hotkey sorted by name instead of a completely random order.