### PR TITLE
[Enhancement]: Session Switcher Combo

### DIFF
--- a/src/views/network/view_network.cpp
+++ b/src/views/network/view_network.cpp
@@ -138,7 +138,7 @@ namespace big
 				if (id == eSessionType::LEAVE_ONLINE && gta_util::get_network_player_mgr()->m_player_count == 0) // Don't show a Leave Online option in single player (it actually sends us INTO online)
 					continue;
 
-				ImGui::BeginDisabled(selected_region_index == -1 && id != eSessionType::LEAVE_ONLINE); // Leave online is always enabled
+				ImGui::BeginDisabled(selected_region_index == -1 && id != eSessionType::LEAVE_ONLINE); // Leave Online is always enabled in online sessions since we don't care about the selected region
 				components::selectable(g_translation_service.get_translation(name), false, [&id] {
 					session::join_type(id);
 				});

--- a/src/views/network/view_network.cpp
+++ b/src/views/network/view_network.cpp
@@ -97,11 +97,10 @@ namespace big
 			{
 				for (const auto& region_type : regions)
 				{
-                    components::selectable(region_type.name, *g_pointers->m_gta.m_region_code == region_type.id, [&region_type] 
-                    {
-                        *g_pointers->m_gta.m_region_code = region_type.id;
-                        region_updated = true;
-                    });
+					components::selectable(region_type.name, *g_pointers->m_gta.m_region_code == region_type.id, [&region_type] {
+						*g_pointers->m_gta.m_region_code = region_type.id;
+						region_updated                   = true;
+					});
 				}
 				ImGui::EndCombo();
 			}

--- a/src/views/network/view_network.cpp
+++ b/src/views/network/view_network.cpp
@@ -84,10 +84,11 @@ namespace big
 		if (g_pointers->m_gta.m_region_code == nullptr)
 			return;
 
-		static int selected_region_index     = -1;
-		static bool region_updated = false;
+		static int selected_region_index = -1;
+		static bool region_updated       = false;
 
-        std::string region_str = (selected_region_index == -1) ? "SESSION_SELECT_COMBO"_T.data() : regions[*g_pointers->m_gta.m_region_code].name;
+		std::string region_str =
+		    (selected_region_index == -1) ? "SESSION_SELECT_COMBO"_T.data() : regions[*g_pointers->m_gta.m_region_code].name;
 
 		ImGui::BeginGroup();
 		components::sub_title("SESSION_SELECT"_T);

--- a/src/views/network/view_network.cpp
+++ b/src/views/network/view_network.cpp
@@ -81,11 +81,14 @@ namespace big
 
 	void render_session_switcher()
 	{
+		static int selected_region_index     = -1;
+        std::string region_str = (selected_region_index == -1) ? "REGIONS"_T.data() : regions[*g_pointers->m_gta.m_region_code].name;
+
 		ImGui::BeginGroup();
 		components::sub_title("SESSION_SWITCHER"_T);
 		if (ImGui::BeginListBox("###session_switch", get_listbox_dimensions()))
 		{
-			if (ImGui::BeginCombo("##regionswitcher", "REGIONS"_T.data()))
+			if (ImGui::BeginCombo("##regionswitcher", region_str.c_str()))
 			{
 				for (const auto& region_type : regions)
 				{
@@ -93,6 +96,9 @@ namespace big
 						*g_pointers->m_gta.m_region_code = region_type.id;
 					});
 				}
+
+				selected_region_index = *g_pointers->m_gta.m_region_code;
+
 				ImGui::EndCombo();
 			}
 


### PR DESCRIPTION
Instead of the "Session Switcher" combo drop-down always just saying "Regions", now it will show which region the user had selected.

![image](https://github.com/YimMenu/YimMenu/assets/13259220/4fd46b0c-090c-46a9-aac0-e2e015ee7e8b)
