### PR TITLE
Fixed vehicle extras to match the scripts.

### DIFF
--- a/src/gta/vehicle_values.hpp
+++ b/src/gta/vehicle_values.hpp
@@ -430,7 +430,6 @@ enum CustomVehicleModType
 	MOD_PRIMARY_CUSTOM   = -131,
 	MOD_SECONDARY_CUSTOM = -132,
 
-	MOD_EXTRA_0  = -200,
 	MOD_EXTRA_1  = -201,
 	MOD_EXTRA_2  = -202,
 	MOD_EXTRA_3  = -203,

--- a/src/util/vehicle.cpp
+++ b/src/util/vehicle.cpp
@@ -345,9 +345,9 @@ namespace big::vehicle
 		}
 
 		// EXTRA
-		for (int extra = MOD_EXTRA_11; extra <= MOD_EXTRA_0; extra++)
+		for (int extra = MOD_EXTRA_14; extra <= MOD_EXTRA_1; extra++)
 		{
-			int gta_extra_id  = (extra - MOD_EXTRA_0) * -1;
+			int gta_extra_id  = (extra - MOD_EXTRA_1) * -1;
 			owned_mods[extra] = val_77 >> (gta_extra_id - 1) & 1;
 		}
 
@@ -438,9 +438,9 @@ namespace big::vehicle
 			}
 		}
 
-		for (int extra = MOD_EXTRA_11; extra <= MOD_EXTRA_0; extra++)
+		for (int extra = MOD_EXTRA_14; extra <= MOD_EXTRA_1; extra++)
 		{
-			int gta_extra_id = (extra - MOD_EXTRA_0) * -1;
+			int gta_extra_id = (extra - MOD_EXTRA_1) * -1;
 			if (owned_mods.count(extra) && VEHICLE::DOES_EXTRA_EXIST(vehicle, gta_extra_id))
 			{
 				VEHICLE::SET_VEHICLE_EXTRA(vehicle, gta_extra_id, owned_mods[extra] == 0);
@@ -526,9 +526,9 @@ namespace big::vehicle
 			}
 		}
 
-		for (int extra = MOD_EXTRA_11; extra <= MOD_EXTRA_0; extra++)
+		for (int extra = MOD_EXTRA_14; extra <= MOD_EXTRA_1; extra++)
 		{
-			int gta_extra_id = (extra - MOD_EXTRA_0) * -1;
+			int gta_extra_id = (extra - MOD_EXTRA_1) * -1;
 			if (VEHICLE::DOES_EXTRA_EXIST(vehicle, gta_extra_id))
 			{
 				owned_mods[extra] = VEHICLE::IS_VEHICLE_EXTRA_TURNED_ON(vehicle, gta_extra_id);

--- a/src/views/vehicle/view_lsc.cpp
+++ b/src/views/vehicle/view_lsc.cpp
@@ -450,7 +450,7 @@ namespace big
 		}
 
 		int item_counter = 0;
-		for (int extra = MOD_EXTRA_0; extra >= MOD_EXTRA_14; extra--)
+		for (int extra = MOD_EXTRA_1; extra >= MOD_EXTRA_14; extra--)
 		{
 			if (owned_mods.find(extra) != owned_mods.end())
 			{
@@ -461,7 +461,7 @@ namespace big
 				}
 				if ((item_counter % 5) != 0)
 					ImGui::SameLine();
-				int gta_extra_id      = (extra - MOD_EXTRA_0) * -1;
+				int gta_extra_id      = (extra - MOD_EXTRA_1) * -1;
 				auto name             = std::format("{}: #{}", "VIEW_LSC_EXTRAS"_T, gta_extra_id);
 				bool is_extra_enabled = owned_mods[extra] == 1;
 				if (ImGui::Checkbox(name.c_str(), &is_extra_enabled))


### PR DESCRIPTION
The scripts are deceiving, as they initialize the iterator to 0, but each time it is referenced, it adds 1 to it. The max for those instances is 8 (9?). However, there are some that max out at 14. Those start at 1 implicitly.

Example scripts:

```
iVar0 = 1;
while (iVar0 <= 14)
{
	if (VEHICLE::DOES_EXTRA_EXIST(iParam0, iVar0))
	{
		VEHICLE::SET_VEHICLE_EXTRA(*uParam1, iVar0, !VEHICLE::IS_VEHICLE_EXTRA_TURNED_ON(iParam0, iVar0));
	}
	iVar0++;
}
```

```
iVar0 = 0;
while (iVar0 < 8)
{
	if (VEHICLE::DOES_EXTRA_EXIST(iParam0, iVar0 + 1))
	{
		if (func_7891(iParam0))
		{
			VEHICLE::SET_VEHICLE_EXTRA(iParam0, iVar0 + 1, true);
		}
		else
		{
			VEHICLE::SET_VEHICLE_EXTRA(iParam0, iVar0 + 1, false);
		}
	}
	iVar0++;
}
```