### PR TITLE
Feature: Infinite Vehicle Ammo

### DIFF
--- a/src/backend/looped/vehicle/infinite_veh_ammo.cpp
+++ b/src/backend/looped/vehicle/infinite_veh_ammo.cpp
@@ -1,0 +1,44 @@
+#include "backend/looped_command.hpp"
+#include "natives.hpp"
+
+namespace big
+{
+	class infinite_veh_ammo : looped_command
+	{
+		using looped_command::looped_command;
+
+		virtual void on_tick() override
+        {
+            Vehicle player_veh = self::veh;
+
+            if (player_veh != 0 && VEHICLE::DOES_VEHICLE_HAVE_WEAPONS(player_veh))
+            {
+                for (int i = 0; i < 3; i++)
+                {
+                    VEHICLE::SET_VEHICLE_WEAPON_RESTRICTED_AMMO(player_veh, i, -1);
+                }
+
+                VEHICLE::SET_VEHICLE_BOMB_AMMO(player_veh, -1);
+                VEHICLE::SET_VEHICLE_COUNTERMEASURE_AMMO(player_veh, -1);
+            }
+        }
+
+		virtual void on_disable() override
+		{
+			Vehicle player_veh = self::veh;
+
+			if (player_veh != 0 && VEHICLE::DOES_VEHICLE_HAVE_WEAPONS(player_veh))
+			{
+				for (int i = 0; i < 3; i++)
+				{
+					VEHICLE::SET_VEHICLE_WEAPON_RESTRICTED_AMMO(player_veh, i, 20);
+				}
+
+				VEHICLE::SET_VEHICLE_BOMB_AMMO(player_veh, 20);
+				VEHICLE::SET_VEHICLE_COUNTERMEASURE_AMMO(player_veh, 20);
+			}
+		}
+	};
+
+	infinite_veh_ammo g_infinite_veh_ammo("infinitevehammo", "VEHICLE_INFINITE_AMMO", "VEHICLE_INFINITE_AMMO_DESC", g.vehicle.infinite_veh_ammo);
+}

--- a/src/backend/looped/vehicle/infinite_veh_ammo.cpp
+++ b/src/backend/looped/vehicle/infinite_veh_ammo.cpp
@@ -8,9 +8,9 @@ namespace big
 		using looped_command::looped_command;
 
 		virtual void on_tick() override
-        {
+        	{
 			if (self::veh && VEHICLE::DOES_VEHICLE_HAVE_WEAPONS(self::veh))
-            {
+            		{
 				for (int i = 0; i < 3; i++)
 				{
 					VEHICLE::SET_VEHICLE_WEAPON_RESTRICTED_AMMO(self::veh, i, -1);
@@ -18,8 +18,8 @@ namespace big
 
 				VEHICLE::SET_VEHICLE_BOMB_AMMO(self::veh, -1);
 				VEHICLE::SET_VEHICLE_COUNTERMEASURE_AMMO(self::veh, -1);
-            }
-        }
+            		}
+        	}
 
 		virtual void on_disable() override
 		{

--- a/src/backend/looped/vehicle/infinite_veh_ammo.cpp
+++ b/src/backend/looped/vehicle/infinite_veh_ammo.cpp
@@ -9,33 +9,29 @@ namespace big
 
 		virtual void on_tick() override
         {
-            Vehicle player_veh = self::veh;
-
-            if (player_veh != 0 && VEHICLE::DOES_VEHICLE_HAVE_WEAPONS(player_veh))
+			if (self::veh && VEHICLE::DOES_VEHICLE_HAVE_WEAPONS(self::veh))
             {
                 for (int i = 0; i < 3; i++)
                 {
-                    VEHICLE::SET_VEHICLE_WEAPON_RESTRICTED_AMMO(player_veh, i, -1);
+					VEHICLE::SET_VEHICLE_WEAPON_RESTRICTED_AMMO(self::veh, i, -1);
                 }
 
-                VEHICLE::SET_VEHICLE_BOMB_AMMO(player_veh, -1);
-                VEHICLE::SET_VEHICLE_COUNTERMEASURE_AMMO(player_veh, -1);
+                VEHICLE::SET_VEHICLE_BOMB_AMMO(self::veh, -1);
+				VEHICLE::SET_VEHICLE_COUNTERMEASURE_AMMO(self::veh, -1);
             }
         }
 
 		virtual void on_disable() override
 		{
-			Vehicle player_veh = self::veh;
-
-			if (player_veh != 0 && VEHICLE::DOES_VEHICLE_HAVE_WEAPONS(player_veh))
+			if (self::veh && VEHICLE::DOES_VEHICLE_HAVE_WEAPONS(self::veh))
 			{
 				for (int i = 0; i < 3; i++)
 				{
-					VEHICLE::SET_VEHICLE_WEAPON_RESTRICTED_AMMO(player_veh, i, 20);
+					VEHICLE::SET_VEHICLE_WEAPON_RESTRICTED_AMMO(self::veh, i, 20);
 				}
 
-				VEHICLE::SET_VEHICLE_BOMB_AMMO(player_veh, 20);
-				VEHICLE::SET_VEHICLE_COUNTERMEASURE_AMMO(player_veh, 20);
+				VEHICLE::SET_VEHICLE_BOMB_AMMO(self::veh, 20);
+				VEHICLE::SET_VEHICLE_COUNTERMEASURE_AMMO(self::veh, 20);
 			}
 		}
 	};

--- a/src/backend/looped/vehicle/infinite_veh_ammo.cpp
+++ b/src/backend/looped/vehicle/infinite_veh_ammo.cpp
@@ -11,12 +11,12 @@ namespace big
         {
 			if (self::veh && VEHICLE::DOES_VEHICLE_HAVE_WEAPONS(self::veh))
             {
-                for (int i = 0; i < 3; i++)
-                {
+				for (int i = 0; i < 3; i++)
+				{
 					VEHICLE::SET_VEHICLE_WEAPON_RESTRICTED_AMMO(self::veh, i, -1);
-                }
+				}
 
-                VEHICLE::SET_VEHICLE_BOMB_AMMO(self::veh, -1);
+				VEHICLE::SET_VEHICLE_BOMB_AMMO(self::veh, -1);
 				VEHICLE::SET_VEHICLE_COUNTERMEASURE_AMMO(self::veh, -1);
             }
         }

--- a/src/core/settings.hpp
+++ b/src/core/settings.hpp
@@ -753,6 +753,7 @@ namespace big
 			bool drive_on_water                         = false;
 			bool horn_boost                             = false;
 			bool instant_brake                          = false;
+			bool infinite_veh_ammo					    = false;
 			bool block_homing                           = true;
 			bool ls_customs                             = false; // don't save this to disk
 			bool seatbelt                               = false;
@@ -807,7 +808,7 @@ namespace big
 				NLOHMANN_DEFINE_TYPE_INTRUSIVE(vehicle_ammo_special, enabled, type, explosion_tag, speed, time_between_shots, alternate_wait_time, weapon_range, rocket_time_between_shots, rocket_alternate_wait_time, rocket_lock_on_range, rocket_range, rocket_reload_time, rocket_explosion_tag, rocket_lifetime, rocket_launch_speed, rocket_time_before_homing, rocket_improve_tracking)
 			} vehicle_ammo_special{};
 
