### PR TITLE
(improvement) load_3d_ground_at_coords

### DIFF
--- a/src/util/entity.cpp
+++ b/src/util/entity.cpp
@@ -201,7 +201,7 @@ namespace big::entity
 
 	    do {
 	        found_ground = MISC::GET_GROUND_Z_FOR_3D_COORD(location.x, location.y, max_ground_check, &ground_z, FALSE, FALSE);
-	        STREAMING::REQUEST_ADDITIONAL_COLLISION_AT_COORD(location.x, location.y, location.z);
+	        STREAMING::REQUEST_COLLISION_AT_COORD(location.x, location.y, location.z);
 
 	        if (current_attempts % 10 == 0)
 	        {

--- a/src/util/entity.cpp
+++ b/src/util/entity.cpp
@@ -194,26 +194,35 @@ namespace big::entity
 	bool load_ground_at_3dcoord(Vector3& location)
 	{
 		constexpr float max_ground_check	= 1000.f;
-		constexpr int max_attempts			= 200;
-		float ground_z						= location.z + 1.f;
+		constexpr int max_attempts			= 300;
+		float ground_z						= location.z;
 		int current_attempts				= 0;
 
-		while (!MISC::GET_GROUND_Z_FOR_3D_COORD(location.x, location.y, max_ground_check, &ground_z, FALSE, FALSE))
+		while (!MISC::GET_GROUND_Z_FOR_3D_COORD(location.x, location.y, max_ground_check, &ground_z, FALSE, FALSE) && current_attempts != max_attempts)
 		{
-			STREAMING::REQUEST_ADDITIONAL_COLLISION_AT_COORD(location.x, location.y, location.z);
-			if (current_attempts >= max_attempts)
+			if (MISC::GET_GROUND_Z_FOR_3D_COORD(location.x, location.y, max_ground_check, &ground_z, FALSE, FALSE))
 			{
-				return false;
+				break;
 			}
-			current_attempts++;
+
+			STREAMING::REQUEST_ADDITIONAL_COLLISION_AT_COORD(location.x, location.y, location.z);
+
 			if (current_attempts % 10 == 0)
 			{
 				location.z += 25.f;
 			}
+
+			current_attempts++;
+
 			script::get_current()->yield();
 		}
 
-		location.z = ground_z;
+		if (current_attempts >= max_attempts)
+		{
+			return false;
+		}
+
+		location.z = ground_z + 1.f;
 		return true;
 	}
 

--- a/src/util/entity.cpp
+++ b/src/util/entity.cpp
@@ -193,37 +193,33 @@ namespace big::entity
 
 	bool load_ground_at_3dcoord(Vector3& location)
 	{
-		constexpr float max_ground_check	= 1000.f;
-		constexpr int max_attempts			= 300;
-		float ground_z						= location.z;
-		int current_attempts				= 0;
+	    constexpr float max_ground_check = 1000.f;
+	    constexpr int max_attempts = 300;
+	    float ground_z = location.z;
+	    int current_attempts = 0;
+	    bool found_ground;
 
-		while (!MISC::GET_GROUND_Z_FOR_3D_COORD(location.x, location.y, max_ground_check, &ground_z, FALSE, FALSE) && current_attempts != max_attempts)
-		{
-			if (MISC::GET_GROUND_Z_FOR_3D_COORD(location.x, location.y, max_ground_check, &ground_z, FALSE, FALSE))
-			{
-				break;
-			}
+	    do {
+	        found_ground = MISC::GET_GROUND_Z_FOR_3D_COORD(location.x, location.y, max_ground_check, &ground_z, FALSE, FALSE);
+	        STREAMING::REQUEST_ADDITIONAL_COLLISION_AT_COORD(location.x, location.y, location.z);
 
-			STREAMING::REQUEST_ADDITIONAL_COLLISION_AT_COORD(location.x, location.y, location.z);
+	        if (current_attempts % 10 == 0)
+	        {
+	            location.z += 25.f;
+	        }
 
-			if (current_attempts % 10 == 0)
-			{
-				location.z += 25.f;
-			}
+	        ++current_attempts;
 
-			current_attempts++;
+	        script::get_current()->yield();
+	    } while (!found_ground && current_attempts < max_attempts);
 
-			script::get_current()->yield();
-		}
+	    if (!found_ground)
+	    {
+	        return false;
+	    }
 
-		if (current_attempts >= max_attempts)
-		{
-			return false;
-		}
-
-		location.z = ground_z + 1.f;
-		return true;
+	    location.z = ground_z + 1.f;
+	    return true;
 	}
 
 	double distance_to_middle_of_screen(const rage::fvector2& screen_pos)

--- a/src/util/entity.cpp
+++ b/src/util/entity.cpp
@@ -191,47 +191,6 @@ namespace big::entity
 		return target_entities;
 	}
 
-	bool force_manual_ground_check(Vector3& location)
-	{
-		float groundZ;
-		bool done = false;
-
-		for (int i = 0; i < 10; i++)
-		{
-			for (int z = 0; z < 1000; z += 25)
-			{
-				float ground_iteration = static_cast<float>(z);
-				// Only request a collision after the first try failed because the location might already be loaded on first attempt.
-				if (i >= 1 && z % 100 == 0)
-				{
-					STREAMING::REQUEST_COLLISION_AT_COORD(location.x, location.y, ground_iteration);
-					script::get_current()->yield();
-				}
-
-				if (MISC::GET_GROUND_Z_FOR_3D_COORD(location.x, location.y, ground_iteration, &groundZ, false, false))
-				{
-					location.z = groundZ + 1.f;
-					done       = true;
-				}
-			}
-
-			float height;
-			if (done && WATER::GET_WATER_HEIGHT(location.x, location.y, location.z, &height))
-			{
-				location.z = height + 1.f;
-			}
-
-			if (done)
-			{
-				return true;
-			}
-		}
-
-		location.z = 1000.f;
-
-		return false;
-	}
-
 	bool load_ground_at_3dcoord(Vector3& location)
 	{
 		constexpr float max_ground_check	= 1000.f;
@@ -244,14 +203,13 @@ namespace big::entity
 			STREAMING::REQUEST_ADDITIONAL_COLLISION_AT_COORD(location.x, location.y, location.z);
 			if (current_attempts >= max_attempts)
 			{
-				if (force_manual_ground_check(location))
-				{
-					return true;
-				}
-
 				return false;
 			}
 			current_attempts++;
+			if (current_attempts % 10 == 0)
+			{
+				location.z += 25.f;
+			}
 			script::get_current()->yield();
 		}
 

--- a/src/util/entity.cpp
+++ b/src/util/entity.cpp
@@ -194,7 +194,7 @@ namespace big::entity
 	bool load_ground_at_3dcoord(Vector3& location)
 	{
 		constexpr float max_ground_check	= 1000.f;
-		constexpr int max_attempts			= 100;
+		constexpr int max_attempts			= 200;
 		float ground_z						= location.z + 1.f;
 		int current_attempts				= 0;
 


### PR DESCRIPTION
I have been testing teleports, and how to improve loading ground at coords faster. Without having to for loop 10K times, and i have came with this solution.

Testing outputs: 

- Empty areas: 0 - 10 attempts.
- Populated areas: around 20 - 50 attempts.
- Highest point on the map: Around 135 attempts