### PR TITLE
Revert "Direct implementation of fix vectors (#3147)"

### DIFF
--- a/src/function_types.hpp
+++ b/src/function_types.hpp
@@ -61,6 +61,7 @@ namespace big::functions
 {
 	using run_script_threads = bool (*)(uint32_t ops_to_execute);
 	using get_native_handler = rage::scrNativeHandler (*)(rage::scrNativeRegistrationTable* registration_table, rage::scrNativeHash hash);
+	using fix_vectors = void (*)(rage::scrNativeCallContext* call_ctx);
 
 	using get_net_game_player = CNetGamePlayer* (*)(Player player);
 

--- a/src/gta_pointers.hpp
+++ b/src/gta_pointers.hpp
@@ -87,6 +87,7 @@ namespace big
 		functions::handle_to_ptr m_handle_to_ptr;
 		rage::scrNativeRegistrationTable* m_native_registration_table;
 		functions::get_native_handler m_get_native_handler;
+		functions::fix_vectors m_fix_vectors;
 
 		rage::atArray<GtaThread*>* m_script_threads;
 		rage::scrProgramTable* m_script_program_table;

--- a/src/invoker/invoker.cpp
+++ b/src/invoker/invoker.cpp
@@ -19,12 +19,6 @@ namespace big
 
 	void native_invoker::fix_vectors()
 	{
-		for (; m_call_context.m_data_count; m_call_context.m_orig[m_call_context.m_data_count][2].Int = m_call_context.m_buffer[m_call_context.m_data_count].z)
-		{
-			--m_call_context.m_data_count;
-			m_call_context.m_orig[m_call_context.m_data_count]->Int   = m_call_context.m_buffer[m_call_context.m_data_count].x;
-			m_call_context.m_orig[m_call_context.m_data_count][1].Int = m_call_context.m_buffer[m_call_context.m_data_count].y;
-		}
-		--m_call_context.m_data_count;
+		g_pointers->m_gta.m_fix_vectors(&m_call_context);
 	}
 }

--- a/src/pointers.cpp
+++ b/src/pointers.cpp
@@ -104,6 +104,15 @@ namespace big
                 g_pointers->m_gta.m_get_native_handler        = ptr.add(12).rip().as<functions::get_native_handler>();
             }
         },
+        // Fix Vectors
+        {
+            "FV",
+            "83 79 18 00 48 8B D1 74 4A FF 4A 18 48 63 4A 18 48 8D 41 04 48 8B 4C CA",
+            [](memory::handle ptr)
+            {
+                g_pointers->m_gta.m_fix_vectors = ptr.as<functions::fix_vectors>();
+            }
+        },
         // Script Threads
         {
             "ST",


### PR DESCRIPTION
This reverts commit fb07065aaf3d0777d4cacef3e211d3b3cd6a09db.

Fix https://github.com/YimMenu/YimMenu/issues/3172
Fix https://github.com/YimMenu/YimMenu/issues/3168
Fix https://github.com/YimMenu/YimMenu/issues/3165
Fix https://github.com/YimMenu/YimMenu/issues/3164