### PR TITLE
Fix debug build

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,6 +1,17 @@
-﻿{
+﻿﻿{
   "configurations": [
     {
+      "name": "x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": ""
+    },
+	{
       "name": "x64-Release",
       "generator": "Ninja",
       "configurationType": "RelWithDebInfo",

--- a/src/memory/pattern.cpp
+++ b/src/memory/pattern.cpp
@@ -36,46 +36,26 @@ namespace memory
 
 	pattern::pattern(std::string_view ida_sig)
 	{
-		const auto size = ida_sig.size();
-		for (std::size_t i{}; i != size; ++i)
+		const auto size_minus_one = ida_sig.size() - 1;
+		m_bytes.reserve(size_minus_one / 2);
+		for (size_t i = 0; i != size_minus_one; ++i)
 		{
 			if (ida_sig[i] == ' ')
 				continue;
-			bool last = (i == ida_sig.size() - 1);
+
 			if (ida_sig[i] != '?')
 			{
-				if (!last)
+				auto c1 = to_hex(ida_sig[i]);
+				auto c2 = to_hex(ida_sig[i + 1]);
+				if (c1 && c2)
 				{
-					auto c1 = to_hex(ida_sig[i]);
-					auto c2 = to_hex(ida_sig[i + 1]);
-					if (c1 && c2)
-					{
-						m_bytes.emplace_back(static_cast<uint8_t>((*c1 * 0x10) + *c2));
-					}
+					m_bytes.emplace_back(static_cast<uint8_t>((*c1 * 0x10) + *c2));
 				}
 			}
 			else
 			{
 				m_bytes.push_back({});
-
-				// add support for double question mark sigs
-				if (ida_sig[i + 1] == '?')
-				{
-					++i;
-				}
 			}
-		}
-	}
-
-	pattern::pattern(const void* bytes, std::string_view mask)
-	{
-		const auto size = mask.size();
-		for (std::size_t i{}; i != size; ++i)
-		{
-			if (mask[i] != '?')
-				m_bytes.emplace_back(static_cast<const uint8_t*>(bytes)[i]);
-			else
-				m_bytes.push_back(std::nullopt);
 		}
 	}
 }

--- a/src/memory/pattern.hpp
+++ b/src/memory/pattern.hpp
@@ -16,7 +16,6 @@ namespace memory
 
 	public:
 		pattern(std::string_view ida_sig);
-		explicit pattern(const void* bytes, std::string_view mask);
 
 		inline pattern(const char* ida_sig) :
 		    pattern(std::string_view(ida_sig))


### PR DESCRIPTION
allow injecting the menu with debug flags, remove unused pattern double ?? support as it was never used and was causing UB since a long time now (out of range array access)