### PR TITLE
Increased the maximum length of CEO Name from 15 to 64 characters.

### DIFF
--- a/src/function_types.hpp
+++ b/src/function_types.hpp
@@ -75,7 +75,6 @@ namespace big::functions
 
 	using set_gravity_level = void (*)(int level);
 
-	using check_chat_profanity              = int(__int64 chat_type, const char* input, const char** output);
 	using write_player_game_state_data_node = bool (*)(rage::netObject* plr, CPlayerGameStateDataNode* node);
 
 	using get_gameplay_cam_coords = Vector3 (*)();

--- a/src/gta_pointers.hpp
+++ b/src/gta_pointers.hpp
@@ -106,7 +106,6 @@ namespace big
 		PVOID m_native_return;
 		PVOID m_ctext_file_ptr;
 		PVOID m_get_label_text;
-		functions::check_chat_profanity* m_check_chat_profanity;
 		functions::write_player_game_state_data_node m_write_player_game_state_data_node;
 
 		ChatData** m_chat_data;

--- a/src/gta_pointers.hpp
+++ b/src/gta_pointers.hpp
@@ -104,6 +104,7 @@ namespace big
 		functions::set_gravity_level m_set_gravity_level;
 
 		PVOID m_native_return;
+		PVOID m_ctext_file_ptr;
 		PVOID m_get_label_text;
 		functions::check_chat_profanity* m_check_chat_profanity;
 		functions::write_player_game_state_data_node m_write_player_game_state_data_node;

--- a/src/native_hooks/am_pi_menu.hpp
+++ b/src/native_hooks/am_pi_menu.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#include "script_function.hpp"
+
+namespace big
+{
+	namespace am_pi_menu
+	{
+		static void DISPLAY_ONSCREEN_KEYBOARD(rage::scrNativeCallContext* src)
+		{
+			auto input_type       = src->get_arg<int>(0);
+			auto window_title     = src->get_arg<const char*>(1);
+			auto unk1             = src->get_arg<const char*>(2);
+			auto input_default    = src->get_arg<const char*>(3);
+			auto unk2             = src->get_arg<const char*>(4);
+			auto unk3             = src->get_arg<const char*>(5);
+			auto unk4             = src->get_arg<const char*>(6);
+			auto max_input_length = src->get_arg<int>(7);
+
+			if (max_input_length == 15)
+				max_input_length = 64;
+
+			MISC::DISPLAY_ONSCREEN_KEYBOARD(input_type, window_title, unk1, input_default, unk2, unk3, unk4, max_input_length);
+		}
+	}
+}

--- a/src/native_hooks/native_hooks.cpp
+++ b/src/native_hooks/native_hooks.cpp
@@ -11,6 +11,7 @@
 #include "network_session_host.hpp"
 #include "shop_controller.hpp"
 #include "tunables.hpp"
+#include "am_pi_menu.hpp"
 
 #include <script/scrProgram.hpp>
 #include <script/scrProgramTable.hpp>
@@ -127,6 +128,8 @@ namespace big
 
 		add_native_detour("am_launcher"_J, NativeIndex::START_NEW_SCRIPT_WITH_ARGS, am_launcher::START_NEW_SCRIPT_WITH_ARGS);
 		add_native_detour("am_launcher"_J, NativeIndex::NETWORK_HAS_RECEIVED_HOST_BROADCAST_DATA, freemode::NETWORK_HAS_RECEIVED_HOST_BROADCAST_DATA);
+
+		add_native_detour("am_pi_menu"_J, NativeIndex::DISPLAY_ONSCREEN_KEYBOARD, am_pi_menu::DISPLAY_ONSCREEN_KEYBOARD);
 
 		add_native_detour("fm_race_creator"_J, NativeIndex::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH, creator::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH);
 		add_native_detour("fm_capture_creator"_J, NativeIndex::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH, creator::GET_NUMBER_OF_THREADS_RUNNING_THE_SCRIPT_WITH_THIS_HASH);

