### PR TITLE
[Hotfix]: Wanted Level

### DIFF
--- a/src/backend/looped/self/wanted_level.cpp
+++ b/src/backend/looped/self/wanted_level.cpp
@@ -26,7 +26,7 @@ namespace big
 		}
 	};
 
-	clear_wanted g_clear_wanted("clearwanted", "CLEAR_WANTED_LEVEL", "CLEAR_WANTED_LEVEL_DESC_SELF", 0);
+	clear_wanted g_clear_wanted("clearwantedself", "CLEAR_WANTED_LEVEL", "CLEAR_WANTED_LEVEL_DESC_SELF", 0);
 
 	class never_wanted : looped_command
 	{
@@ -39,10 +39,7 @@ namespace big
 			g_local_player->m_player_info->m_is_wanted    = false;
 
 			// Since we're hiding the force wanted checkbox and wanted slider, we don't need to do anything else
-		}
-		virtual void on_disable() override
-		{
-			// If we turn off never wanted, be sure to disable force wanted to restore to a "default" setting
+			g.self.wanted_level       = 0;
 			g.self.force_wanted_level = false;
 		}
 	};

--- a/src/services/hotkey/hotkey_service.cpp
+++ b/src/services/hotkey/hotkey_service.cpp
@@ -14,7 +14,7 @@ namespace big
 		// ordered alphabetically to more easily see if a certain hotkey is present
 		register_hotkey("beastjump", g.settings.hotkeys.beastjump, "beastjump"_J);
 		register_hotkey("bringpv", g.settings.hotkeys.bringvehicle, "bringpv"_J);
-		register_hotkey("clearwantedlvl", g.settings.hotkeys.clear_wanted, "clearwantedlvl"_J);
+		register_hotkey("clearwantedself", g.settings.hotkeys.clear_wanted, "clearwantedself"_J);
 		register_hotkey("cmdexecutor", g.settings.hotkeys.cmd_excecutor, "cmdexecutor"_J);
 		register_hotkey("fastquit", g.settings.hotkeys.fast_quit, "fastquit"_J);
 		register_hotkey("fastrun", g.settings.hotkeys.superrun, "fastrun"_J);

--- a/src/views/self/view_self.cpp
+++ b/src/views/self/view_self.cpp
@@ -218,7 +218,7 @@ namespace big
 		if (!g.self.never_wanted)
 		{
 			ImGui::SameLine();
-			components::command_button<"clearwanted">();
+			components::command_button<"clearwantedself">();
 
 			// Most ImGui widgets return true when they've been changed, so this is useful to prevent us from overwriting the wanted level's natural decay/progression if we're not keeping it locked
 			ImGui::SetNextItemWidth(200);

--- a/src/views/settings/view_hotkey_settings.cpp
+++ b/src/views/settings/view_hotkey_settings.cpp
@@ -59,7 +59,7 @@ namespace big
 		if (ImGui::Hotkey("VIEW_HOTKEY_SETTINGS_TOGGLE_VEHICLE_FLY"_T.data(), &g.settings.hotkeys.vehicle_flymode))
 			g_hotkey_service->update_hotkey("vehiclefly", g.settings.hotkeys.vehicle_flymode);
 		if (ImGui::Hotkey("CLEAR_WANTED_LEVEL"_T.data(), &g.settings.hotkeys.clear_wanted))
-			g_hotkey_service->update_hotkey("clearwantedlvl", g.settings.hotkeys.clear_wanted);
+			g_hotkey_service->update_hotkey("clearwantedself", g.settings.hotkeys.clear_wanted);
 
 		ImGui::PopItemWidth();
 	}


### PR DESCRIPTION
Couple things slipped through my fingers the other night that I'm resolving with this PR:

- Never Wanted will now properly reset the slider and force wanted level buttons, which I think is better behavior because we don't want to restore a previously-configured wanted level when turning off Never Wanted
- I renamed the clear wanted level command for self to "clearwantedself" since I failed to notice that the "clearwanted" command was already being used by the player menu's clear wanted option, which broke it
- Also updated the hotkey to properly call the new command