### PR TITLE
Debug Build Fix for VS2022

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,4 +1,4 @@
-﻿﻿{
+﻿{
   "configurations": [
     {
       "name": "x64-Debug",


### PR DESCRIPTION
Fixed EOL character used in CMakeSettings.json casing it to invalidly be parsed.