### PR TITLE
PlayerDB Delete Untrusted Players

### DIFF
--- a/src/services/player_database/player_database_service.cpp
+++ b/src/services/player_database/player_database_service.cpp
@@ -219,6 +219,33 @@ namespace big
 		return player;
 	}
 
+	void player_database_service::remove_untrusted_players()
+	{
+		for (auto it = m_players.begin(); it != m_players.end();)
+		{
+			if (!it->second->is_trusted)
+			{
+				it = m_players.erase(it);
+			}
+			else
+			{
+				++it;
+			}
+		}
+
+		for (auto it = m_sorted_players.begin(); it != m_sorted_players.end();)
+		{
+			if (!it->second->is_trusted)
+			{
+				it = m_sorted_players.erase(it);
+			}
+			else
+			{
+				++it;
+			}
+		}
+	}
+
 	std::shared_ptr<persistent_player> player_database_service::get_player_by_rockstar_id(uint64_t rockstar_id)
 	{
 		if (m_players.contains(rockstar_id))
@@ -303,7 +330,7 @@ namespace big
 					updating = true;
 					g_fiber_pool->queue_job([this] {
 						update_player_states(true);
-						updating = false;
+						updating    = false;
 						last_update = std::chrono::high_resolution_clock::now();
 					});
 				}

--- a/src/services/player_database/player_database_service.cpp
+++ b/src/services/player_database/player_database_service.cpp
@@ -330,7 +330,7 @@ namespace big
 					updating = true;
 					g_fiber_pool->queue_job([this] {
 						update_player_states(true);
-						updating    = false;
+						updating = false;
 						last_update = std::chrono::high_resolution_clock::now();
 					});
 				}

--- a/src/services/player_database/player_database_service.hpp
+++ b/src/services/player_database/player_database_service.hpp
@@ -47,6 +47,7 @@ namespace big
 		std::map<std::string, std::shared_ptr<persistent_player>>& get_sorted_players();
 		std::shared_ptr<persistent_player> get_player_by_rockstar_id(uint64_t rockstar_id);
 		std::shared_ptr<persistent_player> get_or_create_player(player_ptr player);
+		void remove_untrusted_players();
 		void update_rockstar_id(uint64_t old, uint64_t _new);
 		void remove_rockstar_id(uint64_t rockstar_id);
 

--- a/src/views/network/view_player_database.cpp
+++ b/src/views/network/view_player_database.cpp
@@ -281,6 +281,33 @@ namespace big
 			ImGui::EndChild();
 		}
 
+		if (ImGui::Button("REMOVE_UNTRUSTED"_T.data()))
+		{
+			ImGui::OpenPopup("##removeuntrusted");
+		}
+
+		if (ImGui::BeginPopupModal("##removeuntrusted"))
+		{
+			ImGui::Text("VIEW_NET_PLAYER_DB_ARE_YOU_SURE"_T.data());
+
+			if (ImGui::Button("YES"_T.data()))
+			{
+				g_player_database_service->set_selected(nullptr);
+				g_player_database_service->remove_untrusted_players();
+				g_player_database_service->save();
+				ImGui::CloseCurrentPopup();
+			}
+			ImGui::SameLine();
+			if (ImGui::Button("NO"_T.data()))
+			{
+				ImGui::CloseCurrentPopup();
+			}
+
+			ImGui::EndPopup();
+		}
+
+		ImGui::SameLine();
+
 		if (ImGui::Button("REMOVE_ALL"_T.data()))
 		{
 			ImGui::OpenPopup("##removeall");
@@ -306,8 +333,6 @@ namespace big
 
 			ImGui::EndPopup();
 		}
-
-		ImGui::SameLine();
 
 		components::button("RELOAD_PLYR_ONLINE_STATES"_T, [] {
 			g_player_database_service->update_player_states();


### PR DESCRIPTION
As a player, I currently enjoy the option to clear the Player Database of player entries that are marked as modders. YimMenu adds these entries automatically as reactions to events such as attacking players with god mode, superjump, kick/crash attempts, and more.

However, I also use the Player Database to keep track of trusted players and friends, especially since I find it much easier to track and join friends using YimMenu rather than the in-game browser. Finding friends in the Player Database can become difficult as it fills up, and I don't want to delete friends with the Remove All option.

This PR adds another button called "Remove Untrusted" which removes any players from the Player Database who are not marked "Trust". This allows players like me to enjoy the advantages of YimMenu's player database with friends and other trusted players, without having to navigate through large lists of modders every time.