### PR TITLE
Lessen Detections

### DIFF
--- a/src/backend/looped/system/spoofing.cpp
+++ b/src/backend/looped/system/spoofing.cpp
@@ -18,7 +18,7 @@ namespace big
 			uint64_t host_token;
 			g_pointers->m_gta.m_generate_uuid(&host_token);
 
-			host_token = g.session.force_session_host ? (rand() % 10000) : host_token;
+			host_token = (g.session.force_session_host && !g_player_service->get_self()->is_host()) ? (rand() % 10000) : host_token;
 
 			*g_pointers->m_gta.m_host_token = host_token;
 
@@ -51,7 +51,7 @@ namespace big
 
 					if (g.spoofing.spoof_blip)
 					{
-						if (g.spoofing.blip_type == 0)// random
+						if (g.spoofing.blip_type == 0) // random
 							scr_globals::globalplayer_bd.as<GlobalPlayerBD*>()->Entries[self::id].PlayerBlip.PlayerVehicleBlipType = (eBlipType)(rand() % 90);
 						else
 							scr_globals::globalplayer_bd.as<GlobalPlayerBD*>()->Entries[self::id].PlayerBlip.PlayerVehicleBlipType =

--- a/src/hooks/misc/serialize_join_request_message.cpp
+++ b/src/hooks/misc/serialize_join_request_message.cpp
@@ -13,7 +13,7 @@ namespace big
 		if (info->unk_0xC0 == 0)
 			info->unk_0xC0 = 1; // TODO: do we need this anymore?
 
-		if (g.protections.desync_kick)
+		if (g.protections.desync_kick && !g_player_service->get_self()->is_host())
 			info->m_gamer_info.m_nat_type = 0;
 
 		info->m_num_handles = 0;
@@ -27,7 +27,7 @@ namespace big
 		if (g.session.join_in_sctv_slots)
 			data.m_matchmaking_group = 4;
 
-		if (g.protections.desync_kick)
+		if (g.protections.desync_kick && !g_player_service->get_self()->is_host())
 			data.m_nat_type = 0;
 
 		return g_hooking->get_original<hooks::serialize_join_request_message_2>()(msg, buf, size, bits_serialized);


### PR DESCRIPTION
Only activate desync protections(when not host) and only spoof host token when not host to stop other players from detecting us as modders for unnecessary reasons.