### PR TITLE
[Workaround]: Remove Start LS Customs Button from LS Customs Menu

### DIFF
--- a/src/views/debug/view_debug_misc.cpp
+++ b/src/views/debug/view_debug_misc.cpp
@@ -60,6 +60,10 @@ namespace big
 				DLC::ON_ENTER_SP();
 			});
 
+			components::button("START_LS_CUSTOMS"_T, [] {
+				g.vehicle.ls_customs = true;
+			});
+
 			components::button("SKIP_CUTSCENE"_T, [] {
 				CUTSCENE::STOP_CUTSCENE_IMMEDIATELY();
 			});

--- a/src/views/vehicle/view_lsc.cpp
+++ b/src/views/vehicle/view_lsc.cpp
@@ -192,7 +192,15 @@ namespace big
 			});
 		}
 
+		// LSC script is broken, release builds should hide the button from users but we will keep it for debugging
+		#ifndef NDEBUG
+		components::button("START_LS_CUSTOMS"_T, [] {
+			g.vehicle.ls_customs = true;
+		});
+
 		ImGui::SameLine();
+		#endif
+
 		if (components::button("MAX_VEHICLE"_T))
 		{
 			g_fiber_pool->queue_job([] {

--- a/src/views/vehicle/view_lsc.cpp
+++ b/src/views/vehicle/view_lsc.cpp
@@ -192,9 +192,6 @@ namespace big
 			});
 		}
 
-		components::button("START_LS_CUSTOMS"_T, [] {
-			g.vehicle.ls_customs = true;
-		});
 		ImGui::SameLine();
 		if (components::button("MAX_VEHICLE"_T))
 		{

--- a/src/views/vehicle/view_lsc.cpp
+++ b/src/views/vehicle/view_lsc.cpp
@@ -192,15 +192,6 @@ namespace big
 			});
 		}
 
-		// LSC script is broken, release builds should hide the button from users but we will keep it for debugging
-		#ifndef NDEBUG
-		components::button("START_LS_CUSTOMS"_T, [] {
-			g.vehicle.ls_customs = true;
-		});
-
-		ImGui::SameLine();
-		#endif
-
 		if (components::button("MAX_VEHICLE"_T))
 		{
 			g_fiber_pool->queue_job([] {


### PR DESCRIPTION
After making changes to a vehicle via the LSC script, the game stops responding to mouse and keyboard events. It gets stuck in some sort of transition phase between LSC and freemode. Maybe it's waiting for the drive-out cutscene to finish before returning player control? I'm not sure, but it's 100% reproducible.

Unless someone wants to take a crack at fixing this script, I think we should prevent users from activating it since they're spending actual GTA$.