### PR TITLE
Added formatting to money on HUD.

### DIFF
--- a/src/gta_pointers.hpp
+++ b/src/gta_pointers.hpp
@@ -366,6 +366,8 @@ namespace big
 		CWeaponInfoManager* m_weapon_info_manager;
 
 		functions::can_create_vehicle m_can_create_vehicle;
+
+		PVOID m_format_int;
 	};
 #pragma pack(pop)
 	static_assert(sizeof(gta_pointers) % 8 == 0, "Pointers are not properly aligned");

--- a/src/hooking/hooking.cpp
+++ b/src/hooking/hooking.cpp
@@ -142,6 +142,8 @@ namespace big
 
 		detour_hook_helper::add<hooks::can_create_vehicle>("CCV", g_pointers->m_gta.m_can_create_vehicle);
 
+		detour_hook_helper::add<hooks::format_int>("FI", g_pointers->m_gta.m_format_int);
+
 		g_hooking = this;
 	}
 

--- a/src/hooking/hooking.hpp
+++ b/src/hooking/hooking.hpp
@@ -193,6 +193,8 @@ namespace big
 		static bool sync_reader_serialize_array(void* _this, void* array, int size);
 
 		static bool can_create_vehicle();
+
+		static void format_int(int64_t integer_to_format, char* format_string, size_t size_always_64, bool use_commas);
 	};
 
 	class minhook_keepalive

--- a/src/hooks/misc/format_int.cpp
+++ b/src/hooks/misc/format_int.cpp
@@ -13,12 +13,12 @@ namespace big
 
 	void hooks::format_int(int64_t integer_to_format, char* format_string, size_t size_always_64, bool use_commas)
 	{
-		void* return_address        = _ReturnAddress();
-		unsigned char* return_bytes = static_cast<unsigned char*>(return_address);
+		auto return_address         = _ReturnAddress();
+		auto return_bytes           = static_cast<unsigned char*>(return_address);
 		if (return_bytes[0] == 0x48 && return_bytes[1] == 0x8D && return_bytes[2] == 0x15) //lea     rdx, aHcGreenlightFo ; "~HC_GREENLIGHT~ <font size='20'>"
 		{
 			auto money_format = format_money(integer_to_format);
-			strcpy_s(format_string, size_always_64, money_format.c_str());
+			std::strcpy(format_string, money_format.c_str());
 			return;
 		}
 		g_hooking->get_original<format_int>()(integer_to_format, format_string, size_always_64, use_commas);

--- a/src/hooks/misc/format_int.cpp
+++ b/src/hooks/misc/format_int.cpp
@@ -8,12 +8,7 @@ namespace big
 		ss.imbue(std::locale(""));
 		ss << "$" << std::put_money(static_cast<long double>(amount) * 100, false);
 		std::string money = ss.str();
-		size_t pos        = money.find('.');
-		if (pos != std::string::npos)
-		{
-			money = money.substr(0, pos);
-		}
-		return money;
+		return money.substr(0, money.size() - 3);
 	}
 
 	void hooks::format_int(int64_t integer_to_format, char* format_string, size_t size_always_64, bool use_commas)

--- a/src/hooks/misc/format_int.cpp
+++ b/src/hooks/misc/format_int.cpp
@@ -1,0 +1,31 @@
+#include "hooking/hooking.hpp"
+
+namespace big
+{
+	static inline std::string format_money(int64_t amount)
+	{
+		std::stringstream ss;
+		ss.imbue(std::locale(""));
+		ss << "$" << std::put_money(static_cast<long double>(amount) * 100, false);
+		std::string money = ss.str();
+		size_t pos        = money.find('.');
+		if (pos != std::string::npos)
+		{
+			money = money.substr(0, pos);
+		}
+		return money;
+	}
+
+	void hooks::format_int(int64_t integer_to_format, char* format_string, size_t size_always_64, bool use_commas)
+	{
+		void* return_address        = _ReturnAddress();
+		unsigned char* return_bytes = static_cast<unsigned char*>(return_address);
+		if (return_bytes[0] == 0x48 && return_bytes[1] == 0x8D && return_bytes[2] == 0x15) //lea     rdx, aHcGreenlightFo ; "~HC_GREENLIGHT~ <font size='20'>"
+		{
+			auto money_format = format_money(integer_to_format);
+			strcpy_s(format_string, size_always_64, money_format.c_str());
+			return;
+		}
+		g_hooking->get_original<format_int>()(integer_to_format, format_string, size_always_64, use_commas);
+	}
+}

--- a/src/pointers.cpp
+++ b/src/pointers.cpp
@@ -1772,6 +1772,15 @@ namespace big
             {
                 g_pointers->m_gta.m_can_create_vehicle = ptr.as<functions::can_create_vehicle>();
             }
+        },
+        // Format Integer
+        {
+            "FI",
+            "48 83 EC ? 44 88 4C 24",
+            [](memory::handle ptr)
+            {
+                g_pointers->m_gta.m_format_int = ptr.as<PVOID>();
+            }
         }
         >(); // don't leave a trailing comma at the end
 


### PR DESCRIPTION
This utilizes the C++20 std::locale library to format the money on screen. For European users, it should use the period instead of commas.

![image](https://github.com/YimMenu/YimMenu/assets/100792176/dfbb2864-16f8-42c3-9d85-68da498758b5)

@ShinyWasabi has been working on this for 2 days and couldn't get it to work right, so I took like 10 seconds to look at it and I did, although he wanted to just force the use_commas parameter to true, I took a better route IMO.