### PR TITLE
refactor!: Rewrite of the old notification service

### DIFF
--- a/src/backend/commands/player/kick/end_session_kick.cpp
+++ b/src/backend/commands/player/kick/end_session_kick.cpp
@@ -21,7 +21,7 @@ namespace big
 				return;
 			if (!scripts::force_host("freemode"_J))
 			{
-				g_notification_service->push_error("END_KICK"_T.data(), "BACKEND_END_SESSION_KICK_FORCE_SCRIPT_HOST_FAILED"_T.data());
+				g_notification_service.push_error("END_KICK"_T.data(), "BACKEND_END_SESSION_KICK_FORCE_SCRIPT_HOST_FAILED"_T.data());
 				return;
 			}
 

--- a/src/backend/commands/player/kick/host_kick.cpp
+++ b/src/backend/commands/player/kick/host_kick.cpp
@@ -18,7 +18,7 @@ namespace big
 				return;
 			if (!g_player_service->get_self()->is_host())
 			{
-				g_notification_service->push_error("HOST_KICK"_T.data(), "BACKEND_HOST_KICK_FAILED"_T.data());
+				g_notification_service.push_error("HOST_KICK"_T.data(), "BACKEND_HOST_KICK_FAILED"_T.data());
 				return;
 			}
 

--- a/src/backend/commands/player/kick/script_host_kick.cpp
+++ b/src/backend/commands/player/kick/script_host_kick.cpp
@@ -21,7 +21,7 @@ namespace big
 				return;
 			if (!scripts::force_host("freemode"_J))
 			{
-				g_notification_service->push_error("Kick", "Force script host failed!");
+				g_notification_service.push_error("Kick", "Force script host failed!");
 				return;
 			}
 

