### PR TITLE
Refactored g_model_preview_service->show_vehicle

### DIFF
--- a/src/views/vehicle/spawn/view_persist_car.cpp
+++ b/src/views/vehicle/spawn/view_persist_car.cpp
@@ -141,9 +141,7 @@ namespace big
 					}
 					else if (ImGui::IsItemHovered())
 					{
-						g_fiber_pool->queue_job([pair] {
-							g_model_preview_service->show_vehicle_persisted(pair);
-						});
+						g_model_preview_service->show_vehicle_persisted(pair);
 					}
 
 					ImGui::SameLine();

--- a/src/views/vehicle/spawn/view_pv.cpp
+++ b/src/views/vehicle/spawn/view_pv.cpp
@@ -228,11 +228,8 @@ namespace big
 						}
 						else if (ImGui::IsItemHovered())
 						{
-							g_fiber_pool->queue_job([&personal_veh] {
-								g_model_preview_service->show_vehicle(
-								    vehicle::get_owned_mods_from_vehicle_idx(personal_veh->get_vehicle_idx()),
-								    g.clone_pv.spawn_maxed);
-							});
+							g_model_preview_service->show_vehicle(vehicle::get_owned_mods_from_vehicle_idx(personal_veh->get_vehicle_idx()),
+							    g.clone_pv.spawn_maxed);
 						}
 					}
 				}

--- a/src/views/vehicle/view_spawn_vehicle.cpp
+++ b/src/views/vehicle/view_spawn_vehicle.cpp
@@ -153,10 +153,8 @@ namespace big
 					}
 					else if (ImGui::IsItemHovered())
 					{
-						g_fiber_pool->queue_job([] {
-							g_model_preview_service->show_vehicle(vehicle::get_owned_mods_from_vehicle(self::veh),
-							    g.spawn_vehicle.spawn_maxed);
-						});
+						g_model_preview_service->show_vehicle(vehicle::get_owned_mods_from_vehicle(self::veh),
+						    g.spawn_vehicle.spawn_maxed);
 					}
 				}
 			}

--- a/src/views/world/view_spawn_ped.cpp
+++ b/src/views/world/view_spawn_ped.cpp
@@ -292,11 +292,9 @@ namespace big
 						}
 						else if (ImGui::IsItemHovered())
 						{
-							g_fiber_pool->queue_job([] {
-								Ped ped   = self::ped;
-								Hash hash = ENTITY::GET_ENTITY_MODEL(ped);
-								g_model_preview_service->show_ped(hash, ped);
-							});
+							Ped ped   = self::ped;
+							Hash hash = ENTITY::GET_ENTITY_MODEL(ped);
+							g_model_preview_service->show_ped(hash, ped);
 						}
 
 						if (selected_ped_player_id == -1)
@@ -323,15 +321,13 @@ namespace big
 								}
 								else if (ImGui::IsItemHovered())
 								{
-									g_fiber_pool->queue_job([plyr_id] {
-										auto plyr = g_player_service->get_by_id(plyr_id);
-										if (plyr)
-										{
-											Ped ped   = PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(plyr->id());
-											Hash hash = ENTITY::GET_ENTITY_MODEL(ped);
-											g_model_preview_service->show_ped(hash, ped);
-										}
-									});
+									auto plyr = g_player_service->get_by_id(plyr_id);
+									if (plyr)
+									{
+										Ped ped   = PLAYER::GET_PLAYER_PED_SCRIPT_INDEX(plyr->id());
+										Hash hash = ENTITY::GET_ENTITY_MODEL(ped);
+										g_model_preview_service->show_ped(hash, ped);
+									}
 								}
 								ImGui::PopID();
 


### PR DESCRIPTION
Refactored g_model_preview_service->show_vehicle and its variants to not be wrapped in a queue_job fiber, as it would quickly exhaust the fiber pool causing collisions with subsequent calls being out of lockstep. or even dropped on the floor entirely.

Closes #2875
Closes #2675
Closes #2077