### PR TITLE
lua: allow functions to be called without giving all of its args.

### DIFF
--- a/src/common.hpp
+++ b/src/common.hpp
@@ -61,8 +61,7 @@
 #include "services/notifications/notification_service.hpp"
 #include "services/translation_service/translation_service.hpp"
 
-#define SOL_ALL_SAFETIES_ON 1
-#include "lua/sol.hpp"
+#include "lua/sol_include.hpp"
 
 #include <script/types.hpp>
 

--- a/src/lua/sol_include.hpp
+++ b/src/lua/sol_include.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#define SOL_SAFE_USERTYPE 1
+#define SOL_SAFE_REFERENCES 1
+#define SOL_SAFE_FUNCTION 1
+#define SOL_SAFE_NUMERICS 1
+#define SOL_SAFE_GETTER 1
+#define SOL_NO_CHECK_NUMBER_PRECISION 1
+
+// This is intended to be disabled.
+// Allow functions to be called without giving all of its args.
+// Enabling it would make current usage of native functions like
+// local r, g, b = VEHICLE.GET_VEHICLE_COLOR(spawnedVehicle)
+// much more annoying due to how pointer args are handled,
+// there is no way to know unless by hardcoding manually all of them that
+// a pointer arg is an in or out parameter.
+//
+// #define SOL_SAFE_FUNCTION_CALLS
+
+#include "lua/sol.hpp"


### PR DESCRIPTION
That make usage of native functions that normally use pointer args to be much more easy to deal with.

Closes #2742 