--- a/src/backend/commands/player/toxic/turn_into_beast.cpp
+++ b/src/backend/commands/player/toxic/turn_into_beast.cpp
@@ -23,11 +23,11 @@ namespace big
 			{
 				if (!NETWORK::NETWORK_IS_PLAYER_A_PARTICIPANT_ON_SCRIPT(id, "am_launcher", -1))
 				{
-					g_notification_service->push_error("TURN_INTO_BEAST"_T.data(), "BACKEND_TURN_INTO_BEAST_CANNOT_START_AM_LAUNCHER"_T.data());
+					g_notification_service.push_error("TURN_INTO_BEAST"_T.data(), "BACKEND_TURN_INTO_BEAST_CANNOT_START_AM_LAUNCHER"_T.data());
 					return;
 				}
 
-				g_notification_service->push("TURN_INTO_BEAST"_T.data(), "BACKEND_TURN_INTO_BEAST_STARTING"_T.data());
+				g_notification_service.push("TURN_INTO_BEAST"_T.data(), "BACKEND_TURN_INTO_BEAST_STARTING"_T.data());
 
 				scripts::start_launcher_script(47);
 
@@ -35,7 +35,7 @@ namespace big
 				{
 					if (i >= 1000)
 					{
-						g_notification_service->push_error("TURN_INTO_BEAST"_T.data(), "BACKEND_TURN_INTO_BEAST_FAILED"_T.data());
+						g_notification_service.push_error("TURN_INTO_BEAST"_T.data(), "BACKEND_TURN_INTO_BEAST_FAILED"_T.data());
 						return;
 					}
 
@@ -48,7 +48,7 @@ namespace big
 
 			if (!scripts::force_host("am_hunt_the_beast"_J))
 			{
-				g_notification_service->push_error("TURN_INTO_BEAST"_T.data(), "BACKEND_TURN_INTO_BEAST_FAILED_CONTROL"_T.data());
+				g_notification_service.push_error("TURN_INTO_BEAST"_T.data(), "BACKEND_TURN_INTO_BEAST_FAILED_CONTROL"_T.data());
 				return;
 			}
 
@@ -89,7 +89,7 @@ namespace big
 			{
 				if (i >= 7000)
 				{
-					g_notification_service->push_error("TURN_INTO_BEAST"_T.data(), "BACKEND_TURN_INTO_BEAST_FAILED"_T.data());
+					g_notification_service.push_error("TURN_INTO_BEAST"_T.data(), "BACKEND_TURN_INTO_BEAST_FAILED"_T.data());
 					return;
 				}
 
@@ -100,7 +100,7 @@ namespace big
 
 			if (!scripts::force_host("am_hunt_the_beast"_J))
 			{
-				g_notification_service->push_error("TURN_INTO_BEAST"_T.data(), "BACKEND_TURN_INTO_BEAST_FAILED_CONTROL"_T.data());
+				g_notification_service.push_error("TURN_INTO_BEAST"_T.data(), "BACKEND_TURN_INTO_BEAST_FAILED_CONTROL"_T.data());
 				return;
 			}
 

--- a/src/backend/commands/player/vehicle/boost_vehicle.cpp
+++ b/src/backend/commands/player/vehicle/boost_vehicle.cpp
@@ -14,7 +14,7 @@ namespace big
 			Ped ped = PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id());
 			if (!PED::IS_PED_IN_ANY_VEHICLE(ped, true))
 			{
-				g_notification_service->push_warning("TOXIC"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
+				g_notification_service.push_warning("TOXIC"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
 			}
 			else
 			{
@@ -26,7 +26,7 @@ namespace big
 				}
 				else
 				{
-					g_notification_service->push_warning("TOXIC"_T.data(), "ERROR_FAILED_TO_TAKE_CONTROL"_T.data());
+					g_notification_service.push_warning("TOXIC"_T.data(), "ERROR_FAILED_TO_TAKE_CONTROL"_T.data());
 				}
 			}
 		}

--- a/src/backend/commands/player/vehicle/burst_tyres.cpp
+++ b/src/backend/commands/player/vehicle/burst_tyres.cpp
@@ -15,7 +15,7 @@ namespace big
 
 			if (!PED::IS_PED_IN_ANY_VEHICLE(ped, true))
 			{
-				g_notification_service->push_warning("TOXIC"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
+				g_notification_service.push_warning("TOXIC"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
 			}
 			else
 			{

--- a/src/backend/commands/player/vehicle/close_doors.cpp
+++ b/src/backend/commands/player/vehicle/close_doors.cpp
@@ -14,7 +14,7 @@ namespace big
 
 			if (!PED::IS_PED_IN_ANY_VEHICLE(ped, true))
 			{
-				g_notification_service->push_warning("TOXIC"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
+				g_notification_service.push_warning("TOXIC"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
 			}
 			else
 			{
@@ -26,7 +26,7 @@ namespace big
 				}
 				else
 				{
-					g_notification_service->push_warning("TOXIC"_T.data(), "ERROR_FAILED_TO_TAKE_CONTROL"_T.data());
+					g_notification_service.push_warning("TOXIC"_T.data(), "ERROR_FAILED_TO_TAKE_CONTROL"_T.data());
 				}
 			}
 		}

--- a/src/backend/commands/player/vehicle/downgrade_vehicle.cpp
+++ b/src/backend/commands/player/vehicle/downgrade_vehicle.cpp
@@ -16,7 +16,7 @@ namespace big
 
 			if (!PED::IS_PED_IN_ANY_VEHICLE(ped, true))
 			{
-				g_notification_service->push_warning("TOXIC"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
+				g_notification_service.push_warning("TOXIC"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
 			}
 			else
 			{

--- a/src/backend/commands/player/vehicle/flip_180.cpp
+++ b/src/backend/commands/player/vehicle/flip_180.cpp
@@ -18,7 +18,7 @@ namespace big
 
 			if (!PED::IS_PED_IN_ANY_VEHICLE(player_ped, true))
 			{
-				g_notification_service->push_warning("TOXIC"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
+				g_notification_service.push_warning("TOXIC"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
 			}
 			else
 			{

--- a/src/backend/commands/player/vehicle/flying_vehicle.cpp
+++ b/src/backend/commands/player/vehicle/flying_vehicle.cpp
@@ -15,7 +15,7 @@ namespace big
 
 			if (!PED::IS_PED_IN_ANY_VEHICLE(ent, true))
 			{
-				g_notification_service->push_warning("TOXIC"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
+				g_notification_service.push_warning("TOXIC"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
 			}
 			else
 			{

--- a/src/backend/commands/player/vehicle/kill_engine.cpp
+++ b/src/backend/commands/player/vehicle/kill_engine.cpp
@@ -13,7 +13,7 @@ namespace big
 			Ped ped = PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id());
 			if (!PED::IS_PED_IN_ANY_VEHICLE(ped, true))
 			{
-				g_notification_service->push_warning("TOXIC"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
+				g_notification_service.push_warning("TOXIC"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
 			}
 			else
 			{
@@ -25,7 +25,7 @@ namespace big
 				}
 				else
 				{
-					g_notification_service->push_warning("TOXIC"_T.data(), "ERROR_FAILED_TO_TAKE_CONTROL"_T.data());
+					g_notification_service.push_warning("TOXIC"_T.data(), "ERROR_FAILED_TO_TAKE_CONTROL"_T.data());
 				}
 			}
 		}

--- a/src/backend/commands/player/vehicle/lock_doors.cpp
+++ b/src/backend/commands/player/vehicle/lock_doors.cpp
@@ -14,7 +14,7 @@ namespace big
 			Ped ped = PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id());
 			if (!PED::IS_PED_IN_ANY_VEHICLE(ped, true))
 			{
-				g_notification_service->push_warning("TOXIC"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
+				g_notification_service.push_warning("TOXIC"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
 			}
 			else
 			{

--- a/src/backend/commands/player/vehicle/open_doors.cpp
+++ b/src/backend/commands/player/vehicle/open_doors.cpp
@@ -14,7 +14,7 @@ namespace big
 			Ped ped = PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id());
 			if (!PED::IS_PED_IN_ANY_VEHICLE(ped, true))
 			{
-				g_notification_service->push_warning("TOXIC"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
+				g_notification_service.push_warning("TOXIC"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
 			}
 			else
 			{
@@ -29,7 +29,7 @@ namespace big
 				}
 				else
 				{
-					g_notification_service->push_warning("TOXIC"_T.data(), "ERROR_FAILED_TO_TAKE_CONTROL"_T.data());
+					g_notification_service.push_warning("TOXIC"_T.data(), "ERROR_FAILED_TO_TAKE_CONTROL"_T.data());
 				}
 			}
 		}

--- a/src/backend/commands/player/vehicle/remote_control_vehicle.cpp
+++ b/src/backend/commands/player/vehicle/remote_control_vehicle.cpp
@@ -15,9 +15,9 @@ namespace big
 			if (veh == 0)
 			{
 				if (g.player.spectating)
-					g_notification_service->push_warning("REMOTE_CONTROL"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
+					g_notification_service.push_warning("REMOTE_CONTROL"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
 				else
-					g_notification_service->push_warning("REMOTE_CONTROL"_T.data(), std::format("{} {}", "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T, "BACKEND_REMOTE_CONTROL_VEHICLE_SPECTATE"_T).c_str());
+					g_notification_service.push_warning("REMOTE_CONTROL"_T.data(), std::format("{} {}", "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T, "BACKEND_REMOTE_CONTROL_VEHICLE_SPECTATE"_T).c_str());
 				return;
 			}
 

--- a/src/backend/commands/player/vehicle/special_ability.cpp
+++ b/src/backend/commands/player/vehicle/special_ability.cpp
@@ -15,7 +15,7 @@ namespace big
 			Ped ped = PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id());
 			if (!PED::IS_PED_IN_ANY_VEHICLE(ped, true))
 			{
-				g_notification_service->push_warning("TOXIC"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
+				g_notification_service.push_warning("TOXIC"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
 			}
 			else
 			{

--- a/src/backend/commands/player/vehicle/stop_vehicle.cpp
+++ b/src/backend/commands/player/vehicle/stop_vehicle.cpp
@@ -13,7 +13,7 @@ namespace big
 			Ped ped = PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id());
 			if (!PED::IS_PED_IN_ANY_VEHICLE(ped, true))
 			{
-				g_notification_service->push_warning("TOXIC"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
+				g_notification_service.push_warning("TOXIC"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
 			}
 			else
 			{
@@ -25,7 +25,7 @@ namespace big
 				}
 				else
 				{
-					g_notification_service->push_warning("TOXIC"_T.data(), "ERROR_FAILED_TO_TAKE_CONTROL"_T.data());
+					g_notification_service.push_warning("TOXIC"_T.data(), "ERROR_FAILED_TO_TAKE_CONTROL"_T.data());
 				}
 			}
 		}

--- a/src/backend/commands/player/vehicle/unlock_doors.cpp
+++ b/src/backend/commands/player/vehicle/unlock_doors.cpp
@@ -14,7 +14,7 @@ namespace big
 			Ped ped = PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(player->id());
 			if (!PED::IS_PED_IN_ANY_VEHICLE(ped, true))
 			{
-				g_notification_service->push_warning("VEHICLE"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
+				g_notification_service.push_warning("VEHICLE"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
 			}
 			else
 			{

--- a/src/backend/commands/player/vehicle/upgrade_vehicle.cpp
+++ b/src/backend/commands/player/vehicle/upgrade_vehicle.cpp
@@ -17,7 +17,7 @@ namespace big
 
 			if (!PED::IS_PED_IN_ANY_VEHICLE(ped, true))
 			{
-				g_notification_service->push_warning("TOXIC"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
+				g_notification_service.push_warning("TOXIC"_T.data(), "ERROR_PLAYER_IS_NOT_IN_VEHICLE"_T.data());
 			}
 			else
 			{

--- a/src/backend/commands/session/wipe_session.cpp
+++ b/src/backend/commands/session/wipe_session.cpp
@@ -15,7 +15,7 @@ namespace big
 			{
 				player_mgr->RemovePlayer(plyr->get_net_game_player());
 			}
-			g_notification_service->push("EMPTY_SESSION"_T.data(), "BACKEND_WIPE_SESSION_COMPLETE"_T.data());
+			g_notification_service.push("EMPTY_SESSION"_T.data(), "BACKEND_WIPE_SESSION_COMPLETE"_T.data());
 		}
 	};
 	empty_session g_empty_session("emptysession", "EMPTY_SESSION", "BACKEND_WIPE_SESSION_DESC", 0);

--- a/src/backend/commands/spawn/spawn_vehicle.cpp
+++ b/src/backend/commands/spawn/spawn_vehicle.cpp
@@ -42,7 +42,7 @@ namespace big
 
 			if (veh == 0)
 			{
-				g_notification_service->push_error("GUI_TAB_SPAWN_VEHICLE"_T.data(), "UNABLE_TO_SPAWN_VEHICLE"_T.data());
+				g_notification_service.push_error("GUI_TAB_SPAWN_VEHICLE"_T.data(), "UNABLE_TO_SPAWN_VEHICLE"_T.data());
 			}
 			else
 			{

--- a/src/backend/context/default_command_context.cpp
+++ b/src/backend/context/default_command_context.cpp
@@ -14,11 +14,11 @@ namespace big
 
 	void default_command_context::report_output(const std::string& output) const
 	{
-		g_notification_service->push("BACKEND_COMMAND"_T.data(), output);
+		g_notification_service.push("BACKEND_COMMAND"_T.data(), output);
 	}
 
 	void default_command_context::report_error(const std::string& error) const
 	{
-		g_notification_service->push_error("BACKEND_COMMAND"_T.data(), error);
+		g_notification_service.push_error("BACKEND_COMMAND"_T.data(), error);
 	}
 }

--- a/src/backend/looped/self/super_hero_fly.cpp
+++ b/src/backend/looped/self/super_hero_fly.cpp
@@ -391,7 +391,7 @@ namespace big
 
 		virtual void on_enable() override
 		{
-			g_notification_service->push("SUPER_HERO_FLY"_T.data(), "SUPER_HERO_FLY_ENABLE_NOTIFICATION"_T.data());
+			g_notification_service.push("SUPER_HERO_FLY"_T.data(), "SUPER_HERO_FLY_ENABLE_NOTIFICATION"_T.data());
 		}
 
 		virtual void on_disable() override

--- a/src/backend/looped/self/toggle_passive.cpp
+++ b/src/backend/looped/self/toggle_passive.cpp
@@ -19,7 +19,7 @@ namespace big
 			{
 				on_disable();
 				g.self.passive = false;
-				g_notification_service->push_warning("PASSIVE"_T.data(), "BACKEND_LOOPED_SELF_TOGGLE_PASSIVE_DISABLED_PASSIVE_MODE_MESSAGE"_T.data());
+				g_notification_service.push_warning("PASSIVE"_T.data(), "BACKEND_LOOPED_SELF_TOGGLE_PASSIVE_DISABLED_PASSIVE_MODE_MESSAGE"_T.data());
 				return;
 			}
 			*g_tunables_service->get_tunable<int*>(-29732167) = 0; // End Passive Time = 0s

--- a/src/backend/looped/vehicle/auto_drive.cpp
+++ b/src/backend/looped/vehicle/auto_drive.cpp
@@ -29,7 +29,7 @@ namespace big
 		{
 			current_destination     = AutoDriveDestination::STOPPED;
 			changing_driving_styles = false;
-			g_notification_service->push_warning("AUTO_DRIVE"_T.data(), "PLAYER_INFO_NO_VEHICLE"_T.data());
+			g_notification_service.push_warning("AUTO_DRIVE"_T.data(), "PLAYER_INFO_NO_VEHICLE"_T.data());
 		}
 		else if (current_driving_flag != driving_style_flags[g.vehicle.auto_drive_style] || current_speed != g.vehicle.auto_drive_speed)
 		{
@@ -77,11 +77,11 @@ namespace big
 
 				if (to_waypoint && !does_waypoint_exist)
 				{
-					g_notification_service->push_warning("AUTO_DRIVE"_T.data(), "TELEPORT_NO_WAYPOINT_SET"_T.data());
+					g_notification_service.push_warning("AUTO_DRIVE"_T.data(), "TELEPORT_NO_WAYPOINT_SET"_T.data());
 				}
 				else
 				{
-					g_notification_service->push_warning("AUTO_DRIVE"_T.data(), "BACKEND_LOOPED_VEHICLE_AUTO_DRIVE_STOPPED"_T.data());
+					g_notification_service.push_warning("AUTO_DRIVE"_T.data(), "BACKEND_LOOPED_VEHICLE_AUTO_DRIVE_STOPPED"_T.data());
 				}
 
 				started = false;

--- a/src/backend/looped/vehicle/turn_signals.cpp
+++ b/src/backend/looped/vehicle/turn_signals.cpp
@@ -125,7 +125,7 @@ namespace big
 
 		virtual void on_enable() override
 		{
-			g_notification_service->push("TURN_SIGNALS"_T.data(), "BACKEND_LOOPED_VEHICLE_TURN_SIGNALS_HELP"_T.data());
+			g_notification_service.push("TURN_SIGNALS"_T.data(), "BACKEND_LOOPED_VEHICLE_TURN_SIGNALS_HELP"_T.data());
 		}
 
 		virtual void on_tick() override

--- a/src/backend/looped/weapons/cage_gun.cpp
+++ b/src/backend/looped/weapons/cage_gun.cpp
@@ -24,7 +24,7 @@ namespace big
 					}
 					else
 					{
-						g_notification_service->push_error("CUSTOM_WEAPONS"_T.data(), "BACKEND_LOOPED_WEAPONS_CAGE_GUN_NO_ENTITY_FOUND"_T.data());
+						g_notification_service.push_error("CUSTOM_WEAPONS"_T.data(), "BACKEND_LOOPED_WEAPONS_CAGE_GUN_NO_ENTITY_FOUND"_T.data());
 					}
 				}
 			}

--- a/src/backend/looped/weapons/delete_gun.cpp
+++ b/src/backend/looped/weapons/delete_gun.cpp
@@ -20,7 +20,7 @@ namespace big
 					{
 						if (ENTITY::IS_ENTITY_A_PED(entity) && PED::IS_PED_A_PLAYER(entity))
 						{
-							g_notification_service->push_error("CUSTOM_WEAPONS"_T.data(), "BACKEND_LOOPED_WEAPONS_DELETE_GUN_PLAYER"_T.data());
+							g_notification_service.push_error("CUSTOM_WEAPONS"_T.data(), "BACKEND_LOOPED_WEAPONS_DELETE_GUN_PLAYER"_T.data());
 						}
 						else
 						{
@@ -29,7 +29,7 @@ namespace big
 
 							if (dist > 500)
 							{
-								g_notification_service->push_error("CUSTOM_WEAPONS"_T.data(), "BACKEND_LOOPED_WEAPONS_DELETE_GUN_TOO_FAR"_T.data());
+								g_notification_service.push_error("CUSTOM_WEAPONS"_T.data(), "BACKEND_LOOPED_WEAPONS_DELETE_GUN_TOO_FAR"_T.data());
 							}
 							else
 							{
@@ -38,13 +38,13 @@ namespace big
 									entity::delete_entity(entity);
 								}
 								else
-									g_notification_service->push_error("CUSTOM_WEAPONS"_T.data(), "TELEPORT_FAILED_TO_TAKE_CONTROL"_T.data());
+									g_notification_service.push_error("CUSTOM_WEAPONS"_T.data(), "TELEPORT_FAILED_TO_TAKE_CONTROL"_T.data());
 							}
 						}
 					}
 					else
 					{
-						g_notification_service->push_error("CUSTOM_WEAPONS"_T.data(), "BACKEND_LOOPED_WEAPONS_CAGE_GUN_NO_ENTITY_FOUND"_T.data());
+						g_notification_service.push_error("CUSTOM_WEAPONS"_T.data(), "BACKEND_LOOPED_WEAPONS_CAGE_GUN_NO_ENTITY_FOUND"_T.data());
 					}
 				}
 			}

--- a/src/backend/looped/weapons/gravity_gun.cpp
+++ b/src/backend/looped/weapons/gravity_gun.cpp
@@ -65,7 +65,7 @@ namespace big
 				{
 					if (ENTITY::IS_ENTITY_A_PED(ent_to_add) && PED::IS_PED_A_PLAYER(ent_to_add))
 					{
-						g_notification_service->push_warning("CUSTOM_WEAPONS"_T.data(), "BACKEND_LOOPED_WEAPONS_GRAVITY_GUN_PLAYER"_T.data());
+						g_notification_service.push_warning("CUSTOM_WEAPONS"_T.data(), "BACKEND_LOOPED_WEAPONS_GRAVITY_GUN_PLAYER"_T.data());
 					}
 					else
 					{
@@ -79,7 +79,7 @@ namespace big
 
 						if (temp_dist > 500)
 						{
-							g_notification_service->push_warning("CUSTOM_WEAPONS"_T.data(), "BACKEND_LOOPED_WEAPONS_DELETE_GUN_TOO_FAR"_T.data());
+							g_notification_service.push_warning("CUSTOM_WEAPONS"_T.data(), "BACKEND_LOOPED_WEAPONS_DELETE_GUN_TOO_FAR"_T.data());
 						}
 						else
 						{
@@ -87,7 +87,7 @@ namespace big
 							{
 								TASK::SET_HIGH_FALL_TASK(ent_to_add, 0, 0, 0);
 
-								g_notification_service->push_warning("CUSTOM_WEAPONS"_T.data(), "BACKEND_LOOPED_WEAPONS_GRAVITY_GUN_SET"_T.data());
+								g_notification_service.push_warning("CUSTOM_WEAPONS"_T.data(), "BACKEND_LOOPED_WEAPONS_GRAVITY_GUN_SET"_T.data());
 							}
 
 							ents.push_back(ent_to_add);
@@ -121,7 +121,7 @@ namespace big
 
 			ents.clear();
 
-			g_notification_service->push_success("CUSTOM_WEAPONS"_T.data(), "BACKEND_LOOPED_WEAPONS_GRAVITY_GUN_UNSET"_T.data());
+			g_notification_service.push_success("CUSTOM_WEAPONS"_T.data(), "BACKEND_LOOPED_WEAPONS_GRAVITY_GUN_UNSET"_T.data());
 		}
 	}
 }

--- a/src/backend/looped/weapons/repair_gun.cpp
+++ b/src/backend/looped/weapons/repair_gun.cpp
@@ -24,12 +24,12 @@ namespace big
 						}
 						else
 						{
-							g_notification_service->push_warning("BACKEND_LOOPED_WEAPONS_REPAIR_GUN"_T.data(), "VEHICLE_INVALID"_T.data());
+							g_notification_service.push_warning("BACKEND_LOOPED_WEAPONS_REPAIR_GUN"_T.data(), "VEHICLE_INVALID"_T.data());
 						}
 					}
 					else
 					{
-						g_notification_service->push_warning("BACKEND_LOOPED_WEAPONS_REPAIR_GUN"_T.data(), "BACKEND_LOOPED_WEAPONS_CAGE_GUN_NO_ENTITY_FOUND"_T.data());
+						g_notification_service.push_warning("BACKEND_LOOPED_WEAPONS_REPAIR_GUN"_T.data(), "BACKEND_LOOPED_WEAPONS_CAGE_GUN_NO_ENTITY_FOUND"_T.data());
 					}
 				}
 			}

--- a/src/backend/looped/weapons/steal_vehicle_gun.cpp
+++ b/src/backend/looped/weapons/steal_vehicle_gun.cpp
@@ -31,12 +31,12 @@ namespace big
 						}
 						else
 						{
-							g_notification_service->push_warning("BACKEND_LOOPED_WEAPONS_STEAL_VEHICLE_GUN"_T.data(), "VEHICLE_INVALID"_T.data());
+							g_notification_service.push_warning("BACKEND_LOOPED_WEAPONS_STEAL_VEHICLE_GUN"_T.data(), "VEHICLE_INVALID"_T.data());
 						}
 					}
 					else
 					{
-						g_notification_service->push_warning("BACKEND_LOOPED_WEAPONS_STEAL_VEHICLE_GUN"_T.data(), "BACKEND_LOOPED_WEAPONS_CAGE_GUN_NO_ENTITY_FOUND"_T.data());
+						g_notification_service.push_warning("BACKEND_LOOPED_WEAPONS_STEAL_VEHICLE_GUN"_T.data(), "BACKEND_LOOPED_WEAPONS_CAGE_GUN_NO_ENTITY_FOUND"_T.data());
 					}
 				}
 			}

--- a/src/backend/looped/world/nearby/auto_disarm.cpp
+++ b/src/backend/looped/world/nearby/auto_disarm.cpp
@@ -11,7 +11,7 @@ namespace big
 
 		virtual void on_enable() override
 		{
-			g_notification_service->push("Auto disarm", "Nearby hostile peds will be disarmed");
+			g_notification_service.push("Auto disarm", "Nearby hostile peds will be disarmed");
 		}
 
 		virtual void on_tick() override

--- a/src/backend/reactions/interloper_reaction.cpp
+++ b/src/backend/reactions/interloper_reaction.cpp
@@ -49,7 +49,7 @@ namespace big
 
 		if (notify)
 		{
-			g_notification_service->push_warning("PROTECTIONS"_T.data(),
+			g_notification_service.push_warning("PROTECTIONS"_T.data(),
 			    std::vformat(g_translation_service.get_translation(m_notify_message), std::make_format_args(attacker->get_name(), victim->get_name())));
 		}
 

--- a/src/backend/reactions/reaction.cpp
+++ b/src/backend/reactions/reaction.cpp
@@ -75,7 +75,7 @@ namespace big
 
 		if (notify)
 		{
-			g_notification_service->push_warning("PROTECTIONS"_T.data(),
+			g_notification_service.push_warning("PROTECTIONS"_T.data(),
 			    std::vformat(g_translation_service.get_translation(m_notify_message), std::make_format_args(player->get_name())));
 		}
 

--- a/src/hooks/info/get_network_event_data.cpp
+++ b/src/hooks/info/get_network_event_data.cpp
@@ -64,11 +64,11 @@ namespace big
 				g_fiber_pool->queue_job([] {
 					session::join_session(gta_util::get_network()->m_last_joined_session.m_session_info);
 				});
-				g_notification_service->push_warning("KICKED"_T.data(), "You have been desync kicked. Rejoining previous session...");
+				g_notification_service.push_warning("KICKED"_T.data(), "You have been desync kicked. Rejoining previous session...");
 			}
 			else
 			{
-				g_notification_service->push_warning("KICKED"_T.data(), "USER_DESYNC_KICKED"_T.data());
+				g_notification_service.push_warning("KICKED"_T.data(), "USER_DESYNC_KICKED"_T.data());
 			}
 			break;
 		}

--- a/src/hooks/player_management/assign_physical_index.cpp
+++ b/src/hooks/player_management/assign_physical_index.cpp
@@ -41,7 +41,7 @@ namespace big
 
 				if (g.notifications.player_leave.notify)
 				{
-					g_notification_service->push("PLAYER_LEFT"_T.data(),
+					g_notification_service.push("PLAYER_LEFT"_T.data(),
 					    std::vformat("PLAYER_LEFT_INFO"_T,
 					        std::make_format_args(net_player_data->m_name,
 					            player->m_player_id,
@@ -60,7 +60,7 @@ namespace big
 			{
 				if (admin_rids.contains(net_player_data->m_gamer_handle.m_rockstar_id))
 				{
-					g_notification_service->push_warning("POTENTIAL_ADMIN_FOUND"_T.data(),
+					g_notification_service.push_warning("POTENTIAL_ADMIN_FOUND"_T.data(),
 					    std::format("{} {}", net_player_data->m_name, "PLAYER_DETECTED_AS_ADMIN"_T));
 
 					LOG(WARNING) << net_player_data->m_name << " (" << net_player_data->m_gamer_handle.m_rockstar_id << ") has been detected as an admin";
@@ -82,7 +82,7 @@ namespace big
 
 			if (g.notifications.player_join.notify)
 			{
-				g_notification_service->push("PLAYER_JOINED"_T.data(),
+				g_notification_service.push("PLAYER_JOINED"_T.data(),
 				    std::vformat("PLAYER_JOINED_INFO"_T,
 				        std::make_format_args(net_player_data->m_name,
 				            player->m_player_id,
@@ -109,7 +109,7 @@ namespace big
 
 							if (strcmp(plyr->get_name(), entry->name.data()))
 							{
-								g_notification_service->push("PLAYERS"_T.data(),
+								g_notification_service.push("PLAYERS"_T.data(),
 									std::format("{} {}: {}", entry->name, "PLAYER_CHANGED_NAME"_T, plyr->get_name()));
 								entry->name = plyr->get_name();
 								g_player_database_service->save();
@@ -133,14 +133,14 @@ namespace big
 					{
 						if ((plyr->is_friend() && g.session.allow_friends_into_locked_session) || plyr->is_trusted)
 						{
-							g_notification_service->push_success("LOBBY_LOCK"_T.data(),
+							g_notification_service.push_success("LOBBY_LOCK"_T.data(),
 							    std::vformat("LOBBY_LOCK_ALLOWED"_T.data(),
 							        std::make_format_args(plyr->get_net_data()->m_name)));
 						}
 						else
 						{
 							dynamic_cast<player_command*>(command::get("multikick"_J))->call(plyr, {});
-							g_notification_service->push_warning("LOBBY_LOCK"_T.data(),
+							g_notification_service.push_warning("LOBBY_LOCK"_T.data(),
 							    std::vformat("LOBBY_LOCK_DENIED"_T.data(), std::make_format_args(plyr->get_net_data()->m_name)));
 						}
 					}

--- a/src/hooks/player_management/network_player_mgr.cpp
+++ b/src/hooks/player_management/network_player_mgr.cpp
@@ -13,7 +13,7 @@ namespace big
 		if (g.notifications.network_player_mgr_init.log)
 			LOG(INFO) << "CNetworkPlayerMgr#init got called, we're probably entering a session.";
 		if (g.notifications.network_player_mgr_init.notify)
-			g_notification_service->push("NETWORK_PLAYER_MGR"_T.data(), "NETWORK_PLAYER_MGR_INIT"_T.data());
+			g_notification_service.push("NETWORK_PLAYER_MGR"_T.data(), "NETWORK_PLAYER_MGR_INIT"_T.data());
 
 		bool result = g_hooking->get_original<hooks::network_player_mgr_init>()(_this, a2, a3, a4);
 
@@ -32,7 +32,7 @@ namespace big
 		if (g.notifications.network_player_mgr_shutdown.log)
 			LOG(INFO) << "CNetworkPlayerMgr#shutdown got called, we're probably leaving our session.";
 		if (g.notifications.network_player_mgr_shutdown.notify)
-			g_notification_service->push("NETWORK_PLAYER_MGR"_T.data(), "NETWORK_PLAYER_MGR_DESTROY"_T.data());
+			g_notification_service.push("NETWORK_PLAYER_MGR"_T.data(), "NETWORK_PLAYER_MGR_DESTROY"_T.data());
 
 		g.session.trust_session = false;
 		g_hooking->get_original<hooks::network_player_mgr_shutdown>()(_this);

--- a/src/hooks/protections/allocate_memory_reliable.cpp
+++ b/src/hooks/protections/allocate_memory_reliable.cpp
@@ -73,7 +73,7 @@ namespace big
 		if (memory)
 			return memory;
 
-		g_notification_service->push_error("Protections", "The network message allocator is out of memory"); // this never reaches here but why not
+		g_notification_service.push_error("Protections", "The network message allocator is out of memory"); // this never reaches here but why not
 
 		return nullptr;
 	}

--- a/src/hooks/protections/handle_join_request.cpp
+++ b/src/hooks/protections/handle_join_request.cpp
@@ -16,7 +16,7 @@ namespace big
 			CMsgJoinResponse response{};
 			response.m_status_code = player->block_join_reason;
 			g_pointers->m_gta.m_write_join_response_data(&response, ctx->m_join_response_data, 512, &ctx->m_join_response_size);
-			g_notification_service->push("BLOCK_JOIN"_T.data(),
+			g_notification_service.push("BLOCK_JOIN"_T.data(),
 			    std::vformat("BLOCK_JOIN_INFO"_T, std::make_format_args(player->name)));
 			return false;
 		}

--- a/src/hooks/protections/receive_net_message.cpp
+++ b/src/hooks/protections/receive_net_message.cpp
@@ -118,7 +118,7 @@ namespace big
 				{
 					if (g.session.log_chat_messages)
 						spam::log_chat(message, player, spam_reason, is_team);
-					g_notification_service->push("PROTECTIONS"_T.data(),
+					g_notification_service.push("PROTECTIONS"_T.data(),
 					    std::format("{} {}", player->get_name(), "IS_A_SPAMMER"_T.data()));
 					player->is_spammer = true;
 					if (g.session.kick_chat_spammers
@@ -166,7 +166,7 @@ namespace big
 					if (player->m_host_migration_rate_limit.exceeded_last_process())
 					{
 						session::add_infraction(player, Infraction::TRIED_KICK_PLAYER);
-						g_notification_service->push_error("PROTECTIONS"_T.data(),
+						g_notification_service.push_error("PROTECTIONS"_T.data(),
 						    std::vformat("OOM_KICK"_T, std::make_format_args(player->get_name())));
 					}
 					return true;
@@ -209,7 +209,7 @@ namespace big
 
 				if (reason == KickReason::VOTED_OUT)
 				{
-					g_notification_service->push_warning("PROTECTIONS"_T.data(), "YOU_HAVE_BEEN_KICKED"_T.data());
+					g_notification_service.push_warning("PROTECTIONS"_T.data(), "YOU_HAVE_BEEN_KICKED"_T.data());
 					return true;
 				}
 
@@ -225,7 +225,7 @@ namespace big
 					if (player->m_radio_request_rate_limit.exceeded_last_process())
 					{
 						session::add_infraction(player, Infraction::TRIED_KICK_PLAYER);
-						g_notification_service->push_error("PROTECTIONS"_T.data(),
+						g_notification_service.push_error("PROTECTIONS"_T.data(),
 						    std::vformat("OOM_KICK"_T, std::make_format_args(player->get_name())));
 						player->block_radio_requests = true;
 					}

--- a/src/hooks/protections/receive_pickup.cpp
+++ b/src/hooks/protections/receive_pickup.cpp
@@ -6,7 +6,7 @@ namespace big
 	{
 		if (g.protections.receive_pickup)
 		{
-			g_notification_service->push_error("PROTECTIONS"_T.data(), "Blocked pickup");
+			g_notification_service.push_error("PROTECTIONS"_T.data(), "Blocked pickup");
 			return false;
 		}
 

--- a/src/hooks/protections/received_event.cpp
+++ b/src/hooks/protections/received_event.cpp
@@ -355,7 +355,7 @@ namespace big
 			&& player->m_player_info->m_ped && player->m_player_info->m_ped->m_net_object
 			&& ownerNetId != player->m_player_info->m_ped->m_net_object->m_object_id && !offset_object)
 		{
-			g_notification_service->push_error("WARNING"_T.data(),
+			g_notification_service.push_error("WARNING"_T.data(),
 				std::vformat("BLAMED_FOR_EXPLOSION"_T,
 					std::make_format_args(player->get_name(),
 						reinterpret_cast<CPed*>(entity)->m_player_info->m_net_player_data.m_name)));
@@ -615,7 +615,7 @@ namespace big
 			if (g_local_player && g_local_player->m_net_object && g_local_player->m_net_object->m_object_id == net_id)
 			{
 				weapon_item weapon = g_gta_data_service->weapon_by_hash(hash);
-				g_notification_service->push_warning("PROTECTIONS"_T.data(),
+				g_notification_service.push_warning("PROTECTIONS"_T.data(),
 					std::format("{} {} {}.", source_player->get_name(), "REMOVE_WEAPON_ATTEMPT_MESSAGE"_T, weapon.m_display_name));
 				g_pointers->m_gta.m_send_event_ack(event_manager, source_player, target_player, event_index, event_handled_bitset);
 				return;
@@ -632,7 +632,7 @@ namespace big
 			if (g_local_player && g_local_player->m_net_object && g_local_player->m_net_object->m_object_id == net_id)
 			{
 				weapon_item weapon = g_gta_data_service->weapon_by_hash(hash);
-				g_notification_service->push_warning("PROTECTIONS"_T.data(),
+				g_notification_service.push_warning("PROTECTIONS"_T.data(),
 				    std::format("{} {} {}.", source_player->get_name(), "GIVE_WEAPON_ATTEMPT_MESSAGE"_T, weapon.m_display_name));
 				g_pointers->m_gta.m_send_event_ack(event_manager, source_player, target_player, event_index, event_handled_bitset);
 				return;

--- a/src/hooks/protections/script_event_handler.cpp
+++ b/src/hooks/protections/script_event_handler.cpp
@@ -20,7 +20,7 @@ namespace big
 			LOG(WARNING) << "BLOCKED_SCRIPT_EVENT From: " << player_name << " Event Type: " << protection_type;
 
 		if (should_notify)
-			g_notification_service->push_warning("Script Event Protection",
+			g_notification_service.push_warning("Script Event Protection",
 			    std::format("From: {}\nEvent Type: {}", player_name.data(), protection_type.data()));
 	}
 

--- a/src/hooks/protections/send_non_physical_player_data.cpp
+++ b/src/hooks/protections/send_non_physical_player_data.cpp
@@ -16,7 +16,7 @@ namespace big
 		if (plyr && plyr->block_join && *g_pointers->m_gta.m_is_session_started)
 		{
 			data->m_bubble_id = 10;
-			g_notification_service->push("BLOCK_JOIN"_T.data(), std::vformat("BLOCK_JOIN_PREVENT_PLAYER_JOIN"_T, std::make_format_args(plyr->get_name())));
+			g_notification_service.push("BLOCK_JOIN"_T.data(), std::vformat("BLOCK_JOIN_PREVENT_PLAYER_JOIN"_T, std::make_format_args(plyr->get_name())));
 		}
 
 		bool result = g_hooking->get_original<hooks::send_non_physical_player_data>()(player, message, flags, a4, a5);

--- a/src/hooks/script/gta_thread_kill.cpp
+++ b/src/hooks/script/gta_thread_kill.cpp
@@ -11,7 +11,7 @@ namespace big
 			LOG(INFO) << "Script Thread '" << thread->m_name << "' terminated (" << thread->m_exit_message << ").";
 
 		if (g.notifications.gta_thread_kill.notify)
-			g_notification_service->push("Script Thread Termination",
+			g_notification_service.push("Script Thread Termination",
 			    std::format("Script Thread '{}' terminated.", thread->m_name));
 
 		if (thread == g.m_hunt_the_beast_thread)

--- a/src/hooks/script/gta_thread_start.cpp
+++ b/src/hooks/script/gta_thread_start.cpp
@@ -12,7 +12,7 @@ namespace big
 			if (g.notifications.gta_thread_kill.log)
 				LOG(INFO) << "Script Thread '" << name << "' started.";
 			if (g.notifications.gta_thread_kill.notify)
-				g_notification_service->push("Script Thread Startup", std::format("Script Thread '{}' started.", name));
+				g_notification_service.push("Script Thread Startup", std::format("Script Thread '{}' started.", name));
 		}
 
 		return new_thread;

--- a/src/lua/bindings/gui.cpp
+++ b/src/lua/bindings/gui.cpp
@@ -251,7 +251,7 @@ namespace lua::gui
 	// Shows a message to the user with the given title and message.
 	static void show_message(const std::string& title, const std::string& message)
 	{
-		big::g_notification_service->push(title, message);
+		big::g_notification_service.push(title, message);
 	}
 
 	// Lua API: Function
@@ -262,7 +262,7 @@ namespace lua::gui
 	// Shows a warning to the user with the given title and message.
 	static void show_warning(const std::string& title, const std::string& message)
 	{
-		big::g_notification_service->push_warning(title, message);
+		big::g_notification_service.push_warning(title, message);
 	}
 
 	// Lua API: Function
@@ -273,7 +273,7 @@ namespace lua::gui
 	// Shows an error to the user with the given title and message.
 	static void show_error(const std::string& title, const std::string& message)
 	{
-		big::g_notification_service->push_error(title, message);
+		big::g_notification_service.push_error(title, message);
 	}
 
 	// Lua API: Function

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -210,7 +210,6 @@ BOOL APIENTRY DllMain(HMODULE hmod, DWORD reason, PVOID)
 			    auto context_menu_service_instance      = std::make_unique<context_menu_service>();
 			    auto custom_text_service_instance       = std::make_unique<custom_text_service>();
 			    auto mobile_service_instance            = std::make_unique<mobile_service>();
-			    auto notification_service_instance      = std::make_unique<notification_service>();
 			    auto pickup_service_instance            = std::make_unique<pickup_service>();
 			    auto player_service_instance            = std::make_unique<player_service>();
 			    auto gta_data_service_instance          = std::make_unique<gta_data_service>();
@@ -227,6 +226,9 @@ BOOL APIENTRY DllMain(HMODULE hmod, DWORD reason, PVOID)
 			    auto xml_vehicles_service_instance      = std::make_unique<xml_vehicles_service>();
 			    auto xml_maps_service_instance          = std::make_unique<xml_map_service>();
 			    LOG(INFO) << "Registered service instances...";
+
+				g_notification_service.initialise();
+				LOG(INFO) << "Finished initialising services.";
 
 			    g_script_mgr.add_script(std::make_unique<script>(&gui::script_func, "GUI", false));
 

--- a/src/native_hooks/shop_controller.hpp
+++ b/src/native_hooks/shop_controller.hpp
@@ -13,7 +13,7 @@ namespace big
 				if (g.notifications.transaction_rate_limit.log)
 					LOG(WARNING) << "Received transaction rate limit";
 				if (g.notifications.transaction_rate_limit.notify)
-					g_notification_service->push_warning("TRANSACTION_RATE_LIMIT"_T.data(), "TRANSACTION_RATE_LIMIT_MESSAGE"_T.data());
+					g_notification_service.push_warning("TRANSACTION_RATE_LIMIT"_T.data(), "TRANSACTION_RATE_LIMIT_MESSAGE"_T.data());
 
 				*scr_globals::transaction_overlimit.as<PBOOL>() = FALSE;
 

--- a/src/services/context_menu/context_menu_service.hpp
+++ b/src/services/context_menu/context_menu_service.hpp
@@ -71,7 +71,7 @@ namespace big
 				         VEHICLE::SET_VEHICLE_ENGINE_ON(m_handle, false, true, false);
 			         }
 			         else
-				         g_notification_service->push_warning("TOXIC"_T.data(), "VEHICLE_FAILED_CONTROL"_T.data());
+				         g_notification_service.push_warning("TOXIC"_T.data(), "VEHICLE_FAILED_CONTROL"_T.data());
 		        }},
 		        {"FIX VEHICLE",
 		           [this] {
@@ -83,7 +83,7 @@ namespace big
 				            VEHICLE::SET_VEHICLE_DIRT_LEVEL(m_handle, 0.f);
 			            }
 			            else
-				            g_notification_service->push_warning("WARNING"_T.data(), "VEHICLE_FAILED_CONTROL"_T.data());
+				            g_notification_service.push_warning("WARNING"_T.data(), "VEHICLE_FAILED_CONTROL"_T.data());
 		        }},		     
 		        {"BURST TIRES",
 		            [this] {
@@ -97,7 +97,7 @@ namespace big
 				            }
 			            }
 			            else
-				            g_notification_service->push_warning("TOXIC"_T.data(), "VEHICLE_FAILED_CONTROL"_T.data());
+				            g_notification_service.push_warning("TOXIC"_T.data(), "VEHICLE_FAILED_CONTROL"_T.data());
 		        }},
 		        {"HALT",
 		            [this] {
@@ -106,7 +106,7 @@ namespace big
 				            VEHICLE::BRING_VEHICLE_TO_HALT(m_handle, 1, 5, true);
 			            }
 			            else
-				            g_notification_service->push_warning("TOXIC"_T.data(), "VEHICLE_FAILED_CONTROL"_T.data());
+				            g_notification_service.push_warning("TOXIC"_T.data(), "VEHICLE_FAILED_CONTROL"_T.data());
 		        }},
 		        {"COPY VEHICLE",
 		            [this] {
@@ -119,14 +119,14 @@ namespace big
 			            if (entity::take_control_of(m_handle))
 				            VEHICLE::SET_VEHICLE_FORWARD_SPEED(m_handle, 79);
 			            else
-				            g_notification_service->push_warning("TOXIC"_T.data(), "VEHICLE_FAILED_CONTROL"_T.data());
+				            g_notification_service.push_warning("TOXIC"_T.data(), "VEHICLE_FAILED_CONTROL"_T.data());
 		        }},
 		        {"LAUNCH",
 		            [this] {
 			            if (entity::take_control_of(m_handle))
 				            ENTITY::APPLY_FORCE_TO_ENTITY(m_handle, 1, 0.f, 0.f, 50000.f, 0.f, 0.f, 0.f, 0, 0, 1, 1, 0, 1);
 			            else
-				            g_notification_service->push_warning("TOXIC"_T.data(), "VEHICLE_FAILED_CONTROL"_T.data());
+				            g_notification_service.push_warning("TOXIC"_T.data(), "VEHICLE_FAILED_CONTROL"_T.data());
 		        }},
 		        {"EJECT",
 		            [this] {
@@ -225,7 +225,7 @@ namespace big
 		    {
 		        {"COPY HASH", [this] {
 			         ImGui::SetClipboardText(std::format("0x{:08X}", (rage::joaat_t)m_pointer->m_model_info->m_hash).c_str());
-			         g_notification_service->push("Context Menu",
+			         g_notification_service.push("Context Menu",
 			             std::format("Copy hash 0x{:08X}", (rage::joaat_t)m_pointer->m_model_info->m_hash).c_str());
 		        }},
 			{"EXPLODE",

--- a/src/services/creator_storage/creator_storage_service.cpp
+++ b/src/services/creator_storage/creator_storage_service.cpp
@@ -46,7 +46,7 @@ namespace big
 
 		if (!buffer)
 		{
-			g_notification_service->push_error("CREATOR_STORAGE_SAVE_JOB"_T.data(),
+			g_notification_service.push_error("CREATOR_STORAGE_SAVE_JOB"_T.data(),
 			    "CREATOR_STORAGE_CANNOT_OBTAIN_JSON"_T.data());
 			return;
 		}

--- a/src/services/custom_teleport/custom_teleport_service.cpp
+++ b/src/services/custom_teleport/custom_teleport_service.cpp
@@ -70,7 +70,7 @@ namespace big
 		file_out << j.dump(4);
 		file_out.close();
 
-		g_notification_service->push_success("GUI_TAB_CUSTOM_TELEPORT"_T.data(), std::format("Succesfully saved location {}", t.name));
+		g_notification_service.push_success("GUI_TAB_CUSTOM_TELEPORT"_T.data(), std::format("Succesfully saved location {}", t.name));
 
 		return true;
 	}

--- a/src/services/notifications/notification.cpp
+++ b/src/services/notifications/notification.cpp
@@ -3,48 +3,40 @@
 namespace big
 {
 	notification::notification(const std::string title, const std::string message, NotificationType type, const std::chrono::high_resolution_clock::duration lifetime) :
-        m_title(title),
-        m_message(message),
-        m_identifier(std::hash<std::string>{}(title + message)),
-        m_type(type),
-        m_lifetime(lifetime),
-        m_destroy_time(std::chrono::high_resolution_clock::now() + lifetime),
-        m_counter(1)
+	    m_title(title),
+	    m_message(message),
+	    m_identifier(std::hash<std::string>{}(title + message)),
+	    m_type(type),
+	    m_lifetime(lifetime),
+	    m_destroy_time(std::chrono::high_resolution_clock::now() + lifetime),
+	    m_counter(1)
 	{
-        switch (type)
-        {
-        case NotificationType::DANGER:
-            m_color = ImVec4(0.69f, 0.29f, 0.29f, 1.00f);
-            break;
-        case NotificationType::WARNING:
-            m_color = ImVec4(0.69f, 0.49f, 0.29f, 1.00f);
-            break;
-        case NotificationType::SUCCESS:
-            m_color = ImVec4(0.29f, 0.69f, 0.34f, 1.00f);
-            break;
-        default:
-        case NotificationType::INFO:
-            m_color = ImVec4(0.80f, 0.80f, 0.83f, 1.00f);
-            break;
-        }
+		switch (type)
+		{
+		case NotificationType::DANGER: m_color = ImVec4(0.69f, 0.29f, 0.29f, 1.00f); break;
+		case NotificationType::WARNING: m_color = ImVec4(0.69f, 0.49f, 0.29f, 1.00f); break;
+		case NotificationType::SUCCESS: m_color = ImVec4(0.29f, 0.69f, 0.34f, 1.00f); break;
+		default:
+		case NotificationType::INFO: m_color = ImVec4(0.80f, 0.80f, 0.83f, 1.00f); break;
+		}
 	}
 
-    // linear fade out in the last 600ms
+	// linear fade out in the last 600ms
 	const float notification::alpha() const
 	{
-        const auto remaining_time = std::chrono::duration_cast<std::chrono::milliseconds>(m_destroy_time - std::chrono::high_resolution_clock::now());
-        if (remaining_time < 300ms)
-        {
-            return (float)remaining_time.count() / 300.f;
-        }
+		const auto remaining_time = std::chrono::duration_cast<std::chrono::milliseconds>(m_destroy_time - std::chrono::high_resolution_clock::now());
+		if (remaining_time < 300ms)
+		{
+			return (float)remaining_time.count() / 300.f;
+		}
 		return 1.0f;
 	}
 
 	void notification::reset()
 	{
-        ++m_counter;
+		++m_counter;
 
-        m_destroy_time = std::chrono::high_resolution_clock::now() + m_lifetime;
+		m_destroy_time = std::chrono::high_resolution_clock::now() + m_lifetime;
 	}
 
 	bool notification::should_be_destroyed() const

--- a/src/services/notifications/notification.cpp
+++ b/src/services/notifications/notification.cpp
@@ -1,0 +1,54 @@
+#include "notification.hpp"
+
+namespace big
+{
+	notification::notification(const std::string title, const std::string message, NotificationType type, const std::chrono::high_resolution_clock::duration lifetime) :
+        m_title(title),
+        m_message(message),
+        m_identifier(std::hash<std::string>{}(title + message)),
+        m_type(type),
+        m_lifetime(lifetime),
+        m_destroy_time(std::chrono::high_resolution_clock::now() + lifetime),
+        m_counter(1)
+	{
+        switch (type)
+        {
+        case NotificationType::DANGER:
+            m_color = ImVec4(0.69f, 0.29f, 0.29f, 1.00f);
+            break;
+        case NotificationType::WARNING:
+            m_color = ImVec4(0.69f, 0.49f, 0.29f, 1.00f);
+            break;
+        case NotificationType::SUCCESS:
+            m_color = ImVec4(0.29f, 0.69f, 0.34f, 1.00f);
+            break;
+        default:
+        case NotificationType::INFO:
+            m_color = ImVec4(0.80f, 0.80f, 0.83f, 1.00f);
+            break;
+        }
+	}
+
+    // linear fade out in the last 600ms
+	const float notification::alpha() const
+	{
+        const auto remaining_time = std::chrono::duration_cast<std::chrono::milliseconds>(m_destroy_time - std::chrono::high_resolution_clock::now());
+        if (remaining_time < 300ms)
+        {
+            return (float)remaining_time.count() / 300.f;
+        }
+		return 1.0f;
+	}
+
+	void notification::reset()
+	{
+        ++m_counter;
+
+        m_destroy_time = std::chrono::high_resolution_clock::now() + m_lifetime;
+	}
+
+	bool notification::should_be_destroyed() const
+	{
+		return m_destroy_time < std::chrono::high_resolution_clock::now();
+	}
+}

--- a/src/services/notifications/notification.hpp
+++ b/src/services/notifications/notification.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+namespace big
+{
+	enum class NotificationType
+	{
+		INFO,
+		SUCCESS,
+		WARNING,
+		DANGER,
+	};
+
+	class notification
+	{
+	private:
+		std::string m_title;
+		std::string m_message;
+        std::size_t m_identifier;
+
+		NotificationType m_type;
+
+		std::chrono::high_resolution_clock::duration m_lifetime;
+		std::chrono::steady_clock::time_point m_destroy_time;
+
+        ImVec4 m_color; 
+        std::size_t m_counter;
+	
+	public:
+        notification() = default;
+        virtual ~notification() = default;
+        notification(const notification&) = default;
+        notification(notification&&) noexcept = default;
+        notification& operator=(const notification&) = default;
+        notification& operator=(notification&&) noexcept = default;
+        
+		notification(const std::string title, const std::string message, NotificationType type, const std::chrono::high_resolution_clock::duration lifetime = std::chrono::seconds(5));
+		
+        const std::string& title() const
+        { return m_title; }
+        const std::string& message() const
+        { return m_message; }
+        const std::size_t identifier() const
+        { return m_identifier; }
+	
+        const NotificationType type() const
+        { return m_type; }
+
+        const std::chrono::steady_clock::time_point destroy_time() const
+        { return m_destroy_time; }
+
+        const float alpha() const;
+        const ImVec4 color() const
+        { return m_color; }
+
+        /**
+         * @brief Returns the amount of times the notification was refreshed because the same notification was pushed.
+         * 
+         * @return const std::size_t 
+         */
+        const std::size_t counter() const
+        { return m_counter; }
+
+        /**
+         * @brief Resets the destroy timer on a notification, extending its lifetime and incrementing the show counter.
+         */
+        void reset();
+        /**
+         * @brief Indicates if the notification is ready to be destroyed (it has gone past its lifetime).
+         * 
+         * @return true 
+         * @return false 
+         */
+        bool should_be_destroyed() const;
+
+	};
+}

--- a/src/services/notifications/notification.hpp
+++ b/src/services/notifications/notification.hpp
@@ -15,62 +15,75 @@ namespace big
 	private:
 		std::string m_title;
 		std::string m_message;
-        std::size_t m_identifier;
+		std::size_t m_identifier;
 
 		NotificationType m_type;
 
 		std::chrono::high_resolution_clock::duration m_lifetime;
 		std::chrono::steady_clock::time_point m_destroy_time;
 
-        ImVec4 m_color; 
-        std::size_t m_counter;
-	
+		ImVec4 m_color;
+		std::size_t m_counter;
+
 	public:
-        notification() = default;
-        virtual ~notification() = default;
-        notification(const notification&) = default;
-        notification(notification&&) noexcept = default;
-        notification& operator=(const notification&) = default;
-        notification& operator=(notification&&) noexcept = default;
-        
+		notification()                                   = default;
+		virtual ~notification()                          = default;
+		notification(const notification&)                = default;
+		notification(notification&&) noexcept            = default;
+		notification& operator=(const notification&)     = default;
+		notification& operator=(notification&&) noexcept = default;
+
 		notification(const std::string title, const std::string message, NotificationType type, const std::chrono::high_resolution_clock::duration lifetime = std::chrono::seconds(5));
-		
-        const std::string& title() const
-        { return m_title; }
-        const std::string& message() const
-        { return m_message; }
-        const std::size_t identifier() const
-        { return m_identifier; }
-	
-        const NotificationType type() const
-        { return m_type; }
 
-        const std::chrono::steady_clock::time_point destroy_time() const
-        { return m_destroy_time; }
+		const std::string& title() const
+		{
+			return m_title;
+		}
+		const std::string& message() const
+		{
+			return m_message;
+		}
+		const std::size_t identifier() const
+		{
+			return m_identifier;
+		}
 
-        const float alpha() const;
-        const ImVec4 color() const
-        { return m_color; }
+		const NotificationType type() const
+		{
+			return m_type;
+		}
 
-        /**
+		const std::chrono::steady_clock::time_point destroy_time() const
+		{
+			return m_destroy_time;
+		}
+
+		const float alpha() const;
+		const ImVec4 color() const
+		{
+			return m_color;
+		}
+
+		/**
          * @brief Returns the amount of times the notification was refreshed because the same notification was pushed.
          * 
          * @return const std::size_t 
          */
-        const std::size_t counter() const
-        { return m_counter; }
+		const std::size_t counter() const
+		{
+			return m_counter;
+		}
 
-        /**
+		/**
          * @brief Resets the destroy timer on a notification, extending its lifetime and incrementing the show counter.
          */
-        void reset();
-        /**
+		void reset();
+		/**
          * @brief Indicates if the notification is ready to be destroyed (it has gone past its lifetime).
          * 
          * @return true 
          * @return false 
          */
-        bool should_be_destroyed() const;
-
+		bool should_be_destroyed() const;
 	};
 }

--- a/src/services/notifications/notification_service.cpp
+++ b/src/services/notifications/notification_service.cpp
@@ -35,7 +35,7 @@ namespace big
 	std::vector<notification> notification_service::get()
 	{
 		// remove old notifications
-		for (auto it = m_notifications.begin(); it != m_notifications.end(); )
+		for (auto it = m_notifications.begin(); it != m_notifications.end();)
 		{
 			if (it->second.should_be_destroyed())
 			{
@@ -57,7 +57,7 @@ namespace big
 
 	void notification_service::push(notification n)
 	{
-		const auto [pair, inserted] = m_notifications.insert({ n.identifier(), n });
+		const auto [pair, inserted] = m_notifications.insert({n.identifier(), n});
 		if (!inserted)
 		{
 			pair->second.reset();

--- a/src/services/notifications/notification_service.cpp
+++ b/src/services/notifications/notification_service.cpp
@@ -4,69 +4,64 @@
 
 namespace big
 {
-	notification_service::notification_service()
+	bool notification_service::initialise()
 	{
 		push("NOTIFICATION_WELCOME_TITLE"_T.data(),
 		    std::vformat("NOTIFICATION_WELCOME_TEXT"_T, std::make_format_args(ImGui::key_names[g.settings.hotkeys.menu_toggle])));
 
-		g_notification_service = this;
-	}
-
-	notification_service::~notification_service()
-	{
-		g_notification_service = nullptr;
-	}
-
-	void notification_service::push(notification n)
-	{
-		this->notifications.emplace(std::hash<std::string>{}(n.message + n.title), n);
+		return true;
 	}
 
 	void notification_service::push(const std::string& title, const std::string& message)
 	{
-		this->push({NotificationType::INFO, title, message, std::chrono::system_clock::now(), 5000.f, 1.f});
+		push({title, message, NotificationType::INFO});
 	}
 
 	void notification_service::push_warning(const std::string& title, const std::string& message)
 	{
-		this->push({NotificationType::WARNING, title, message, std::chrono::system_clock::now(), 7000.f, 1.f});
+		push({title, message, NotificationType::WARNING, 7s});
 	}
 
 	void notification_service::push_error(const std::string& title, const std::string& message)
 	{
-		this->push({NotificationType::DANGER, title, message, std::chrono::system_clock::now(), 7000.f, 1.f});
+		push({title, message, NotificationType::DANGER, 7s});
 	}
 
 	void notification_service::push_success(const std::string& title, const std::string& message)
 	{
-		this->push({NotificationType::SUCCESS, title, message, std::chrono::system_clock::now(), 7000.f, 1.f});
+		push({title, message, NotificationType::SUCCESS, 7s});
 	}
 
 	std::vector<notification> notification_service::get()
 	{
-		std::vector<notification> notifications_to_sent;
-		std::vector<std::size_t> to_remove;
-		for (auto& n : this->notifications)
+		// remove old notifications
+		for (auto it = m_notifications.begin(); it != m_notifications.end(); )
 		{
-			std::chrono::time_point<std::chrono::system_clock> curTime = std::chrono::system_clock::now();
-			const float time_diff =
-			    (float)std::chrono::duration_cast<std::chrono::milliseconds>(curTime - n.second.created_on).count();
-			n.second.alpha = 1;
-			if (n.second.destroy_in <= time_diff)
+			if (it->second.should_be_destroyed())
 			{
-				n.second.alpha = 1.f - ((time_diff - n.second.destroy_in) / 600);
-				n.second.alpha = n.second.alpha < 0.f ? 0.f : n.second.alpha;
+				it = m_notifications.erase(it++);
+
+				continue;
 			}
-
-			if (n.second.alpha > 0.f)
-				notifications_to_sent.push_back(n.second);
-			else
-				to_remove.push_back(n.first);
+			++it;
 		}
-		for (std::size_t k : to_remove)
-			this->notifications.erase(k);
 
-		return notifications_to_sent;
+		// grab only the notifications, no need for the keys
+		auto sorted = m_notifications | std::views::values | std::ranges::to<std::vector<notification>>();
+		std::sort(sorted.begin(), sorted.end(), [](auto const& a, auto const& b) {
+			// inverse sorting, highest remaining time goes to top
+			return a.destroy_time() > b.destroy_time();
+		});
+		return sorted;
+	}
+
+	void notification_service::push(notification n)
+	{
+		const auto [pair, inserted] = m_notifications.insert({ n.identifier(), n });
+		if (!inserted)
+		{
+			pair->second.reset();
+		}
 	}
 
 }

--- a/src/services/notifications/notification_service.hpp
+++ b/src/services/notifications/notification_service.hpp
@@ -1,46 +1,31 @@
 #pragma once
+#include "notification.hpp"
+
 namespace big
 {
-	enum class NotificationType
-	{
-		INFO,
-		SUCCESS,
-		WARNING,
-		DANGER,
-	};
-
-	struct notification
-	{
-		NotificationType type;
-		const std::string title;
-		const std::string message;
-		const std::chrono::time_point<std::chrono::system_clock> created_on;
-		const float destroy_in;
-		float alpha;
-	};
 
 	class notification_service final
 	{
-		std::unordered_map<std::size_t, notification> notifications;
+		std::unordered_map<std::size_t, notification> m_notifications;
 
 	public:
-		notification_service();
-		virtual ~notification_service();
+		notification_service() = default;
+		virtual ~notification_service() = default;
 
-		void push(notification);
-		void push(const std::string&, const std::string&);
-		void push_warning(const std::string&, const std::string&);
-		void push_error(const std::string&, const std::string&);
-		void push_success(const std::string&, const std::string&);
+		bool initialise();
+
+		void push(const std::string& title, const std::string& message);
+		void push_warning(const std::string& title, const std::string& message);
+		void push_error(const std::string& title, const std::string& message);
+		void push_success(const std::string& title, const std::string& message);
+
+		// cleans up old notifications from the map and returns a sorted list based on the destroy time
 		std::vector<notification> get();
 
-		std::map<NotificationType, ImVec4> notification_colors = {
-		    {NotificationType::INFO, ImVec4(0.80f, 0.80f, 0.83f, 1.00f)},
-		    {NotificationType::SUCCESS, ImVec4(0.29f, 0.69f, 0.34f, 1.00f)},
-		    {NotificationType::WARNING, ImVec4(0.69f, 0.49f, 0.29f, 1.00f)},
-		    {NotificationType::DANGER, ImVec4(0.69f, 0.29f, 0.29f, 1.00f)},
-		};
+	private:
+		void push(notification notification);
+
 	};
 
-	inline notification_service* g_notification_service{};
+	inline notification_service g_notification_service{};
 }

--- a/src/services/ped_animations/ped_animations_service.cpp
+++ b/src/services/ped_animations/ped_animations_service.cpp
@@ -82,7 +82,7 @@ namespace big
 		file_out << j.dump(4);
 		file_out.close();
 
-		g_notification_service->push_success("Animations", std::format("Succesfully saved location {}", p.name));
+		g_notification_service.push_success("Animations", std::format("Succesfully saved location {}", p.name));
 
 		return true;
 	}

--- a/src/services/persist_weapons/persist_weapons.cpp
+++ b/src/services/persist_weapons/persist_weapons.cpp
@@ -115,7 +115,7 @@ namespace big
 			}
 			catch (std::exception& e)
 			{
-				g_notification_service->push_warning("Persist Weapons", "Failed to load JSON file from disk.");
+				g_notification_service.push_warning("Persist Weapons", "Failed to load JSON file from disk.");
 				LOG(WARNING) << "Persist Weapons failed to load JSON file: " << g.persist_weapons.weapon_loadout_file << " because " << e.what();
 			}
 		}

--- a/src/services/player_database/player_database_service.cpp
+++ b/src/services/player_database/player_database_service.cpp
@@ -35,24 +35,24 @@ namespace big
 
 		if (g.player_db.notify_when_joinable && !is_joinable_session(player.session_type) && is_joinable_session(new_session_type))
 		{
-			g_notification_service->push_success("Player DB", std::format("{} is now in a joinable session", player.name));
+			g_notification_service.push_success("Player DB", std::format("{} is now in a joinable session", player.name));
 		}
 		else if (g.player_db.notify_when_online && (player.session_type == GSType::Invalid || player.session_type == GSType::Unknown) && new_session_type != GSType::Invalid)
 		{
-			g_notification_service->push_success("Player DB", std::format("{} is now online", player.name));
+			g_notification_service.push_success("Player DB", std::format("{} is now online", player.name));
 		}
 		else if (g.player_db.notify_when_unjoinable && is_joinable_session(player.session_type) && !is_joinable_session(new_session_type) && new_session_type != GSType::Invalid)
 		{
-			g_notification_service->push("Player DB", std::format("{} is no longer in a joinable session", player.name));
+			g_notification_service.push("Player DB", std::format("{} is no longer in a joinable session", player.name));
 		}
 		else if (g.player_db.notify_when_offline && player.session_type != GSType::Invalid && player.session_type != GSType::Unknown && new_session_type == GSType::Invalid)
 		{
-			g_notification_service->push("Player DB", std::format("{} is no longer online", player.name));
+			g_notification_service.push("Player DB", std::format("{} is no longer online", player.name));
 		}
 
 		if (g.player_db.notify_on_session_type_change && (int)new_session_type >= (int)GSType::InviteOnly && (int)new_session_type < (int)GSType::Max)
 		{
-			g_notification_service->push("Player DB", std::format("{} is now in a{} {} session", player.name, new_session_type == GSType::InviteOnly ? "n" : "", get_session_type_str(new_session_type)));
+			g_notification_service.push("Player DB", std::format("{} is now in a{} {} session", player.name, new_session_type == GSType::InviteOnly ? "n" : "", get_session_type_str(new_session_type)));
 		}
 	}
 
@@ -64,14 +64,14 @@ namespace big
 
 		if (new_game_mode == GameMode::None && old_game_mode != GameMode::None && old_game_mode_str != "None")
 		{
-			g_notification_service->push("Player DB", std::format("{} is no longer in a {}", player->name, old_game_mode_str));
+			g_notification_service.push("Player DB", std::format("{} is no longer in a {}", player->name, old_game_mode_str));
 			return;
 		}
 
 		if (!can_fetch_name(new_game_mode))
 		{
 			if (new_game_mode_str != "None")
-				g_notification_service->push("Player DB", std::format("{} is now in a {}", player->name, new_game_mode_str));
+				g_notification_service.push("Player DB", std::format("{} is now in a {}", player->name, new_game_mode_str));
 
 			return;
 		}
@@ -83,11 +83,11 @@ namespace big
 
 		if (mission_name.empty())
 		{
-			g_notification_service->push("Player DB", std::format("{} is now in a {}", player->name, new_game_mode_str));
+			g_notification_service.push("Player DB", std::format("{} is now in a {}", player->name, new_game_mode_str));
 			return;
 		}
 
-		g_notification_service->push("Player DB", std::format("{} has joined the {} \"{}\"", player->name, new_game_mode_str, mission_name));
+		g_notification_service.push("Player DB", std::format("{} has joined the {} \"{}\"", player->name, new_game_mode_str, mission_name));
 		player->game_mode_name = mission_name;
 	}
 
@@ -413,7 +413,7 @@ namespace big
 							else if (it->second->notify_online && it->second->session_id != info.m_session_token
 							    && g.player_db.notify_on_session_change)
 							{
-								g_notification_service->push("Player DB",
+								g_notification_service.push("Player DB",
 								    std::format("{} has joined a new session", it->second->name));
 							}
 
@@ -424,12 +424,12 @@ namespace big
 								{
 									if (is_spectating)
 									{
-										g_notification_service->push("Player DB",
+										g_notification_service.push("Player DB",
 										    std::format("{} is now spectating", it->second->name));
 									}
 									else
 									{
-										g_notification_service->push("Player DB",
+										g_notification_service.push("Player DB",
 										    std::format("{} is no longer spectating", it->second->name));
 									}
 								}
@@ -437,7 +437,7 @@ namespace big
 								if (it->second->notify_online && is_host_of_session != it->second->is_host_of_session
 								    && g.player_db.notify_on_become_host && is_host_of_session && it->second->session_id == info.m_session_token)
 								{
-									g_notification_service->push("Player DB",
+									g_notification_service.push("Player DB",
 									    std::format("{} is now the host of their session", it->second->name));
 								}
 
@@ -446,19 +446,19 @@ namespace big
 								{
 									if (is_host_of_transition_session)
 									{
-										g_notification_service->push("Player DB",
+										g_notification_service.push("Player DB",
 										    std::format("{} has hosted a job lobby", it->second->name));
 									}
 									else
 									{
-										g_notification_service->push("Player DB",
+										g_notification_service.push("Player DB",
 										    std::format("{} has joined a job lobby", it->second->name));
 									}
 								}
 								else if (it->second->notify_online && g.player_db.notify_on_transition_change
 								    && transition_info.m_session_token == -1 && it->second->transition_session_id != -1)
 								{
-									g_notification_service->push("Player DB",
+									g_notification_service.push("Player DB",
 									    std::format("{} is no longer in a job lobby", it->second->name));
 								}
 

--- a/src/services/squad_spawner/squad_spawner.cpp
+++ b/src/services/squad_spawner/squad_spawner.cpp
@@ -153,7 +153,7 @@ namespace big
 		static auto reset_spawn_pos_to_offset = [&]() -> void {
 			Ped player_ped_handle = g_pointers->m_gta.m_ptr_to_handle(s.target->get_ped());
 			s.m_spawn_pos         = ENTITY::GET_OFFSET_FROM_ENTITY_IN_WORLD_COORDS(player_ped_handle, 0, -7, 0);
-			g_notification_service->push_warning("Squad Spawner", "No suitable spot found, spawning at an offset");
+			g_notification_service.push_warning("Squad Spawner", "No suitable spot found, spawning at an offset");
 		};
 
 		static auto is_pos_valid = [&]() -> bool {
@@ -206,7 +206,7 @@ namespace big
 
 		if (!s.target->get_net_game_player() || s.m_squad_size < 1 || !STREAMING::IS_MODEL_VALID(rage::joaat(s.m_ped_model)))
 		{
-			g_notification_service->push_error("Squad spawner", "Error spawning squad");
+			g_notification_service.push_error("Squad spawner", "Error spawning squad");
 			return false;
 		}
 
@@ -225,7 +225,7 @@ namespace big
 			if (VEHICLE::GET_VEHICLE_MODEL_NUMBER_OF_SEATS(veh_model_hash) < s.m_squad_size)
 			{
 				s.m_squad_size = VEHICLE::GET_VEHICLE_MODEL_NUMBER_OF_SEATS(veh_model_hash);
-				g_notification_service->push_warning("Squad Spawner", "The squad vehicle has insufficient seats, decreasing the squad size");
+				g_notification_service.push_warning("Squad Spawner", "The squad vehicle has insufficient seats, decreasing the squad size");
 			}
 		}
 

--- a/src/services/squad_spawner/squad_spawner_save_files.cpp
+++ b/src/services/squad_spawner/squad_spawner_save_files.cpp
@@ -61,7 +61,7 @@ namespace big
 			{
 				write << std::setw(4) << j << std::endl;
 				write.close();
-				g_notification_service->push_success("Squad spawner", std::string("Succesfully saved ").append(s.m_name));
+				g_notification_service.push_success("Squad spawner", std::string("Succesfully saved ").append(s.m_name));
 				fetch_squads();
 				return true;
 			}

--- a/src/services/vehicle/persist_car_service.cpp
+++ b/src/services/vehicle/persist_car_service.cpp
@@ -13,7 +13,7 @@ namespace big
 	{
 		if (!ENTITY::DOES_ENTITY_EXIST(vehicle) || !ENTITY::IS_ENTITY_A_VEHICLE(vehicle))
 		{
-			g_notification_service->push_warning("PERSIST_CAR_TITLE"_T.data(),
+			g_notification_service.push_warning("PERSIST_CAR_TITLE"_T.data(),
 			    "PERSIST_CAR_INVALID_VEHICLE_SAVE_ATTEMPT"_T.data());
 			return;
 		}
@@ -42,7 +42,7 @@ namespace big
 		}
 		catch (std::exception& e)
 		{
-			g_notification_service->push_warning("PERSIST_CAR_TITLE"_T.data(), "Failed to load JSON file");
+			g_notification_service.push_warning("PERSIST_CAR_TITLE"_T.data(), "Failed to load JSON file");
 			return NULL;
 		}
 

--- a/src/services/vehicle/vehicle_control_service.cpp
+++ b/src/services/vehicle/vehicle_control_service.cpp
@@ -172,7 +172,7 @@ namespace big
 					    4.f,
 					    5.f);
 					//LOG(INFO) << "Navmesh probably failed, issiuing regular task ";
-					g_notification_service->push_warning("VEHICLE_CONTROLLER"_T.data(),
+					g_notification_service.push_warning("VEHICLE_CONTROLLER"_T.data(),
 					    "VEHICLE_CONTROLLER_TRY_ALT_PATHFINDING"_T.data());
 					script::get_current()->yield(500ms);
 				}
@@ -308,13 +308,13 @@ namespace big
 			if (vehicle_control::find_suitable_destination_near_player(destination, heading))
 			{
 				//LOG(INFO) << "Suitable destination found";
-				g_notification_service->push_success("VEHICLE_CONTROLLER"_T.data(),
+				g_notification_service.push_success("VEHICLE_CONTROLLER"_T.data(),
 				    "VEHICLE_CONTROLLER_FOUND_LOCATION"_T.data());
 			}
 			else
 			{
 				//LOG(INFO) << "Couldn't find suitable destionation, defaulting to offset of player\nThis might go wrong";
-				g_notification_service->push_error("VEHICLE_CONTROLLER"_T.data(),
+				g_notification_service.push_error("VEHICLE_CONTROLLER"_T.data(),
 				    "VEHICLE_CONTROLLER_FORCE_PATHFINDING"_T.data());
 				destination = behind_pos;
 			}
@@ -338,7 +338,7 @@ namespace big
 			else
 			{
 				//LOG(INFO) << "Navmesh load failed";
-				g_notification_service->push_error("VEHICLE_CONTROLLER"_T.data(), "VEHICLE_CONTROLLER_NAVMESH_FAILURE"_T.data());
+				g_notification_service.push_error("VEHICLE_CONTROLLER"_T.data(), "VEHICLE_CONTROLLER_NAVMESH_FAILURE"_T.data());
 				m_driver_performing_task = false;
 			}
 		}

--- a/src/util/animations.hpp
+++ b/src/util/animations.hpp
@@ -92,7 +92,7 @@ namespace big::animations
 		if (!std::filesystem::exists(g_file_manager.get_project_file("animDictsCompact.json").get_path()))
 		{
 			LOG(WARNING) << "Animations file is not in directory. https://raw.githubusercontent.com/DurtyFree/gta-v-data-dumps/master/animDictsCompact.json";
-			g_notification_service->push_warning("Animations", "Please download the appropriate animations json and put it in the mod directory.");
+			g_notification_service.push_warning("Animations", "Please download the appropriate animations json and put it in the mod directory.");
 			return;
 		}
 

--- a/src/util/mobile.hpp
+++ b/src/util/mobile.hpp
@@ -142,7 +142,7 @@ namespace big::mobile
 		inline void summon_vehicle_by_index(int veh_idx)
 		{
 			if (*scr_globals::freemode_global.at(985).as<int*>() != -1)
-				return g_notification_service->push_warning("Vehicle", "Mechanic is not ready to deliver a vehicle right now.");
+				return g_notification_service.push_warning("Vehicle", "Mechanic is not ready to deliver a vehicle right now.");
 
 			if (g.clone_pv.spawn_inside && self::veh)
 				TASK::CLEAR_PED_TASKS_IMMEDIATELY(PLAYER::PLAYER_PED_ID());
@@ -208,10 +208,10 @@ namespace big::mobile
 			{
 				*scr_globals::gun_van.as<Vector3*>() = spawn_point;
 
-				return g_notification_service->push_success("GUI_TAB_MOBILE"_T.data(), "REQUEST_GUN_VAN_NOTIFY_SUCCESS"_T.data());
+				return g_notification_service.push_success("GUI_TAB_MOBILE"_T.data(), "REQUEST_GUN_VAN_NOTIFY_SUCCESS"_T.data());
 			}
 
-			g_notification_service->push_warning("GUI_TAB_MOBILE"_T.data(), "REQUEST_GUN_VAN_NOTIFY_FAILED"_T.data());
+			g_notification_service.push_warning("GUI_TAB_MOBILE"_T.data(), "REQUEST_GUN_VAN_NOTIFY_FAILED"_T.data());
 		}
 	}
 }

--- a/src/util/notify.hpp
+++ b/src/util/notify.hpp
@@ -61,7 +61,7 @@ namespace big::notify
 				return;
 
 			if (g.reactions.crash.notify)
-				g_notification_service->push_error("Protections", std::format("Blocked {} crash from {}", crash, player->get_name()));
+				g_notification_service.push_error("Protections", std::format("Blocked {} crash from {}", crash, player->get_name()));
 
 			if (g.reactions.crash.log)
 				LOG(WARNING) << "Blocked " << crash << " crash from " << player->get_name() << " ("
@@ -86,7 +86,7 @@ namespace big::notify
 		else
 		{
 			if (g.reactions.crash.notify)
-				g_notification_service->push_error("Protections", std::format("Blocked {} crash from unknown player", crash));
+				g_notification_service.push_error("Protections", std::format("Blocked {} crash from unknown player", crash));
 		}
 	}
 

--- a/src/util/scripts.hpp
+++ b/src/util/scripts.hpp
@@ -120,7 +120,7 @@ namespace big::scripts
 			if (!force_host("am_launcher"_J))
 			{
 				// 2F) Failed to force host of launcher
-				g_notification_service->push_error("Script", "Cannot force script host of am_launcher");
+				g_notification_service.push_error("Script", "Cannot force script host of am_launcher");
 				return;
 			}
 
@@ -178,7 +178,7 @@ namespace big::scripts
 		else
 		{
 			// 1F) Cannot find launcher
-			g_notification_service->push_error("Script", "Cannot start script, am_launcher not running locally");
+			g_notification_service.push_error("Script", "Cannot start script, am_launcher not running locally");
 		}
 	}
 
@@ -216,13 +216,13 @@ namespace big::scripts
 
 		if (g.m_mission_creator_thread || SCRIPT::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH("creator"_J) != 0 || SCRIPT::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH("maintransition"_J) != 0 || STREAMING::IS_PLAYER_SWITCH_IN_PROGRESS() || CUTSCENE::IS_CUTSCENE_ACTIVE())
 		{
-			g_notification_service->push_warning("Creator", "Cannot start creator now");
+			g_notification_service.push_warning("Creator", "Cannot start creator now");
 			return;
 		}
 
 		if (MISC::GET_NUMBER_OF_FREE_STACKS_OF_THIS_SIZE(60500) == 0)
 		{
-			g_notification_service->push_warning("Creator", "No free stacks for MISSION stack size");
+			g_notification_service.push_warning("Creator", "No free stacks for MISSION stack size");
 		}
 
 

--- a/src/util/session.hpp
+++ b/src/util/session.hpp
@@ -100,7 +100,7 @@ namespace big::session
 	{
 		if (SCRIPT::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH("maintransition"_J) != 0 || STREAMING::IS_PLAYER_SWITCH_IN_PROGRESS())
 		{
-			g_notification_service->push_error("RID Joiner", "Player switch in progress, wait a bit.");
+			g_notification_service.push_error("RID Joiner", "Player switch in progress, wait a bit.");
 			return;
 		}
 
@@ -110,7 +110,7 @@ namespace big::session
 		if (SCRIPT::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH("maintransition"_J) == 0)
 		{
 			g.session.join_queued = false;
-			g_notification_service->push_error("RID Joiner", "Unable to launch maintransition");
+			g_notification_service.push_error("RID Joiner", "Unable to launch maintransition");
 		}
 		return;
 	}
@@ -119,7 +119,7 @@ namespace big::session
 	{
 		if (SCRIPT::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH("maintransition"_J) != 0 || STREAMING::IS_PLAYER_SWITCH_IN_PROGRESS())
 		{
-			g_notification_service->push_error("RID Joiner", "Player switch in progress, wait a bit.");
+			g_notification_service.push_error("RID Joiner", "Player switch in progress, wait a bit.");
 			return;
 		}
 
@@ -140,7 +140,7 @@ namespace big::session
 			}
 		}
 
-		g_notification_service->push_error("RID Joiner", "Target player is offline?");
+		g_notification_service.push_error("RID Joiner", "Target player is offline?");
 	}
 
 	inline void join_by_username(std::string username)
@@ -154,7 +154,7 @@ namespace big::session
 				});
 				return;
 			}
-			g_notification_service->push_error("RID Joiner", "Target player is offline?");
+			g_notification_service.push_error("RID Joiner", "Target player is offline?");
 		});
 	}
 
@@ -165,9 +165,9 @@ namespace big::session
 		bool success = g_pointers->m_gta.m_invite_player_by_gamer_handle(g_pointers->m_gta.m_network_config, &player_handle, 1, 0, 0, 0);
 
 		if (!success)
-			return g_notification_service->push_error("Network", "Target player could not be invited, they might be offline?");
+			return g_notification_service.push_error("Network", "Target player could not be invited, they might be offline?");
 
-		g_notification_service->push_success("Network", "Target player has been invited to your session!");
+		g_notification_service.push_success("Network", "Target player has been invited to your session!");
 	}
 
 	inline void show_profile_by_rockstar_id(uint64_t rid)

--- a/src/util/teleport.hpp
+++ b/src/util/teleport.hpp
@@ -48,7 +48,7 @@ namespace big::teleport
 
 		if (ENTITY::IS_ENTITY_DEAD(ent, true))
 		{
-			g_notification_service->push_warning("TELEPORT"_T.data(), "TELEPORT_PLAYER_IS_DEAD"_T.data());
+			g_notification_service.push_warning("TELEPORT"_T.data(), "TELEPORT_PLAYER_IS_DEAD"_T.data());
 			return false;
 		}
 
@@ -66,7 +66,7 @@ namespace big::teleport
 			}
 			else
 			{
-				g_notification_service->push_warning("TELEPORT"_T.data(), "TELEPORT_FAILED_TO_TAKE_CONTROL"_T.data());
+				g_notification_service.push_warning("TELEPORT"_T.data(), "TELEPORT_FAILED_TO_TAKE_CONTROL"_T.data());
 			}
 
 			return true;
@@ -131,7 +131,7 @@ namespace big::teleport
 	{
 		if (!ENTITY::IS_ENTITY_A_VEHICLE(veh))
 		{
-			g_notification_service->push_warning("TELEPORT"_T.data(), "TELEPORT_INVALID_VEHICLE"_T.data());
+			g_notification_service.push_warning("TELEPORT"_T.data(), "TELEPORT_INVALID_VEHICLE"_T.data());
 
 			return false;
 		}
@@ -144,7 +144,7 @@ namespace big::teleport
 
 		if (seat_index == 255)
 		{
-			g_notification_service->push_warning("TELEPORT"_T.data(), "TELEPORT_NO_SEATS_FREE"_T.data());
+			g_notification_service.push_warning("TELEPORT"_T.data(), "TELEPORT_NO_SEATS_FREE"_T.data());
 
 			return false;
 		}
@@ -196,7 +196,7 @@ namespace big::teleport
 	{
 		if (!to_blip((int)BlipIcons::Waypoint))
 		{
-			g_notification_service->push_warning("TELEPORT"_T.data(), "TELEPORT_NO_WAYPOINT_SET"_T.data());
+			g_notification_service.push_warning("TELEPORT"_T.data(), "TELEPORT_NO_WAYPOINT_SET"_T.data());
 
 			return false;
 		}
@@ -209,7 +209,7 @@ namespace big::teleport
 
 		if (!blip::get_objective_location(location))
 		{
-			g_notification_service->push_warning("TELEPORT"_T.data(), "TELEPORT_NO_OBJECTIVE"_T.data());
+			g_notification_service.push_warning("TELEPORT"_T.data(), "TELEPORT_NO_OBJECTIVE"_T.data());
 			return false;
 		}
 
@@ -222,14 +222,14 @@ namespace big::teleport
 	{
 		if (!*g_pointers->m_gta.m_is_session_started)
 		{
-			g_notification_service->push_warning("TELEPORT"_T.data(), "TELEPORT_NOT_ONLINE"_T.data());
+			g_notification_service.push_warning("TELEPORT"_T.data(), "TELEPORT_NOT_ONLINE"_T.data());
 			return false;
 		}
 
 		auto blip = blip::get_selected_blip();
 		if (blip == nullptr)
 		{
-			g_notification_service->push_warning("TELEPORT"_T.data(), "TELEPORT_NOTHING_SELECTED"_T.data());
+			g_notification_service.push_warning("TELEPORT"_T.data(), "TELEPORT_NOTHING_SELECTED"_T.data());
 			return false;
 		}
 		Entity entity = self::ped;

--- a/src/util/toxic.hpp
+++ b/src/util/toxic.hpp
@@ -55,13 +55,13 @@ namespace big::toxic
 	{
 		if (!g_player_service->get_self()->is_host())
 		{
-			g_notification_service->push_error("MODIFY_TIME"_T.data(), "MODIFY_TIME_HOST_REQUIRED"_T.data());
+			g_notification_service.push_error("MODIFY_TIME"_T.data(), "MODIFY_TIME_HOST_REQUIRED"_T.data());
 			return false;
 		}
 
 		if (!target->player_time_value.has_value())
 		{
-			g_notification_service->push_error("MODIFY_TIME"_T.data(), "MODIFY_TIME_NO_PLAYER_TIMESTAMP"_T.data());
+			g_notification_service.push_error("MODIFY_TIME"_T.data(), "MODIFY_TIME_NO_PLAYER_TIMESTAMP"_T.data());
 			return false;
 		}
 
@@ -98,7 +98,7 @@ namespace big::toxic
 	{
 		if (!target->player_time_value.has_value())
 		{
-			g_notification_service->push_error("WARP_TIME_TITLE"_T.data(), "MODIFY_TIME_NO_PLAYER_TIMESTAMP"_T.data());
+			g_notification_service.push_error("WARP_TIME_TITLE"_T.data(), "MODIFY_TIME_NO_PLAYER_TIMESTAMP"_T.data());
 			return;
 		}
 
@@ -114,7 +114,7 @@ namespace big::toxic
 	{
 		if (!g_player_service->get_self()->is_host())
 		{
-			g_notification_service->push_error("MODIFY_TIME"_T.data(), "MODIFY_TIME_HOST_REQUIRED"_T.data());
+			g_notification_service.push_error("MODIFY_TIME"_T.data(), "MODIFY_TIME_HOST_REQUIRED"_T.data());
 			return;
 		}
 

--- a/src/util/train.hpp
+++ b/src/util/train.hpp
@@ -28,11 +28,11 @@ namespace big::train
 				TASK::CLEAR_PED_TASKS_IMMEDIATELY(ped);
 
 			PED::SET_PED_INTO_VEHICLE(PLAYER::PLAYER_PED_ID(), train, -1);
-			g_notification_service->push_success("HIJACK_TRAIN"_T.data(), "HIJACK_TRAIN_FOUND_TRAIN"_T.data());
+			g_notification_service.push_success("HIJACK_TRAIN"_T.data(), "HIJACK_TRAIN_FOUND_TRAIN"_T.data());
 		}
 		else
 		{
-			g_notification_service->push_warning("HIJACK_TRAIN"_T.data(), "Cannot find any trains nearby");
+			g_notification_service.push_warning("HIJACK_TRAIN"_T.data(), "Cannot find any trains nearby");
 		}
 	}
 
@@ -44,7 +44,7 @@ namespace big::train
 		}
 		else
 		{
-			g_notification_service->push_warning("HIJACK_TRAIN"_T.data(), "Cannot find any trains nearby");
+			g_notification_service.push_warning("HIJACK_TRAIN"_T.data(), "Cannot find any trains nearby");
 		}
 	}
 

--- a/src/util/vehicle.cpp
+++ b/src/util/vehicle.cpp
@@ -56,13 +56,13 @@ namespace big::vehicle
 	void bring(Vehicle veh, Vector3 location, bool put_in, int seatIdx)
 	{
 		if (!ENTITY::IS_ENTITY_A_VEHICLE(veh))
-			return g_notification_service->push_error("VEHICLE"_T.data(), "VEHICLE_INVALID"_T.data());
+			return g_notification_service.push_error("VEHICLE"_T.data(), "VEHICLE_INVALID"_T.data());
 
 		auto vecVehicleLocation = ENTITY::GET_ENTITY_COORDS(veh, true);
 		entity::load_ground_at_3dcoord(vecVehicleLocation);
 
 		if (!entity::take_control_of(veh))
-			return g_notification_service->push_warning("VEHICLE"_T.data(), "VEHICLE_FAILED_CONTROL"_T.data());
+			return g_notification_service.push_warning("VEHICLE"_T.data(), "VEHICLE_FAILED_CONTROL"_T.data());
 		auto ped = self::ped;
 
 		ENTITY::SET_ENTITY_COORDS(veh, location.x, location.y, location.z + 1.f, 0, 0, 0, 0);
@@ -605,7 +605,7 @@ namespace big::vehicle
 		if (current_vehicle)
 			VEHICLE::SET_VEHICLE_ENGINE_ON(current_vehicle, state, immediately, disable_auto_start);
 		else
-			return g_notification_service->push_warning("VEHICLE"_T.data(), "PLEASE_ENTER_VEHICLE"_T.data());
+			return g_notification_service.push_warning("VEHICLE"_T.data(), "PLEASE_ENTER_VEHICLE"_T.data());
 	}
 
 	void downgrade(Vehicle vehicle)
@@ -621,7 +621,7 @@ namespace big::vehicle
 	{
 		if (!entity::take_control_of(veh, 4000))
 		{
-			g_notification_service->push_warning("REMOTE_CONTROL"_T.data(), "VEHICLE_FAILED_CONTROL"_T.data());
+			g_notification_service.push_warning("REMOTE_CONTROL"_T.data(), "VEHICLE_FAILED_CONTROL"_T.data());
 			return false;
 		}
 

--- a/src/views/core/view_notifications.cpp
+++ b/src/views/core/view_notifications.cpp
@@ -3,22 +3,32 @@
 
 namespace big
 {
-	float draw_notification(float start_pos, ImDrawList* dl, std::string title, std::string message, ImVec4 color)
+	// developer made, developer left, new developer too scared to touch
+	float draw_notification(float start_pos, ImDrawList* dl, const notification& notif)
 	{
+		auto color = notif.color();
+
 		ImColor textCol   = ImGui::ColorConvertFloat4ToU32({1.f, 1.f, 1.f, 1.f});
 		color.w           = 0.5f;
 		ImColor fadeBegin = ImGui::ColorConvertFloat4ToU32(color);
 		color.w           = 0.f;
 		ImColor fadeEnd   = ImGui::ColorConvertFloat4ToU32(color);
 
+		const auto alpha = notif.alpha();
+		// actually make use of the fadeout
+		textCol.Value.w *= alpha;
+		fadeBegin.Value.w *= alpha;
+		fadeEnd.Value.w *= alpha;
+
 		int j            = 0;
 		int prevSpace    = 0;
 		float total_size = 0.f;
 		std::vector<std::string> split_points;
+
+		auto message = notif.message();
 		for (int i = 0; i <= message.size(); i++)
 		{
-			std::string current_message = message.substr(j, i - j);
-
+			const auto current_message = message.substr(j, i - j);
 			if (message.substr(i, 1) == " ")
 			{
 				prevSpace = i;
@@ -50,6 +60,8 @@ namespace big
 		    fadeEnd,
 		    fadeBegin);
 
+		const auto count = notif.counter();
+		auto title = count > 1 ? std::format("{} ({})", notif.title(), count < 100 ? std::to_string(count) : "+99") : notif.title();
 		dl->AddText(g.window.font_sub_title,
 		    22.f,
 		    {(float)*g_pointers->m_gta.m_resolution_x - 350.f, 15.f + start_pos},
@@ -67,42 +79,13 @@ namespace big
 
 	void view::notifications()
 	{
-		ImDrawList* draw_list = ImGui::GetBackgroundDrawList();
-
-		std::vector<notification> notifications = g_notification_service->get();
+		const auto draw_list = ImGui::GetBackgroundDrawList();
+		const auto notifications = g_notification_service.get();
 
 		float prev_pos = 0.f;
-		for (int i = 0; i < notifications.size(); i++)
+		for (const auto& notif : notifications)
 		{
-			notification& n = notifications[i];
-
-			prev_pos =
-			    draw_notification(prev_pos, draw_list, n.title, n.message, g_notification_service->notification_colors.at(n.type));
+			prev_pos = draw_notification(prev_pos, draw_list, notif);
 		}
-
-		/*ImGui::SetNextWindowSize({ (float)g.window.x * 0.2f, (float)g.window.y });
-		ImGui::SetNextWindowPos({ (float)g.window.x - (float)g.window.x * 0.2f, 0 });
-		if (ImGui::Begin("notifications", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoMouseInputs | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoBringToFrontOnFocus))
-		{
-			std::vector<notification> notifications = g_notification_service->get();
-
-			for (int i = 0; i < notifications.size(); i++)
-			{
-				notification& n = notifications[i];
-				ImGui::PushStyleVar(ImGuiStyleVar_Alpha, n.alpha);
-				ImGui::PushStyleColor(ImGuiCol_ChildBg, ImVec4(0.10f, 0.09f, 0.12f, 1.00f));
-				ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0.10f, 0.09f, 0.12f, 1.00f));
-				ImGui::SetNextWindowBgAlpha(n.alpha);
-				ImGui::BeginChildFrame(i, ImVec2(0, 75.f + (float)(20 * (int)(n.message.size() / 28) + 20 * (float)std::count(n.message.begin(), n.message.end(), '\n'))), ImGuiWindowFlags_NoMouseInputs | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoInputs);
-				ImGui::Text(n.title.c_str());
-				ImGui::PushStyleColor(ImGuiCol_Text, g_notification_service->notification_colors.at(n.type));
-				ImGui::TextWrapped(n.message.c_str());
-				ImGui::PopStyleColor();
-				ImGui::EndChildFrame();
-				ImGui::PopStyleColor(2);
-				ImGui::PopStyleVar();
-			}
-			ImGui::End();
-		} */
 	}
 }

--- a/src/views/core/view_onboarding.cpp
+++ b/src/views/core/view_onboarding.cpp
@@ -33,7 +33,7 @@ namespace big
 		ImGui::SeparatorText("ONBOARDING_SET_MENU_OPEN_KEY"_T.data());
 		if (ImGui::Hotkey("VIEW_HOTKEY_SETTINGS_MENU_TOGGLE"_T.data(), &g.settings.hotkeys.menu_toggle))
 		{
-			g_notification_service->push("ONBOARDING_NOTIFICATION_TITLE"_T.data(), "ONBOARDING_NOTIFICATION_OPEN_KEY"_T.data());
+			g_notification_service.push("ONBOARDING_NOTIFICATION_TITLE"_T.data(), "ONBOARDING_NOTIFICATION_OPEN_KEY"_T.data());
 		}
 	}
 

--- a/src/views/debug/view_debug_globals.cpp
+++ b/src/views/debug/view_debug_globals.cpp
@@ -364,7 +364,7 @@ namespace big
 				}
 				else
 				{
-					g_notification_service->push_warning("DEBUG_TAB_GLOBALS"_T.data(), "VIEW_DEBUG_GLOBAL_INVALID_TYPE"_T.data());
+					g_notification_service.push_warning("DEBUG_TAB_GLOBALS"_T.data(), "VIEW_DEBUG_GLOBAL_INVALID_TYPE"_T.data());
 				}
 			}
 			ImGui::SameLine();

--- a/src/views/debug/view_debug_locals.cpp
+++ b/src/views/debug/view_debug_locals.cpp
@@ -388,7 +388,7 @@ namespace big
 				}
 				else
 				{
-					g_notification_service->push_warning("DEBUG_TAB_LOCALS"_T.data(), "VIEW_DEBUG_LOCALS_INVALID_TYPE"_T.data());
+					g_notification_service.push_warning("DEBUG_TAB_LOCALS"_T.data(), "VIEW_DEBUG_LOCALS_INVALID_TYPE"_T.data());
 				}
 			}
 			ImGui::SameLine();

--- a/src/views/debug/view_debug_misc.cpp
+++ b/src/views/debug/view_debug_misc.cpp
@@ -87,7 +87,7 @@ namespace big
 				if (pathfind::find_closest_vehicle_node(self::pos, safepos, heading, 0))
 					ENTITY::SET_ENTITY_COORDS(self::ped, safepos.x, safepos.y, safepos.z, 0, 0, 0, false);
 				else
-					g_notification_service->push_error("DEBUG_TAB_MISC"_T.data(), "VIEW_DEBUG_MISC_TP_TO_SAFE_POS_FAILED"_T.data());
+					g_notification_service.push_error("DEBUG_TAB_MISC"_T.data(), "VIEW_DEBUG_MISC_TP_TO_SAFE_POS_FAILED"_T.data());
 			});
 
 			ImGui::Checkbox("VIEW_DEBUG_MISC_IMGUI_DEMO"_T.data(), &g.window.demo);

--- a/src/views/debug/view_debug_scripts.cpp
+++ b/src/views/debug/view_debug_scripts.cpp
@@ -16,7 +16,7 @@ namespace big
 				{
 					if (ImGui::Checkbox(script->name(), script->toggle_ptr()))
 					{
-						g_notification_service->push(std::string(script->name()).append("VIEW_DEBUG_SCRIPTS_SCRIPT"_T.data()), script->is_enabled() ? "VIEW_DEBUG_SCRIPTS_RESUMED"_T.data() : "VIEW_DEBUG_SCRIPTS_HALTED"_T.data());
+						g_notification_service.push(std::string(script->name()).append("VIEW_DEBUG_SCRIPTS_SCRIPT"_T.data()), script->is_enabled() ? "VIEW_DEBUG_SCRIPTS_RESUMED"_T.data() : "VIEW_DEBUG_SCRIPTS_HALTED"_T.data());
 					}
 				}
 			});

--- a/src/views/debug/view_debug_threads.cpp
+++ b/src/views/debug/view_debug_threads.cpp
@@ -190,7 +190,7 @@ namespace big
 
 				if (MISC::GET_NUMBER_OF_FREE_STACKS_OF_THIS_SIZE(selected_stack_size) == 0)
 				{
-					g_notification_service->push_warning("VIEW_DEBUG_THREADS"_T.data(), "VIEW_DEBUG_THREADS_NO_FREE_STACKS"_T.data());
+					g_notification_service.push_warning("VIEW_DEBUG_THREADS"_T.data(), "VIEW_DEBUG_THREADS_NO_FREE_STACKS"_T.data());
 				}
 
 				while (!SCRIPT::HAS_SCRIPT_WITH_NAME_HASH_LOADED(hash))
@@ -214,7 +214,7 @@ namespace big
 
 				if (idx == -1)
 				{
-					g_notification_service->push_warning("VIEW_DEBUG_THREADS"_T.data(), "VIEW_DEBUG_THREADS_FAILED_WITH_LAUNCHER"_T.data());
+					g_notification_service.push_warning("VIEW_DEBUG_THREADS"_T.data(), "VIEW_DEBUG_THREADS_FAILED_WITH_LAUNCHER"_T.data());
 					return;
 				}
 

--- a/src/views/network/view_network.cpp
+++ b/src/views/network/view_network.cpp
@@ -58,7 +58,7 @@ namespace big
 				if (g_pointers->m_gta.m_decode_session_info(&info, base64, nullptr))
 					session::join_session(info);
 				else
-					g_notification_service->push_error("RID_JOINER"_T.data(), "VIEW_NET_RIDJOINER_SESSION_INFO_INVALID"_T.data());
+					g_notification_service.push_error("RID_JOINER"_T.data(), "VIEW_NET_RIDJOINER_SESSION_INFO_INVALID"_T.data());
 			});
 
 			components::button("COPY_SESSION_INFO"_T, [] {

--- a/src/views/network/view_player_database.cpp
+++ b/src/views/network/view_player_database.cpp
@@ -231,10 +231,10 @@ namespace big
 					g_thread_pool->push([selected] {
 						if (g_api_service->send_socialclub_message(selected->rockstar_id, message))
 						{
-							g_notification_service->push_success("SCAPI"_T.data(), "MSG_SENT_SUCCESS"_T.data());
+							g_notification_service.push_success("SCAPI"_T.data(), "MSG_SENT_SUCCESS"_T.data());
 							return;
 						}
-						g_notification_service->push_error("SCAPI"_T.data(), "MSG_SENT_FAIL"_T.data());
+						g_notification_service.push_error("SCAPI"_T.data(), "MSG_SENT_FAIL"_T.data());
 					});
 				};
 
@@ -351,7 +351,7 @@ namespace big
 			g_thread_pool->push([] {
 				if (!g_api_service->get_rid_from_username(new_name, *(uint64_t*)&new_rockstar_id))
 				{
-					g_notification_service->push_error("GUI_TAB_PLAYER_DATABASE"_T.data(), std::vformat("VIEW_NET_PLAYER_DB_NO_USER_CAN_BE_FOUND"_T, std::make_format_args(new_name)));
+					g_notification_service.push_error("GUI_TAB_PLAYER_DATABASE"_T.data(), std::vformat("VIEW_NET_PLAYER_DB_NO_USER_CAN_BE_FOUND"_T, std::make_format_args(new_name)));
 					new_rockstar_id = 0;
 				}
 			});

--- a/src/views/network/view_session_browser.cpp
+++ b/src/views/network/view_session_browser.cpp
@@ -79,7 +79,7 @@ namespace big
 				components::button("JOIN"_T, [session] {
 					if (SCRIPT::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH("maintransition"_J) != 0 || STREAMING::IS_PLAYER_SWITCH_IN_PROGRESS())
 					{
-						g_notification_service->push_error("JOIN_SESSION"_T.data(), "PLAYER_SWITCH_IN_PROGRESS"_T.data());
+						g_notification_service.push_error("JOIN_SESSION"_T.data(), "PLAYER_SWITCH_IN_PROGRESS"_T.data());
 						return;
 					}
 
@@ -180,7 +180,7 @@ namespace big
 			selected_session_idx = -1;
 
 			if (!g_matchmaking_service->matchmake())
-				g_notification_service->push_error("MATCHMAKING"_T.data(), "MATCHMAKING_FAIL"_T.data());
+				g_notification_service.push_error("MATCHMAKING"_T.data(), "MATCHMAKING_FAIL"_T.data());
 		});
 	}
 }

--- a/src/views/self/view_animations.cpp
+++ b/src/views/self/view_animations.cpp
@@ -138,27 +138,27 @@ namespace big
 		static auto save_response = [=]() -> bool {
 			if (!STREAMING::DOES_ANIM_DICT_EXIST(g_ped_animation_service.current_animation.dict.data()))
 			{
-				g_notification_service->push_warning("GUI_TAB_ANIMATIONS"_T.data(),
+				g_notification_service.push_warning("GUI_TAB_ANIMATIONS"_T.data(),
 				    std::vformat("VIEW_SELF_ANIMATIONS_DICT_DOES_NOT_EXIST"_T, std::make_format_args(g_ped_animation_service.current_animation.dict)));
 				return false;
 			}
 
 			if (g_ped_animation_service.get_animation_by_name(g_ped_animation_service.current_animation.name))
 			{
-				g_notification_service->push_warning("GUI_TAB_ANIMATIONS"_T.data(),
+				g_notification_service.push_warning("GUI_TAB_ANIMATIONS"_T.data(),
 					std::vformat("VIEW_SELF_ANIMATIONS_ANIM_ALREADY_EXISTS"_T, std::make_format_args(g_ped_animation_service.current_animation.name)));
 				return false;
 			}
 
 			if (category.empty())
 			{
-				g_notification_service->push_warning("GUI_TAB_ANIMATIONS"_T.data(), "VIEW_SELF_ANIMATIONS_CATEGORY_EMPTY_ERROR"_T.data());
+				g_notification_service.push_warning("GUI_TAB_ANIMATIONS"_T.data(), "VIEW_SELF_ANIMATIONS_CATEGORY_EMPTY_ERROR"_T.data());
 				return false;
 			}
 
 			if (g_ped_animation_service.current_animation.anim.empty())
 			{
-				g_notification_service->push_warning("GUI_TAB_ANIMATIONS"_T.data(), "VIEW_SELF_ANIMATIONS_ANIM_EMPTY_ERROR"_T.data());
+				g_notification_service.push_warning("GUI_TAB_ANIMATIONS"_T.data(), "VIEW_SELF_ANIMATIONS_ANIM_EMPTY_ERROR"_T.data());
 				return false;
 			}
 

--- a/src/views/self/view_custom_teleport.cpp
+++ b/src/views/self/view_custom_teleport.cpp
@@ -77,11 +77,11 @@ namespace big
 		components::button("VIEW_SELF_CUSTOM_TELEPORT_SAVE_CURRENT_LOCATION"_T, [] {
 			if (new_location_name.empty())
 			{
-				g_notification_service->push_warning("GUI_TAB_CUSTOM_TELEPORT"_T.data(), "VIEW_SELF_CUSTOM_TELEPORT_INVALID_NAME"_T.data());
+				g_notification_service.push_warning("GUI_TAB_CUSTOM_TELEPORT"_T.data(), "VIEW_SELF_CUSTOM_TELEPORT_INVALID_NAME"_T.data());
 			}
 			else if (g_custom_teleport_service.get_saved_location_by_name(new_location_name))
 			{
-				g_notification_service->push_warning("GUI_TAB_CUSTOM_TELEPORT"_T.data(), std::vformat("VIEW_SELF_CUSTOM_TELEPORT_LOCATION_ALREADY_EXISTS"_T, std::make_format_args(new_location_name)));
+				g_notification_service.push_warning("GUI_TAB_CUSTOM_TELEPORT"_T.data(), std::vformat("VIEW_SELF_CUSTOM_TELEPORT_LOCATION_ALREADY_EXISTS"_T, std::make_format_args(new_location_name)));
 			}
 			else
 			{
@@ -104,15 +104,15 @@ namespace big
 		components::button("VIEW_SELF_CUSTOM_TELEPORT_SAVE_BLIP"_T, [] {
 			if (new_location_name.empty())
 			{
-				g_notification_service->push_warning("GUI_TAB_CUSTOM_TELEPORT"_T.data(), "VIEW_SELF_CUSTOM_TELEPORT_INVALID_NAME"_T.data());
+				g_notification_service.push_warning("GUI_TAB_CUSTOM_TELEPORT"_T.data(), "VIEW_SELF_CUSTOM_TELEPORT_INVALID_NAME"_T.data());
 			}
 			else if (g_custom_teleport_service.get_saved_location_by_name(new_location_name))
 			{
-				g_notification_service->push_warning("GUI_TAB_CUSTOM_TELEPORT"_T.data(), std::vformat("VIEW_SELF_CUSTOM_TELEPORT_LOCATION_ALREADY_EXISTS"_T, std::make_format_args(new_location_name)));
+				g_notification_service.push_warning("GUI_TAB_CUSTOM_TELEPORT"_T.data(), std::vformat("VIEW_SELF_CUSTOM_TELEPORT_LOCATION_ALREADY_EXISTS"_T, std::make_format_args(new_location_name)));
 			}
 			else if (!*g_pointers->m_gta.m_is_session_started)
 			{
-				g_notification_service->push_warning("GUI_TAB_CUSTOM_TELEPORT"_T.data(), "TELEPORT_NOT_ONLINE"_T.data());
+				g_notification_service.push_warning("GUI_TAB_CUSTOM_TELEPORT"_T.data(), "TELEPORT_NOT_ONLINE"_T.data());
 				return;
 			}
 			else
@@ -121,7 +121,7 @@ namespace big
 				auto blip = blip::get_selected_blip();
 				if (blip == nullptr)
 				{
-					g_notification_service->push_warning("GUI_TAB_CUSTOM_TELEPORT"_T.data(), "VIEW_SELF_CUSTOM_TELEPORT_INVALID_BLIP"_T.data());
+					g_notification_service.push_warning("GUI_TAB_CUSTOM_TELEPORT"_T.data(), "VIEW_SELF_CUSTOM_TELEPORT_INVALID_BLIP"_T.data());
 					return;
 				}
 				teleport_location.name  = new_location_name;

--- a/src/views/self/view_mobile.cpp
+++ b/src/views/self/view_mobile.cpp
@@ -59,7 +59,7 @@ namespace big
 
 		components::button("MORS_FIX_ALL"_T, [] {
 			int amount_fixed = mobile::mors_mutual::fix_all();
-			g_notification_service->push_success("MOBILE"_T.data(),
+			g_notification_service.push_success("MOBILE"_T.data(),
 			    std::vformat("VEHICLE_FIX_AMOUNT"_T,
 			        std::make_format_args(amount_fixed,
 			            amount_fixed == 1 ? "VEHICLE_FIX_HAS"_T.data() : "VEHICLE_FIX_HAVE"_T.data())));

--- a/src/views/self/view_outfit_editor.cpp
+++ b/src/views/self/view_outfit_editor.cpp
@@ -59,7 +59,7 @@ namespace big
 			for (auto& item : props.items)
 				ss << item.id << " " << item.drawable_id << " " << item.texture_id << " ";
 			ImGui::SetClipboardText(ss.str().c_str());
-			g_notification_service->push_success("OUTFIT"_T.data(), "EXPORT_TO_CLIPBOARD"_T.data());
+			g_notification_service.push_success("OUTFIT"_T.data(), "EXPORT_TO_CLIPBOARD"_T.data());
 		});
 		ImGui::SameLine();
 

--- a/src/views/self/view_outfit_slots.cpp
+++ b/src/views/self/view_outfit_slots.cpp
@@ -54,7 +54,7 @@ namespace big
 				for (auto& item : props.items)
 					ss << item.id << " " << item.drawable_id << " " << item.texture_id << " ";
 				ImGui::SetClipboardText(ss.str().c_str());
-				g_notification_service->push_success("OUTFIT"_T.data(), "EXPORT_TO_CLIPBOARD"_T.data());
+				g_notification_service.push_success("OUTFIT"_T.data(), "EXPORT_TO_CLIPBOARD"_T.data());
 			});
 			ImGui::SameLine();
 

--- a/src/views/settings/view_proxy_settings.cpp
+++ b/src/views/settings/view_proxy_settings.cpp
@@ -42,11 +42,11 @@ namespace big
 				try
 				{
 					const auto j = nlohmann::json::parse(response.text);
-					g_notification_service->push_success("PROXY_SETTINGS"_T.data(), "PROXY_SETTINGS_TEST_CURRENT_SUCCESS"_T.data());
+					g_notification_service.push_success("PROXY_SETTINGS"_T.data(), "PROXY_SETTINGS_TEST_CURRENT_SUCCESS"_T.data());
 				}
 				catch (const std::exception& e)
 				{
-					g_notification_service->push_error("PROXY_SETTINGS"_T.data(), "PROXY_SETTINGS_TEST_CURRENT_FAIL"_T.data());
+					g_notification_service.push_error("PROXY_SETTINGS"_T.data(), "PROXY_SETTINGS_TEST_CURRENT_FAIL"_T.data());
 				}
 			});
 		}
@@ -66,7 +66,7 @@ namespace big
 			else
 				g_http_client.proxy_mgr().update(settings.proxy_host, settings.proxy_port, settings.protocol);
 
-			g_notification_service->push("PROXY_SETTINGS"_T.data(), "PROXY_SETTINGS_UPDATE_SUCCESS"_T.data());
+			g_notification_service.push("PROXY_SETTINGS"_T.data(), "PROXY_SETTINGS_UPDATE_SUCCESS"_T.data());
 		}
 	}
 }

--- a/src/views/settings/view_settings.cpp
+++ b/src/views/settings/view_settings.cpp
@@ -54,7 +54,7 @@ namespace big
 			g_thread_pool->push([] {
 				g_translation_service.update_n_reload_language_packs();
 
-				g_notification_service->push_success("LANGUAGE"_T.data(), "VIEW_SETTINGS_FINISHED_UPDATING_TRANSLATIONS"_T.data());
+				g_notification_service.push_success("LANGUAGE"_T.data(), "VIEW_SETTINGS_FINISHED_UPDATING_TRANSLATIONS"_T.data());
 			});
 		}
 

--- a/src/views/vehicle/spawn/view_persist_car.cpp
+++ b/src/views/vehicle/spawn/view_persist_car.cpp
@@ -26,7 +26,7 @@ namespace big
 			const auto vehicle = persist_car_service::load_vehicle(selected_vehicle_file, g.persist_car.persist_vehicle_sub_folder);
 			if (!vehicle)
 			{
-				g_notification_service->push_warning("PERSIST_CAR"_T.data(), "PERSIST_CAR_TO_MANY_SPAWNED"_T.data());
+				g_notification_service.push_warning("PERSIST_CAR"_T.data(), "PERSIST_CAR_TO_MANY_SPAWNED"_T.data());
 			}
 			else if (g.persist_car.spawn_inside && self::veh != vehicle)
 			{
@@ -37,7 +37,7 @@ namespace big
 		}
 		else
 		{
-			g_notification_service->push_warning("PERSIST_CAR"_T.data(), "SELECT_FILE_FIRST"_T.data());
+			g_notification_service.push_warning("PERSIST_CAR"_T.data(), "SELECT_FILE_FIRST"_T.data());
 		}
 	}
 
@@ -188,7 +188,7 @@ namespace big
 					return;
 
 				if (!self::veh)
-					return g_notification_service->push_warning("PERSIST_CAR"_T.data(), "PERSIST_CAR_NOT_IN_VEHICLE"_T.data());
+					return g_notification_service.push_warning("PERSIST_CAR"_T.data(), "PERSIST_CAR_NOT_IN_VEHICLE"_T.data());
 
 				save_vehicle(vehicle_file_name_input, save_folder);
 			});
@@ -200,7 +200,7 @@ namespace big
 					return;
 
 				if (!self::veh)
-					return g_notification_service->push_warning("PERSIST_CAR"_T.data(), "PERSIST_CAR_NOT_IN_VEHICLE"_T.data());
+					return g_notification_service.push_warning("PERSIST_CAR"_T.data(), "PERSIST_CAR_NOT_IN_VEHICLE"_T.data());
 
 				save_vehicle(vehicle_file_name_input, g.persist_car.persist_vehicle_sub_folder.c_str());
 			});

--- a/src/views/vehicle/spawn/view_pv.cpp
+++ b/src/views/vehicle/spawn/view_pv.cpp
@@ -193,7 +193,7 @@ namespace big
 
 								if (veh == 0)
 								{
-									g_notification_service->push_error("VEHICLE"_T.data(), "UNABLE_TO_SPAWN_VEHICLE"_T.data());
+									g_notification_service.push_error("VEHICLE"_T.data(), "UNABLE_TO_SPAWN_VEHICLE"_T.data());
 								}
 								else
 								{

--- a/src/views/vehicle/view_fun_vehicle.cpp
+++ b/src/views/vehicle/view_fun_vehicle.cpp
@@ -104,7 +104,7 @@ namespace big
 					if (ImGui::Selectable(driving_style_names[i], g.vehicle.auto_drive_style == (AutoDriveStyle)i))
 					{
 						g.vehicle.auto_drive_style = (AutoDriveStyle)i;
-						g_notification_service->push_success("AUTO_DRIVE"_T.data(),
+						g_notification_service.push_success("AUTO_DRIVE"_T.data(),
 						    std::vformat("DRIVING_STYLE_SET_TO"_T.data(), std::make_format_args(driving_style_names[i])));
 					}
 

--- a/src/views/vehicle/view_lsc.cpp
+++ b/src/views/vehicle/view_lsc.cpp
@@ -364,7 +364,7 @@ namespace big
 								}
 								else
 								{
-									g_notification_service->push_error("GUI_TAB_LSC"_T.data(), "VIEW_LSC_SELECTED_MOD_IS_INVALID"_T.data());
+									g_notification_service.push_error("GUI_TAB_LSC"_T.data(), "VIEW_LSC_SELECTED_MOD_IS_INVALID"_T.data());
 								}
 							}
 							else if (selected_slot == MOD_WINDOW_TINT)

--- a/src/views/vehicle/view_spawn_vehicle.cpp
+++ b/src/views/vehicle/view_spawn_vehicle.cpp
@@ -126,7 +126,7 @@ namespace big
 
 							if (veh == 0)
 							{
-								g_notification_service->push_error("VEHICLE"_T.data(), "UNABLE_TO_SPAWN_VEHICLE"_T.data());
+								g_notification_service.push_error("VEHICLE"_T.data(), "UNABLE_TO_SPAWN_VEHICLE"_T.data());
 							}
 							else
 							{
@@ -176,7 +176,7 @@ namespace big
 
 						if (veh == 0)
 						{
-							g_notification_service->push_error("VEHICLE"_T.data(), "UNABLE_TO_SPAWN_VEHICLE"_T.data());
+							g_notification_service.push_error("VEHICLE"_T.data(), "UNABLE_TO_SPAWN_VEHICLE"_T.data());
 						}
 						else
 						{

--- a/src/views/vehicle/view_vehicle.cpp
+++ b/src/views/vehicle/view_vehicle.cpp
@@ -10,7 +10,7 @@ namespace big
 	{
 		components::button("MORS_FIX_ALL"_T, [] {
 			int amount_fixed = mobile::mors_mutual::fix_all();
-			g_notification_service->push_success("MOBILE"_T.data(),
+			g_notification_service.push_success("MOBILE"_T.data(),
 			    std::vformat("VEHICLE_FIX_AMOUNT"_T.data(),
 			        std::make_format_args(amount_fixed,
 			            amount_fixed == 1 ? "VEHICLE_FIX_HAS"_T.data() : "VEHICLE_FIX_HAVE"_T.data())));

--- a/src/views/world/view_creator.cpp
+++ b/src/views/world/view_creator.cpp
@@ -91,18 +91,18 @@ namespace big
 						if (g_api_service->download_job_metadata(content_id, f1 < 0 ? 0 : f1, f0 < 0 ? 0 : f0, NETWORK::UGC_GET_CONTENT_LANGUAGE(0)))
 						{
 							cached_creator_files = false;
-							g_notification_service->push_success("CREATOR_JOB_IMPORT_NOTIFICATION"_T.data(),
+							g_notification_service.push_success("CREATOR_JOB_IMPORT_NOTIFICATION"_T.data(),
 							    "CREATOR_JOB_IMPORT_SUCCESS"_T.data());
 						}
 						else
 						{
-							g_notification_service->push_error("CREATOR_JOB_IMPORT_NOTIFICATION"_T.data(),
+							g_notification_service.push_error("CREATOR_JOB_IMPORT_NOTIFICATION"_T.data(),
 							    "CREATOR_JOB_FAILED_METADATA_FETCH"_T.data());
 						}
 					}
 					else
 					{
-						g_notification_service->push_error("CREATOR_JOB_IMPORT_NOTIFICATION"_T.data(),
+						g_notification_service.push_error("CREATOR_JOB_IMPORT_NOTIFICATION"_T.data(),
 						    "CREATOR_JOB_UGC_QUERY_FAILED"_T.data());
 					}
 				});

--- a/src/views/world/view_model_swapper.cpp
+++ b/src/views/world/view_model_swapper.cpp
@@ -30,7 +30,7 @@ namespace big
 			std::lock_guard lock(g.world.model_swapper.m);
 			if (dst_text[0] == '\0' || src_text[0] == '\0')
 			{
-				g_notification_service->push_error("GUI_TAB_MODEL_SWAPPER"_T.data(), "VIEW_MODEL_SWAPPER_WRONG_INPUT"_T.data());
+				g_notification_service.push_error("GUI_TAB_MODEL_SWAPPER"_T.data(), "VIEW_MODEL_SWAPPER_WRONG_INPUT"_T.data());
 				return;
 			}
 			std::string str = dst_text;
@@ -58,7 +58,7 @@ namespace big
 			if (!g.world.model_swapper.models.size() || selected_index < 0
 			    || selected_index >= g.world.model_swapper.models.size())
 			{
-				g_notification_service->push_error("GUI_TAB_MODEL_SWAPPER"_T.data(), "VIEW_MODEL_SWAPPER_INVALID_INDEX"_T.data());
+				g_notification_service.push_error("GUI_TAB_MODEL_SWAPPER"_T.data(), "VIEW_MODEL_SWAPPER_INVALID_INDEX"_T.data());
 				return;
 			}
 			g.world.model_swapper.models.erase(std::begin(g.world.model_swapper.models) + selected_index);

--- a/src/views/world/view_spawn_ped.cpp
+++ b/src/views/world/view_spawn_ped.cpp
@@ -63,7 +63,7 @@ namespace big
 				auto plyr = g_player_service->get_by_id(selected_ped_player_id);
 				if (plyr == nullptr || !plyr->is_valid() || !plyr->get_ped() || !plyr->get_ped()->m_navigation)
 				{
-					g_notification_service->push_error("PED"_T.data(), "INVALID_ONLINE_PED"_T.data());
+					g_notification_service.push_error("PED"_T.data(), "INVALID_ONLINE_PED"_T.data());
 					return 0;
 				}
 
@@ -88,7 +88,7 @@ namespace big
 			auto plyr = g_player_service->get_by_id(selected_ped_for_player_id);
 			if (plyr == nullptr || !plyr->is_valid() || !plyr->get_ped() || !plyr->get_ped()->m_navigation)
 			{
-				g_notification_service->push_error("PED"_T.data(), "INVALID_ONLINE_PED"_T.data());
+				g_notification_service.push_error("PED"_T.data(), "INVALID_ONLINE_PED"_T.data());
 				return 0;
 			}
 
@@ -107,7 +107,7 @@ namespace big
 
 		if (ped == 0)
 		{
-			g_notification_service->push_error("PED"_T.data(), "SPAWN_MODEL_FAILED"_T.data());
+			g_notification_service.push_error("PED"_T.data(), "SPAWN_MODEL_FAILED"_T.data());
 			return 0;
 		}
 
@@ -620,7 +620,7 @@ namespace big
 			{
 				if (!ped::change_player_model(rage::joaat(ped_model_buf)))
 				{
-					g_notification_service->push_error("PED"_T.data(), "SPAWN_MODEL_FAILED"_T.data());
+					g_notification_service.push_error("PED"_T.data(), "SPAWN_MODEL_FAILED"_T.data());
 					return;
 				}
 

--- a/src/views/world/view_squad_spawner.cpp
+++ b/src/views/world/view_squad_spawner.cpp
@@ -333,12 +333,12 @@ namespace big
 		static auto check_validity = [=](bool save) -> bool {
 			if (!victim->is_valid() && !save)
 			{
-				g_notification_service->push_error("GUI_TAB_SQUAD_SPAWNER"_T.data(), "VIEW_SQUAD_SPAWN_CHOOSE_FIRST"_T.data());
+				g_notification_service.push_error("GUI_TAB_SQUAD_SPAWNER"_T.data(), "VIEW_SQUAD_SPAWN_CHOOSE_FIRST"_T.data());
 				return false;
 			}
 			if (std::string(new_template.m_ped_model).empty())
 			{
-				g_notification_service->push_error("GUI_TAB_SQUAD_SPAWNER"_T.data(), "VIEW_SQUAD_SPAWN_MODEL_REQUIRED"_T.data());
+				g_notification_service.push_error("GUI_TAB_SQUAD_SPAWNER"_T.data(), "VIEW_SQUAD_SPAWN_MODEL_REQUIRED"_T.data());
 				return false;
 			}
 

--- a/src/views/world/view_world.cpp
+++ b/src/views/world/view_world.cpp
@@ -127,7 +127,7 @@ namespace big
 
 				quantity  = list.size();
 				remaining = quantity;
-				g_notification_service->push("GUI_TAB_TIME_N_WEATHER"_T.data(), std::format("Deleting {} entities", quantity));
+				g_notification_service.push("GUI_TAB_TIME_N_WEATHER"_T.data(), std::format("Deleting {} entities", quantity));
 				deleting   = true;
 				int failed = 0;
 
@@ -167,7 +167,7 @@ namespace big
 				}
 
 				if (failed > 0)
-					g_notification_service->push_warning("GUI_TAB_TIME_N_WEATHER"_T.data(), std::format("Failed deleting {} entities", failed));
+					g_notification_service.push_warning("GUI_TAB_TIME_N_WEATHER"_T.data(), std::format("Failed deleting {} entities", failed));
 
 				deleting = false;
 			});


### PR DESCRIPTION
The main goal was improving the readability of the original code however some ugliness remains.

- Swapped from pointer singleton to instance singleton
- Actually make use of the alpha logic that used to be present
- Added a counter to notifications to indicate if something is being spammed
- Notification timeouts reset if they're sent to the queue again

Main directories/files of interest for reviews:
 - `src/views/core/view_notifications.cpp`
 - `src/services/notifications/*`