### PR TITLE
[Bugfix]: First-Time IPL Loads for North Yankton

### DIFF
--- a/src/core/data/ipls.hpp
+++ b/src/core/data/ipls.hpp
@@ -74,10 +74,11 @@ const ipl_libary ipls[] = {
         {{"jewel2fake"}},
         {{"jewel2fake"}, {"bh1_16_refurb"}},
     }, // Jewelry Interior
-    {"Coroner Morgue Interior", 
-    {244.9, -1374.7, 39.5},
-    {{"coroner_int_on"}, {"coronertrash"}},
-    {{"coroner_int_off"}},
-    {{"coroner_int_off"}},
+    {
+        "Coroner Morgue Interior", 
+        {244.9, -1374.7, 39.5},
+        {{"coroner_int_on"}, {"coronertrash"}},
+        {{"coroner_int_off"}},
+        {{"coroner_int_off"}},
     }, // Coroner Morgue Interior
 };

--- a/src/views/self/view_teleport.cpp
+++ b/src/views/self/view_teleport.cpp
@@ -94,7 +94,7 @@ namespace big
 		ImGui::SeparatorText("GUI_TAB_IPL"_T.data());
 
 		static int current_select = 0;
-		static int last_select    = current_select;
+		static int last_select    = -1;
 
 		ImGui::SetNextItemWidth(400);
 		if (ImGui::BeginCombo("##Ipllocation", ipls[current_select].friendly_name))
@@ -120,18 +120,22 @@ namespace big
 			if (current_select != last_select)
 			{
 				// Unload previously loaded IPL of the last selection
-				for (auto& ipl_name_unload : ipls[last_select].ipl_names)
+				// If this is our first time loading an IPL (especially the first one in the list, then don't unload anything)
+				if (last_select != -1)
 				{
-					if (STREAMING::IS_IPL_ACTIVE(ipl_name_unload))
+					for (auto& ipl_name_unload : ipls[last_select].ipl_names)
 					{
-						STREAMING::REMOVE_IPL(ipl_name_unload);
+						if (STREAMING::IS_IPL_ACTIVE(ipl_name_unload))
+						{
+							STREAMING::REMOVE_IPL(ipl_name_unload);
+						}
 					}
-				}
 
-				// Load previously deleted IPLs of the last selection
-				for (auto& ipl_name_load : ipls[last_select].ipl_names_remove)
-				{
-					STREAMING::REQUEST_IPL(ipl_name_load);
+					// Load previously deleted IPLs of the last selection
+					for (auto& ipl_name_load : ipls[last_select].ipl_names_remove)
+					{
+						STREAMING::REQUEST_IPL(ipl_name_load);
+					}
 				}
 
 				// Load new IPLs of the current selection


### PR DESCRIPTION
This PR resolves a bug with the IPL system where the menu wouldn't load an IPL until the default selection in the drop-down menu (North Yankton) was changed, due to the current_select and last_select static variables both being initialized to zero, causing the if (current_select != last_select) check to pass and thereby avoiding all the subsequent STREAMING:: calls.

Users trying to load North Yankton would first have to select a different IPL from the menu and then re-select North Yankton to be able to load the IPL properly, which is obviously unintended behavior.

This new code allows the IPL load feature to behave as expected.

I also fixed some formatting of the Coroner Morgue Interior ipl_library structure that was bothering me.