### PR TITLE
[Enhancement]: Small Refactor of Session Bad Sport Spoofing Layout

### DIFF
--- a/src/core/settings.hpp
+++ b/src/core/settings.hpp
@@ -703,12 +703,11 @@ namespace big
 			int session_language                = 0;
 			bool spoof_session_player_count     = false;
 			int session_player_count            = 25;
-			bool spoof_session_bad_sport_status = false;
-			bool session_bad_sport              = false;
+			int spoof_session_bad_sport_status  = 0;
 
 			bool voice_chat_audio = false;
 
-			NLOHMANN_DEFINE_TYPE_INTRUSIVE(spoofing, hide_from_player_list, spoof_blip, blip_type, spoof_rank, rank, spoof_job_points, job_points, spoof_kd_ratio, kd_ratio, spoof_bad_sport, badsport_type, spoof_player_model, player_model, spoof_cheater, spoof_hide_god, spoof_hide_veh_god, spoof_hide_spectate, spoof_crew_data, crew_tag, rockstar_crew, square_crew_tag, spoof_session_region_type, session_region_type, spoof_session_language, session_language, spoof_session_player_count, session_player_count, spoof_session_bad_sport_status, session_bad_sport, voice_chat_audio)
+			NLOHMANN_DEFINE_TYPE_INTRUSIVE(spoofing, hide_from_player_list, spoof_blip, blip_type, spoof_rank, rank, spoof_job_points, job_points, spoof_kd_ratio, kd_ratio, spoof_bad_sport, badsport_type, spoof_player_model, player_model, spoof_cheater, spoof_hide_god, spoof_hide_veh_god, spoof_hide_spectate, spoof_crew_data, crew_tag, rockstar_crew, square_crew_tag, spoof_session_region_type, session_region_type, spoof_session_language, session_language, spoof_session_player_count, session_player_count, spoof_session_bad_sport_status, voice_chat_audio)
 		} spoofing{};
 
 		struct vehicle
@@ -1036,6 +1035,13 @@ namespace big
 
 			NLOHMANN_DEFINE_TYPE_INTRUSIVE(session_browser, region_filter_enabled, region_filter, language_filter_enabled, language_filter, player_count_filter_enabled, player_count_filter_minimum, player_count_filter_maximum, sort_method, sort_direction, replace_game_matchmaking, pool_filter_enabled, pool_filter)
 		} session_browser{};
+
+		struct session_protection
+		{
+			int block_join_reason = 0;
+
+			NLOHMANN_DEFINE_TYPE_INTRUSIVE(session_protection, block_join_reason)
+		} session_protection{};
 
 		struct ugc
 		{

--- a/src/hooks/spoofing/send_session_matchmaking_attributes.cpp
+++ b/src/hooks/spoofing/send_session_matchmaking_attributes.cpp
@@ -14,13 +14,11 @@ namespace big
 		if (g.spoofing.spoof_session_player_count)
 			attributes->m_param_values[7] = g.spoofing.session_player_count;
 
-		if (g.spoofing.spoof_session_bad_sport_status)
-		{
-			if (g.spoofing.session_bad_sport)
-				attributes->m_param_values[0] |= (1 << 14);
-			else
-				attributes->m_param_values[0] &= ~(1 << 14);
-		}
+		if (g.spoofing.spoof_session_bad_sport_status == 1)
+			attributes->m_param_values[0] |= (1 << 14); // Bad Sport
+
+		if (g.spoofing.spoof_session_bad_sport_status == 2)
+			attributes->m_param_values[0] &= ~(1 << 14); // Good Sport
 
 		return g_hooking->get_original<hooks::send_session_matchmaking_attributes>()(a1, info, session_id, use_session_id, attributes);
 	}

--- a/src/views/network/view_spoofing.cpp
+++ b/src/views/network/view_spoofing.cpp
@@ -150,11 +150,11 @@ namespace big
 			ImGui::InputInt("###player_count", &g.spoofing.session_player_count);
 		}
 
-		ImGui::Checkbox("VIEW_SPOOFING_SPOOF_SESSION_BAD_SPORT_STATUS"_T.data(), &g.spoofing.spoof_session_bad_sport_status);
-		if (g.spoofing.spoof_session_bad_sport_status)
-		{
-			ImGui::SameLine();
-			ImGui::Checkbox("VIEW_SPOOFING_BADSPORT"_T.data(), &g.spoofing.session_bad_sport);
-		}
+		components::small_text("VIEW_SPOOFING_SPOOF_SESSION_BAD_SPORT_STATUS"_T);
+		ImGui::RadioButton("VIEW_SPOOFING_SPORT_DEFAULT"_T.data(), &g.spoofing.spoof_session_bad_sport_status, 0);
+		ImGui::SameLine();
+		ImGui::RadioButton("VIEW_SPOOFING_SPORT_GOOD"_T.data(), &g.spoofing.spoof_session_bad_sport_status, 1);
+		ImGui::SameLine();
+		ImGui::RadioButton("VIEW_SPOOFING_SPORT_BAD"_T.data(), &g.spoofing.spoof_session_bad_sport_status, 2);
 	}
 }


### PR DESCRIPTION
This PR improves the layout of the session bad sport status spoofer in Network -> Spoofing which works much better with radio buttons. As a result, fewer clicks are required and the end result is described more clearly compared to the previous code.

Translation PR to follow shortly.

Obligatory preview:
![image](https://github.com/YimMenu/YimMenu/assets/13259220/ae16d624-645f-4ce6-96eb-4db4eec6cc1f)
