### PR TITLE
Allow Trusted Players & Friends to Request Control

### DIFF
--- a/src/hooks/protections/received_event.cpp
+++ b/src/hooks/protections/received_event.cpp
@@ -535,7 +535,7 @@ namespace big
 				{
 					auto plyr = g_player_service->get_by_id(source_player->m_player_id);
 					// Let trusted friends and players request control (e.g., they want to hook us to their tow-truck or something)
-					if (plyr && ((g.session.trust_friends && plyr->is_friend()) || plyr->is_trusted))
+					if (plyr && (plyr->is_trusted || (g.session.trust_friends && plyr->is_friend())))
 					{
 						return;
 					}

--- a/src/hooks/protections/received_event.cpp
+++ b/src/hooks/protections/received_event.cpp
@@ -533,6 +533,13 @@ namespace big
 				    || personal_vehicle == veh              //Or we're in our personal vehicle.
 				    || self::spawned_vehicles.contains(net_id)) // Or it's a vehicle we spawned.
 				{
+					auto plyr = g_player_service->get_by_id(source_player->m_player_id);
+					// Let trusted friends and players request control (e.g., they want to hook us to their tow-truck or something)
+					if (plyr && ((g.session.trust_friends && plyr->is_friend()) || plyr->is_trusted))
+					{
+						return;
+					}
+
 					if (g_local_player->m_vehicle->m_driver != source_player->m_player_info->m_ped) //This will block hackers who are not in the car but still want control.
 					{
 						g_pointers->m_gta.m_send_event_ack(event_manager, source_player, target_player, event_index, event_handled_bitset); // Tell them to get bent.


### PR DESCRIPTION
This update adds a check to eNetworkEvents::REQUEST_CONTROL_EVENT to allow trusted players and friends to request control of our vehicles.

I think only a very few use cases would benefit from this change, but the following is a good example:
Closes https://github.com/YimMenu/YimMenu/issues/2999

In general I'm in favor of letting trusted players and friends do whatever they want in order to preserve as much intended functionality as possible. If they do something to bug me I can boot them off my friends list and give them a wedgie at school.