-			NLOHMANN_DEFINE_TYPE_INTRUSIVE(vehicle, speedo_meter, fly, rainbow_paint, speed_unit, god_mode, proof_bullet, proof_fire, proof_collision, proof_melee, proof_explosion, proof_steam, proof_water, proof_mask, auto_drive_destination, auto_drive_style, auto_drive_speed, auto_turn_signals, boost_behavior, drive_on_water, horn_boost, instant_brake, block_homing, seatbelt, turn_signals, vehicle_jump, keep_vehicle_repaired, no_water_collision, disable_engine_auto_start, change_engine_state_immediately, keep_engine_running, keep_vehicle_clean, vehinvisibility, localveh_visibility, keep_on_ground, no_collision, unlimited_weapons, siren_mute, all_vehs_in_heists, abilities, vehicle_ammo_special)
+			NLOHMANN_DEFINE_TYPE_INTRUSIVE(vehicle, speedo_meter, fly, rainbow_paint, speed_unit, god_mode, proof_bullet, proof_fire, proof_collision, proof_melee, proof_explosion, proof_steam, proof_water, proof_mask, auto_drive_destination, auto_drive_style, auto_drive_speed, auto_turn_signals, boost_behavior, drive_on_water, horn_boost, instant_brake, infinite_veh_ammo, block_homing, seatbelt, turn_signals, vehicle_jump, keep_vehicle_repaired, no_water_collision, disable_engine_auto_start, change_engine_state_immediately, keep_engine_running, keep_vehicle_clean, vehinvisibility, localveh_visibility, keep_on_ground, no_collision, unlimited_weapons, siren_mute, all_vehs_in_heists, abilities, vehicle_ammo_special)
 		} vehicle{};
 
 		struct weapons

--- a/src/views/vehicle/view_vehicle.cpp
+++ b/src/views/vehicle/view_vehicle.cpp
@@ -68,6 +68,7 @@ namespace big
 			ImGui::BeginGroup();
 
 			components::command_checkbox<"vehgodmode">("GOD_MODE"_T.data());
+			components::command_checkbox<"infinitevehammo">();
 			components::command_checkbox<"hornboost">();
 			components::command_checkbox<"vehjump">();
 			components::command_checkbox<"invisveh">();


### PR DESCRIPTION
This PR adds a new "Infinite Vehicle Ammo" checkbox to the vehicle menu.
When enabled, any weapons in the player's vehicle, such as Oppressor Mk2 missiles, will have infinite ammo. This includes countermeasures and bombs.

The main difference between this and previous implementation attempts is that SET_VEHICLE_WEAPON_RESTRICTED_AMMO doesn't use weapon hashes and instead simply accesses the vehicle's weapon index.

This is a better long-term solution than trying to directly access a vehicle's weapon hashes since it does not require checks against potential new weapon hashes with future GTAO content updates.

en_us translation forthcoming.

Closes #1021 and #1637.