--- a/src/pointers.cpp
+++ b/src/pointers.cpp
@@ -496,15 +496,6 @@ namespace big
                 g_pointers->m_gta.m_get_label_text = ptr.add(8).rip().as<PVOID>();
             }
         },
-        // Multiplayer chat filter
-        {
-            "MCF",
-            "E8 ? ? ? ? 83 F8 FF 75 B9",
-            [](memory::handle ptr)
-            {
-                g_pointers->m_gta.m_check_chat_profanity = ptr.add(1).rip().as<decltype(gta_pointers::m_check_chat_profanity)>();
-            }
-        },
         // Network
         {
             "N",

--- a/src/pointers.cpp
+++ b/src/pointers.cpp
@@ -489,10 +489,11 @@ namespace big
         // Get Label Text
         {
             "GLT",
-            "75 ? E8 ? ? ? ? 8B 0D ? ? ? ? 65 48 8B 04 25 ? ? ? ? BA ? ? ? ? 48 8B 04 C8 8B 0C 02 D1 E9",
+            "48 8D 0D ? ? ? ? E8 ? ? ? ? 45 33 C9 41 B0 ? B2",
             [](memory::handle ptr)
             {
-                g_pointers->m_gta.m_get_label_text = ptr.sub(19).as<PVOID>();
+                g_pointers->m_gta.m_ctext_file_ptr = ptr.add(3).rip().as<PVOID>();
+                g_pointers->m_gta.m_get_label_text = ptr.add(8).rip().as<PVOID>();
             }
         },
         // Multiplayer chat filter

--- a/src/services/custom_text/custom_text_callbacks.cpp
+++ b/src/services/custom_text/custom_text_callbacks.cpp
@@ -1,4 +1,6 @@
 #include "custom_text_callbacks.hpp"
+#include "hooking/hooking.hpp"
+#include "pointers.hpp"
 
 namespace big
 {
@@ -8,5 +10,16 @@ namespace big
 			return "~r~Dying with god mode, how?";
 
 		return nullptr;
+	}
+
+	const char* do_ceo_name_resize(const char* label)
+	{
+		auto original = g_hooking->get_original<hooks::get_label_text>()(g_pointers->m_gta.m_ctext_file_ptr, label);
+		if (auto pos = strstr((char*)original, "15"))
+		{
+			pos[0] = '6';
+			pos[1] = '4';
+		}
+		return original;
 	}
 }

--- a/src/services/custom_text/custom_text_callbacks.hpp
+++ b/src/services/custom_text/custom_text_callbacks.hpp
@@ -1,4 +1,5 @@
 namespace big
 {
 	extern const char* respawn_label_callback(const char* label);
+	extern const char* do_ceo_name_resize(const char* label);
 }

--- a/src/services/custom_text/custom_text_service.cpp
+++ b/src/services/custom_text/custom_text_service.cpp
@@ -7,6 +7,7 @@ namespace big
 	custom_text_service::custom_text_service()
 	{
 		add_callback_for_labels({"RESPAWN_W"_J, "RESPAWN_W_MP"_J}, respawn_label_callback);
+		add_callback_for_labels({"FMMC_KEY_TIP15"_J}, do_ceo_name_resize);
 		add_label_overwrite("GC_OTR_TMR"_J, "HIDING FROM CLOWNS");
 		// add_label_overwrite("TICK_LEFTCHEAT"_J, "~a~~HUD_COLOUR_WHITE~ has been swatted by Rockstar.");
 


### PR DESCRIPTION
This will hijack the call to DISPLAY_ONSCREEN_KEYBOARD and increase the size from 15 characters to the maximum the string will hold which is 64 characters. However, there doesn't seem to be an easy way to articulate we made this change to the user at runtime. Without them looking at the code, or just noticing the box is slightly bigger now, the instructions at the top still say (MAX: 15 Characters). It has to be a GXT string, it can't be a string literal, I've tried, it just gets set to blank.