### PR TITLE
Prevent autokick of friends and trusted players

### DIFF
--- a/src/backend/looped/session/auto_kick_host.cpp
+++ b/src/backend/looped/session/auto_kick_host.cpp
@@ -12,7 +12,7 @@ namespace big
 		if (kick_host && !bLastKickHost)
 		{
 			g_player_service->iterate([](auto& plyr) {
-				if (plyr.second->is_host())
+				if (plyr.second->is_host() && !plyr.second->is_friend() && !plyr.second->is_trusted)
 				{
 					dynamic_cast<player_command*>(command::get("multikick"_J))->call(plyr.second, {});
 				}


### PR DESCRIPTION
Adds checks to the auto-kick feature to avoid kicking a host if they're a friend or marked as trusted.

Closes #2981 