### PR TITLE
fix delete train

### DIFF
--- a/src/util/train.hpp
+++ b/src/util/train.hpp
@@ -38,7 +38,7 @@ namespace big::train
 
 	inline void delete_train()
 	{
-		if (!self::veh && get_closest_train() != 0)
+		if (get_closest_train() != 0)
 		{
 			VEHICLE::DELETE_ALL_TRAINS();
 		}


### PR DESCRIPTION
The delete train feature was non function because of an incorrect condition (!self::veh) in the delete_train function. 

This PR fixes the issue by removing the problematic condition and simplifying the delete_train function. Now, it only checks if get_closest_train() returns a non-zero value to determine if a train is found.

In reference to #3108