### PR TITLE
Disable Vehicle Heading Updates When Vehicle Flying in First-Person Mode

### DIFF
--- a/src/backend/looped/vehicle/fly.cpp
+++ b/src/backend/looped/vehicle/fly.cpp
@@ -32,10 +32,34 @@ namespace big
 				last_vehicle = vehicle;
 			}
 
-			if (vehicle)
+			if (vehicle && CAM::GET_FOLLOW_PED_CAM_VIEW_MODE() != CameraMode::FIRST_PERSON)
 			{
-				Vector3 cam_pos = CAM::GET_GAMEPLAY_CAM_ROT(0);
-				ENTITY::SET_ENTITY_ROTATION(vehicle, cam_pos.x, cam_pos.y, cam_pos.z, 1, true);
+				Vector3 cam_rot = CAM::GET_GAMEPLAY_CAM_ROT(0);
+
+				/*
+				* Leaving this for experimentation in the future, but vehicle flying in first person is very unpleasant either way
+				
+				Vector3 car_rot;
+				Vector3 rotation_delta;
+ 
+				if (CAM::GET_FOLLOW_PED_CAM_VIEW_MODE() == CameraMode::FIRST_PERSON)
+				{
+
+					car_rot = ENTITY::GET_ENTITY_ROTATION(vehicle, 0);
+					rotation_delta.x = (cam_rot.x - car_rot.x) / 360.0f;
+					rotation_delta.y = (cam_rot.y - car_rot.y) / 360.0f;
+					rotation_delta.z = (cam_rot.z - car_rot.z) / 360.0f;
+
+					Vector3 new_rot = {car_rot.x + rotation_delta.x, car_rot.y + rotation_delta.y, car_rot.z + rotation_delta.z};
+
+					ENTITY::SET_ENTITY_ROTATION(vehicle, new_rot.x, new_rot.y, new_rot.z, 0, true);
+				}
+				else
+				{
+					ENTITY::SET_ENTITY_ROTATION(vehicle, cam_rot.x, cam_rot.y, cam_rot.z, 0, true);
+				}*/
+
+				ENTITY::SET_ENTITY_ROTATION(vehicle, cam_rot.x, cam_rot.y, cam_rot.z, 0, true);
 				ENTITY::SET_ENTITY_COLLISION(vehicle, !g.vehicle.fly.no_collision, true);
 
 				float locspeed = g.vehicle.fly.speed;


### PR DESCRIPTION
I was unable to find a satisfactory solution to the first-person camera issues with the vehicle flying feature. When in first-person mode, the gameplay camera rotation is relative to the vehicle's heading, which means that the vehicle's heading will forever "chase" the camera's rotation until the player manually resets the camera back to near {0,0,0} relative.

I left my experimental code commented out which essentially clamps the sensitivity of the heading updates to prevent users from blowing chunks while spinning at 5,000,000RPM, but it still feels very floaty and unpleasant. Flying in 3rd-person is a much, much better experience.

Note the feature itself remains enabled while in first-person, it's just that the vehicle's heading will no longer chase the camera's rotation. The player vehicle will remain stationary wherever it was before the switch to first-person.

Resolves #2984 though not ideally. Further investigation warranted if someone REALLY wants to use vehicle flying in first person. Probably need to find a way to grab the gameplay camera's absolute rotation.