### PR TITLE
Add Protection GUI Element for Give Collectible

### DIFF
--- a/src/views/settings/view_protection_settings.cpp
+++ b/src/views/settings/view_protection_settings.cpp
@@ -22,38 +22,40 @@ namespace big
 		ImGui::Checkbox("FORCE_TELEPORT"_T.data(), &g.protections.script_events.force_teleport);
 		ImGui::Checkbox("GTA_BANNER"_T.data(), &g.protections.script_events.gta_banner);
 		ImGui::Checkbox("MC_TELEPORT"_T.data(), &g.protections.script_events.mc_teleport);
+		ImGui::Checkbox("SEND_TO_CUTSCENE"_T.data(), &g.protections.script_events.send_to_cutscene);
 		ImGui::EndGroup();
 
 		ImGui::SameLine();
 
 		ImGui::BeginGroup();
-		ImGui::Checkbox("SEND_TO_CUTSCENE"_T.data(), &g.protections.script_events.send_to_cutscene);
 		ImGui::Checkbox("SEND_TO_LOCATION"_T.data(), &g.protections.script_events.send_to_location);
 		ImGui::Checkbox("SOUND_SPAM"_T.data(), &g.protections.script_events.sound_spam);
 		ImGui::Checkbox("PERSONAL_VEHICLE_DESTROYED"_T.data(), &g.protections.script_events.personal_vehicle_destroyed);
 		ImGui::Checkbox("REMOTE_OFF_RADAR"_T.data(), &g.protections.script_events.remote_off_radar);
 		ImGui::Checkbox("ROTATE_CAM"_T.data(), &g.protections.script_events.rotate_cam);
+		ImGui::Checkbox("TELEPORT_TO_WAREHOUSE"_T.data(), &g.protections.script_events.teleport_to_warehouse);
+		ImGui::Checkbox("START_ACTIVITY"_T.data(), &g.protections.script_events.start_activity);
 		ImGui::EndGroup();
 
 		ImGui::SameLine();
 
 		ImGui::BeginGroup();
-		ImGui::Checkbox("TELEPORT_TO_WAREHOUSE"_T.data(), &g.protections.script_events.teleport_to_warehouse);
-		ImGui::Checkbox("START_ACTIVITY"_T.data(), &g.protections.script_events.start_activity);
 		ImGui::Checkbox("SEND_SMS"_T.data(), &g.protections.script_events.send_sms);
 		ImGui::Checkbox("SPECTATE"_T.data(), &g.protections.script_events.spectate);
 		ImGui::Checkbox("VEHICLE_KICK"_T.data(), &g.protections.script_events.vehicle_kick);
 		ImGui::Checkbox("WANTED_LEVEL"_T.data(), &g.protections.script_events.clear_wanted_level);
-		ImGui::EndGroup();
-		ImGui::SameLine();
-
-		ImGui::BeginGroup();
 		ImGui::Checkbox("BLOCK_RID_JOINING"_T.data(), &g.protections.rid_join);
 		if (ImGui::IsItemHovered())
 			ImGui::SetTooltip("BLOCK_RID_JOINING_DESCRIPTION"_T.data());
 		ImGui::Checkbox("RECEIVE_PICKUP"_T.data(), &g.protections.receive_pickup);
 		if (ImGui::IsItemHovered())
 			ImGui::SetTooltip("VIEW_PROTECTION_SETTINGS_RECEIVE_PICKUP_TOOLTIP"_T.data());
+		ImGui::Checkbox("GIVE_COLLECTIBLE"_T.data(), &g.protections.script_events.give_collectible);
+		ImGui::EndGroup();
+
+		ImGui::SameLine();
+
+		ImGui::BeginGroup();
 		ImGui::Checkbox("ADMIN_CHECK"_T.data(), &g.protections.admin_check);
 		ImGui::Checkbox("VIEW_PROTECTION_SETTINGS_KICK_REJOIN"_T.data(), &g.protections.kick_rejoin);
 		ImGui::Checkbox("BLOCK_TRAFFIC_MANIPULATION"_T.data(), &g.protections.stop_traffic);


### PR DESCRIPTION
Adds a checkbox in Protection for Give Collectible as per user request.
Also reorganizes existing elements to make room for the new checkbox.

Needs translation update as well.

`  "GIVE_COLLECTIBLE": "Give Collectible",`

Closes #2935