### PR TITLE
Fix: Vehicle Menu "Vehicle Controller" Translation Text Fix

### DIFF
--- a/src/services/vehicle/vehicle_control_service.cpp
+++ b/src/services/vehicle/vehicle_control_service.cpp
@@ -34,7 +34,7 @@ namespace big
 		}
 	};
 
-	vehicle_control_command g_vehicle_control("vehiclecontrol", "Vehicle controller", "Enables/Disables the vehicle controller.",
+	vehicle_control_command g_vehicle_control("vehiclecontrol", "VEHICLE_CONTROLLER"_T.data(), "VEHICLE_CONTROLLER_DESC"_T.data(),
 	    g.window.vehicle_control.opened);
 
 	void update_controlled_vehicle_doors(controlled_vehicle& veh)


### PR DESCRIPTION
For whatever reason, the "Vehicle controller" option in the Vehicle menu is a hard-coded English string which means it cannot be modified by translation files.

This update simply removes the hardcoded string and replaces it with references to "VEHICLE_CONTROLLER", which already exists in the translation files, and "VEHICLE_CONTROLLER_DESC" which needs to be added.

Helps resolve issues such as the one described here: https://github.com/YimMenu/Translations/pull/135#issuecomment-2073968967