### PR TITLE
Fixing invalid sanity-checks

### DIFF
--- a/src/backend/commands/player/kick/breakup_kick.cpp
+++ b/src/backend/commands/player/kick/breakup_kick.cpp
@@ -20,7 +20,7 @@ namespace big
 
 		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx) override
 		{
-			if (!player || !g_player_service->get_self()->is_host() || !player->get_net_data() || !player->is_valid())
+			if (!player && !g_player_service->get_self()->is_host() && !player->get_net_data() && !player->is_valid())
 				return;
 
 			rage::snMsgRemoveGamersFromSessionCmd cmd{};

--- a/src/backend/commands/player/kick/complaint_kick.cpp
+++ b/src/backend/commands/player/kick/complaint_kick.cpp
@@ -19,7 +19,7 @@ namespace big
 
 		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx) override
 		{
-			if (!player || !player->is_valid())
+			if (!player && !player->is_valid())
 				return;
 			if (gta_util::get_network()->m_game_session_ptr->is_host())
 			{

--- a/src/backend/commands/player/kick/end_session_kick.cpp
+++ b/src/backend/commands/player/kick/end_session_kick.cpp
@@ -17,7 +17,7 @@ namespace big
 
 		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx) override
 		{
-			if (!player || !player->is_valid())
+			if (!player && !player->is_valid())
 				return;
 			if (!scripts::force_host("freemode"_J))
 			{

--- a/src/backend/commands/player/kick/host_kick.cpp
+++ b/src/backend/commands/player/kick/host_kick.cpp
@@ -14,7 +14,7 @@ namespace big
 
 		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx) override
 		{
-			if (!player || !player->is_valid())
+			if (!player && !player->is_valid())
 				return;
 			if (!g_player_service->get_self()->is_host())
 			{

--- a/src/backend/commands/player/kick/oom_kick.cpp
+++ b/src/backend/commands/player/kick/oom_kick.cpp
@@ -20,7 +20,7 @@ namespace big
 
 		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx) override
 		{
-			if (!player || !player->is_valid())
+			if (!player && !player->is_valid())
 				return;
 			packet msg{};
 

--- a/src/backend/commands/player/kick/script_host_kick.cpp
+++ b/src/backend/commands/player/kick/script_host_kick.cpp
@@ -17,7 +17,7 @@ namespace big
 
 		virtual void execute(player_ptr player, const command_arguments& _args, const std::shared_ptr<command_context> ctx) override
 		{
-			if (!player || !player->is_valid())
+			if (!player && !player->is_valid())
 				return;
 			if (!scripts::force_host("freemode"_J))
 			{


### PR DESCRIPTION
There have been some invalid nullptr checks (which apparently even slip throu #3066). Unless I heavily overslept this should fix any possible crashes.

(+ It took me an eternity to not have unwanted whitespace changes on the last lines.....)