### PR TITLE
Fix chat channel (All/Team/Organization) on chat receive

### DIFF
--- a/src/hooks/protections/receive_net_message.cpp
+++ b/src/hooks/protections/receive_net_message.cpp
@@ -107,8 +107,10 @@ namespace big
 			case rage::eNetMessage::MsgTextMessage2:
 			{
 				char message[256];
+				rage::rlGamerHandle temp{};
+				bool is_team = false;
 				buffer.ReadString(message, 256);
-				bool is_team;
+				gamer_handle_deserialize(temp, buffer);
 				buffer.ReadBool(&is_team);
 
 				if (player->is_spammer)
@@ -146,15 +148,8 @@ namespace big
 
 					if (msgType == rage::eNetMessage::MsgTextMessage && g_pointers->m_gta.m_chat_data && player->get_net_data())
 					{
-						rage::rlGamerHandle temp{};
-						gamer_handle_deserialize(temp, buffer);
-
-						g_pointers->m_gta.m_handle_chat_message(*g_pointers->m_gta.m_chat_data,
-						    nullptr,
-						    &player->get_net_data()->m_gamer_handle,
-						    message,
-						    is_team);
-						return true;
+						buffer.Seek(0);
+						return g_hooking->get_original<hooks::receive_net_message>()(netConnectionManager, a2, frame); // Call original function since we can't seem to handle it
 					}
 				}
 				break;


### PR DESCRIPTION
This simply executes all our operations on the chat message before setting it back and returning the original function. This way we won't have to handle the actual message.

Fixes #2878