### PR TITLE
feat(Actions): only trigger on changes that matter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - src/**
       - cmake/**
       - CMakeLists.txt
+      - .github/workflows/ci.yml
 
 jobs:
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+    paths:
+      - src/**
+      - cmake/**
+      - CMakeLists.txt
 
 jobs:
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
       - CMakeLists.txt
       - .github/workflows/ci.yml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     runs-on: [self-hosted, Windows]

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,6 +6,10 @@ on:
     - cron: '0 14 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: nightly
+  cancel-in-progress: true
+
 jobs:
   build_nightly:
     runs-on: [self-hosted, Windows]


### PR DESCRIPTION
These changes will make some helpful changes to prevent hogging the Github Action runner when it's not actually required.

Path Triggers:
 - src/
 - cmake/
 - CMakeLists.txt
 - .github/workflows/ci.yml

Concurrency:
 - If the Github Action is already running a nightly build or a build for a specific PR then these will be cancelled

Closes #2751 