### PR TITLE
More Crash Fixes (?)

### DIFF
--- a/src/util/entity.cpp
+++ b/src/util/entity.cpp
@@ -169,7 +169,7 @@ namespace big::entity
 		{
 			for (auto vehicle : pools::get_all_vehicles())
 			{
-				if (!include_self_veh && vehicle == gta_util::get_local_vehicle())
+				if (!vehicle || (!include_self_veh && vehicle == gta_util::get_local_vehicle()))
 					continue;
 
 				target_entities.push_back(g_pointers->m_gta.m_ptr_to_handle(vehicle));
@@ -180,7 +180,7 @@ namespace big::entity
 		{
 			for (auto ped : pools::get_all_peds())
 			{
-				if (ped == g_local_player)
+				if (!ped || ped == g_local_player)
 					continue;
 
 				target_entities.push_back(g_pointers->m_gta.m_ptr_to_handle(ped));
@@ -191,6 +191,9 @@ namespace big::entity
 		{
 			for (auto prop : pools::get_all_props())
 			{
+				if (!prop)
+					continue;
+
 				target_entities.push_back(g_pointers->m_gta.m_ptr_to_handle(prop));
 			}
 		}

--- a/src/util/notify.cpp
+++ b/src/util/notify.cpp
@@ -22,7 +22,7 @@ namespace big::notify
 
 	void crash_blocked(CNetGamePlayer* player, const char* crash)
 	{
-		if (player)
+		if (player && g_player_service->get_by_id(player->m_player_id))
 		{
 			if ((g_player_service->get_by_id(player->m_player_id)->is_friend() && g.session.trust_friends)
 			    || g_player_service->get_by_id(player->m_player_id)->is_trusted || g.session.trust_session)


### PR DESCRIPTION
More null checks to address these couple of crashes I've been seeing. One from remove_clone_creates and the other from crash_blocked (oh the irony).

crash_blocked:
```
EXCEPTION_ACCESS_VIOLATION
Dumping registers:
RAX: 0x23095EA2E60
RCX: 0x0
RDX: 0x231015D0530
RBX: 0x0
RSI: 0x7FF646FDAD90
RDI: 0x3
RSP: 0x3494AFC670
RBP: 0x3494AFC770
R8:  0x0
R9:  0x10
R10: 0x23047E45A60
R11: 0x23047E45A60
R12: 0x7FFE65C20518
R13: 0x0
R14: 0x22F9C86CD60
R15: 0x7FF646FDF3B0
Dumping stacktrace:
[0]	D:\Documents\GitHub\YimMenu\src\util\notify.cpp L: 28 big::notify::crash_blocked
[1]	D:\Documents\GitHub\YimMenu\src\hooks\protections\received_clone_remove.cpp L: 11 big::hooks::received_clone_remove
[2]	GTA5.exe+0x16DC4F2 0x7FF645D3C4F2
[3]	GTA5.exe+0x16D3D44 0x7FF645D33D44
[4]	GTA5.exe+0x16D9414 0x7FF645D39414
[5]	GTA5.exe+0x1461FD5 0x7FF645AC1FD5
[6]	GTA5.exe+0x16D9541 0x7FF645D39541
[7]	GTA5.exe+0x1400D52 0x7FF645A60D52
[8]	D:\Documents\GitHub\YimMenu\src\hooks\protections\receive_net_message.cpp L: 285 big::hooks::receive_net_message
[9]	GTA5.exe+0x1400E05 0x7FF645A60E05
[10]	GTA5.exe+0x1400B1E 0x7FF645A60B1E
[11]	GTA5.exe+0x142B733 0x7FF645A8B733
[12]	GTA5.exe+0x10CA305 0x7FF64572A305
[13]	GTA5.exe+0x1633449 0x7FF645C93449
[14]	GTA5.exe+0x1632C7F 0x7FF645C92C7F
[15]	GTA5.exe+0x2767E 0x7FF64468767E
[16]	GTA5.exe+0x20D8B 0x7FF644680D8B
[17]	GTA5.exe+0x1632888 0x7FF645C92888
[18]	GTA5.exe+0x1494 0x7FF644661494
[19]	GTA5.exe+0x130904F 0x7FF64596904F
[20]	GTA5.exe+0x1825DCC 0x7FF645E85DCC
[21]	KERNEL32.DLL BaseThreadInitThunk
[22]	ntdll.dll RtlUserThreadStart
--------End of exception--------
```

get_entities:
```
EXCEPTION_ACCESS_VIOLATION
Dumping registers:
RAX: 0x0
RCX: 0x0
RDX: 0x1E
RBX: 0x22FFFFFFF7F
RSI: 0x0
RDI: 0x1E
RSP: 0x34969FF6E0
RBP: 0x0
R8:  0x1E
R9:  0x1
R10: 0x3
R11: 0x34969FF650
R12: 0x0
R13: 0x1
R14: 0x22F9B3BE1D0
R15: 0x22F9B3BE1D0
Dumping stacktrace:
[0]	GTA5.exe+0x1678368 0x7FF645CD8368
[1]	GTA5.exe+0x1628A5F 0x7FF645C88A5F
[2]	D:\Documents\GitHub\YimMenu\src\util\entity.cpp L: 186 big::entity::get_entities
[3]	D:\Documents\GitHub\YimMenu\src\views\esp\view_esp.cpp L: 504 big::esp::draw
[4]	D:\Documents\GitHub\YimMenu\src\hooks\gui\swap_chain_present.cpp L: 11 big::hooks::swapchain_present
[5]	GTA5.exe+0x139A54E 0x7FF6459FA54E
[6]	GTA5.exe+0x7ED74D 0x7FF644E4D74D
[7]	GTA5.exe+0x167F5E1 0x7FF645CDF5E1
[8]	GTA5.exe+0x167F4FE 0x7FF645CDF4FE
[9]	GTA5.exe+0x1659DC5 0x7FF645CB9DC5
[10]	GTA5.exe+0x165A736 0x7FF645CBA736
[11]	GTA5.exe+0x166342A 0x7FF645CC342A
[12]	GTA5.exe+0x131266A 0x7FF64597266A
[13]	KERNEL32.DLL BaseThreadInitThunk
[14]	ntdll.dll RtlUserThreadStart
[15]	GTA5.exe+0x2767E 0x7FF64468767E
[16]	GTA5.exe+0x20D8B 0x7FF644680D8B
[17]	GTA5.exe+0x1632888 0x7FF645C92888
[18]	GTA5.exe+0x1494 0x7FF644661494
[19]	GTA5.exe+0x130904F 0x7FF64596904F
[20]	GTA5.exe+0x1825DCC 0x7FF645E85DCC
[21]	KERNEL32.DLL BaseThreadInitThunk
[22]	ntdll.dll RtlUserThreadStart
--------End of exception--------
```