### PR TITLE
P2905R2 Fix - Refactor rvalue arguments into lvalues for std::make_format_args

### DIFF
--- a/cmake/async-logger.cmake
+++ b/cmake/async-logger.cmake
@@ -1,10 +1,12 @@
 include(FetchContent)
 
+add_compile_definitions(CXX_FORMAT_SUPPORT)
+
 message("AsyncLogger")
 FetchContent_Declare(
     AsyncLogger
     GIT_REPOSITORY https://github.com/Yimura/AsyncLogger.git
-    GIT_TAG v0.0.6
+    GIT_TAG 80ce938277acd44767f858099920ae20f1df42ca
     GIT_PROGRESS TRUE
 )
 FetchContent_MakeAvailable(AsyncLogger)

--- a/src/backend/reactions/interloper_reaction.cpp
+++ b/src/backend/reactions/interloper_reaction.cpp
@@ -41,8 +41,11 @@ namespace big
 
 		if (notify)
 		{
+			auto a_name = attacker->get_name();
+			auto v_name = victim->get_name();
+
 			g_notification_service.push_warning("PROTECTIONS"_T.data(),
-			    std::vformat(g_translation_service.get_translation(m_notify_message), std::make_format_args(attacker->get_name(), victim->get_name())));
+			    std::vformat(g_translation_service.get_translation(m_notify_message), std::make_format_args(a_name, v_name)));
 		}
 
 		process_common(attacker);

--- a/src/backend/reactions/reaction.cpp
+++ b/src/backend/reactions/reaction.cpp
@@ -61,17 +61,20 @@ namespace big
 
 		if (announce_in_chat)
 		{
+			auto p_name = player->get_name();
+
 			auto msg = std::format("{} {}",
-			    g.session.chat_output_prefix,
-			    std::vformat(g_translation_service.get_translation(m_announce_message), std::make_format_args(player->get_name())));
+       g.session.chat_output_prefix, std::vformat(g_translation_service.get_translation(m_announce_message), std::make_format_args(p_name)));
 
 			chat::send_message(msg);
 		}
 
 		if (notify)
 		{
+			auto p_name = player->get_name();
+
 			g_notification_service.push_warning("PROTECTIONS"_T.data(),
-			    std::vformat(g_translation_service.get_translation(m_notify_message), std::make_format_args(player->get_name())));
+       std::vformat(g_translation_service.get_translation(m_notify_message), std::make_format_args(p_name)));
 		}
 
 		process_common(player);
@@ -93,9 +96,11 @@ namespace big
 
 		if (notify)
 		{
+			auto p_name = player->get_name();
+
 			// Use a different notification since the default start_script reaction is "Blocked Start Script"
 			g_notification_service.push_warning("PROTECTIONS"_T.data(),
-			    std::vformat("REACTION_START_SCRIPT_ALLOWED"_T.data(), std::make_format_args(player->get_name())));
+       std::vformat("REACTION_START_SCRIPT_ALLOWED"_T.data(), std::make_format_args(p_name)));
 		}
 	}
 }

--- a/src/hooks/protections/receive_net_message.cpp
+++ b/src/hooks/protections/receive_net_message.cpp
@@ -163,8 +163,9 @@ namespace big
 					if (player->m_host_migration_rate_limit.exceeded_last_process())
 					{
 						session::add_infraction(player, Infraction::TRIED_KICK_PLAYER);
-						g_notification_service.push_error("PROTECTIONS"_T.data(),
-						    std::vformat("OOM_KICK"_T, std::make_format_args(player->get_name())));
+						auto p_name = player->get_name();
+
+						g_notification_service.push_error("PROTECTIONS"_T.data(), std::vformat("OOM_KICK"_T, std::make_format_args(p_name)));
 					}
 					return true;
 				}
@@ -222,8 +223,9 @@ namespace big
 					if (player->m_radio_request_rate_limit.exceeded_last_process())
 					{
 						session::add_infraction(player, Infraction::TRIED_KICK_PLAYER);
-						g_notification_service.push_error("PROTECTIONS"_T.data(),
-						    std::vformat("OOM_KICK"_T, std::make_format_args(player->get_name())));
+						auto p_name = player->get_name();
+
+						g_notification_service.push_error("PROTECTIONS"_T.data(), std::vformat("OOM_KICK"_T, std::make_format_args(p_name)));
 						player->block_radio_requests = true;
 					}
 					return true;

--- a/src/hooks/protections/received_event.cpp
+++ b/src/hooks/protections/received_event.cpp
@@ -370,10 +370,12 @@ namespace big
 			&& player->m_player_info->m_ped && player->m_player_info->m_ped->m_net_object
 			&& ownerNetId != player->m_player_info->m_ped->m_net_object->m_object_id && !offset_object)
 		{
+			auto p_name = player->get_name();
+			auto m_name = reinterpret_cast<CPed*>(entity)->m_player_info->m_net_player_data.m_name;
+
 			g_notification_service.push_error("WARNING"_T.data(),
 				std::vformat("BLAMED_FOR_EXPLOSION"_T,
-					std::make_format_args(player->get_name(),
-						reinterpret_cast<CPed*>(entity)->m_player_info->m_net_player_data.m_name)));
+					std::make_format_args(p_name, m_name)));
 			// too many false positives, disabling it
 			//session::add_infraction(g_player_service->get_by_id(player->m_player_id), Infraction::BLAME_EXPLOSION_DETECTED);
 			return;

--- a/src/hooks/protections/send_non_physical_player_data.cpp
+++ b/src/hooks/protections/send_non_physical_player_data.cpp
@@ -15,8 +15,10 @@ namespace big
 
 		if (plyr && plyr->block_join && *g_pointers->m_gta.m_is_session_started)
 		{
+			auto p_name = plyr->get_name();
+
 			data->m_bubble_id = 10;
-			g_notification_service.push("BLOCK_JOIN"_T.data(), std::vformat("BLOCK_JOIN_PREVENT_PLAYER_JOIN"_T, std::make_format_args(plyr->get_name())));
+			g_notification_service.push("BLOCK_JOIN"_T.data(), std::vformat("BLOCK_JOIN_PREVENT_PLAYER_JOIN"_T, std::make_format_args(p_name)));
 		}
 
 		bool result = g_hooking->get_original<hooks::send_non_physical_player_data>()(player, message, flags, a4, a5);

--- a/src/util/notify.cpp
+++ b/src/util/notify.cpp
@@ -37,7 +37,9 @@ namespace big::notify
 
 			if (g.reactions.crash.announce_in_chat)
 			{
-				auto msg = std::vformat("NOTIFICATION_CRASH_TYPE_BLOCKED"_T, std::make_format_args(player->get_name(), crash));
+				auto p_name = player->get_name();
+
+				auto msg = std::vformat("NOTIFICATION_CRASH_TYPE_BLOCKED"_T, std::make_format_args(p_name, crash));
 				msg = std::format("{} {}", g.session.chat_output_prefix, msg);
 				
 				chat::send_message(msg);

--- a/src/views/core/view_cmd_executor.cpp
+++ b/src/views/core/view_cmd_executor.cpp
@@ -49,12 +49,12 @@ namespace big
 			{
 				for (auto cmd : possible_commands)
 				{
-					ImGui::Text(std::vformat("CMD_EXECUTOR_CMD_TEMPLATE"_T,
-					    std::make_format_args(cmd->get_name(),
-					        cmd->get_label(),
-					        cmd->get_description(),
-					        cmd->get_num_args() ? cmd->get_num_args().value() : 0))
-					                .data());
+					auto cmd_name = cmd->get_name();
+					auto cmd_label = cmd->get_label();
+					auto cmd_description = cmd->get_description();
+					auto cmd_num_args    = cmd->get_num_args() ? cmd->get_num_args().value() : 0;
+
+					ImGui::Text(std::vformat("CMD_EXECUTOR_CMD_TEMPLATE"_T, std::make_format_args(cmd_name, cmd_label, cmd_description, cmd_num_args)).data());
 
 					// check if we aren't on the last iteration
 					if (cmd != possible_commands.back())

--- a/src/views/self/view_mobile.cpp
+++ b/src/views/self/view_mobile.cpp
@@ -59,10 +59,10 @@ namespace big
 
 		components::button("MORS_FIX_ALL"_T, [] {
 			int amount_fixed = mobile::mors_mutual::fix_all();
+			auto v_fixed     = amount_fixed == 1 ? "VEHICLE_FIX_HAS"_T.data() : "VEHICLE_FIX_HAVE"_T.data(); 
+
 			g_notification_service.push_success("MOBILE"_T.data(),
-			    std::vformat("VEHICLE_FIX_AMOUNT"_T,
-			        std::make_format_args(amount_fixed,
-			            amount_fixed == 1 ? "VEHICLE_FIX_HAS"_T.data() : "VEHICLE_FIX_HAVE"_T.data())));
+			    std::vformat("VEHICLE_FIX_AMOUNT"_T, std::make_format_args(amount_fixed, v_fixed)));
 		});
 	}
 }

--- a/src/views/self/view_teleport.cpp
+++ b/src/views/self/view_teleport.cpp
@@ -162,7 +162,9 @@ namespace big
 		ImGui::Spacing();
 		components::small_text("IPL_INFOS"_T);
 
-		ImGui::Text(std::vformat("IPL_CNT"_T, std::make_format_args(ipls[current_select].ipl_names.size())).data());
+		auto ipls_data = ipls[current_select].ipl_names.size();
+
+		ImGui::Text(std::vformat("IPL_CNT"_T, std::make_format_args(ipls_data)).data());
 		ImGui::Text(std::vformat("IPL_POSITION"_T, std::make_format_args(ipls[current_select].location.x, ipls[current_select].location.y, ipls[current_select].location.z)).data());
 	}
 }

--- a/src/views/vehicle/view_vehicle.cpp
+++ b/src/views/vehicle/view_vehicle.cpp
@@ -10,10 +10,11 @@ namespace big
 	{
 		components::button("MORS_FIX_ALL"_T, [] {
 			int amount_fixed = mobile::mors_mutual::fix_all();
+			auto v_fixed     = amount_fixed == 1 ? "VEHICLE_FIX_HAS"_T.data() : "VEHICLE_FIX_HAVE"_T.data(); 
+
 			g_notification_service.push_success("MOBILE"_T.data(),
 			    std::vformat("VEHICLE_FIX_AMOUNT"_T.data(),
-			        std::make_format_args(amount_fixed,
-			            amount_fixed == 1 ? "VEHICLE_FIX_HAS"_T.data() : "VEHICLE_FIX_HAVE"_T.data())));
+			        std::make_format_args(amount_fixed, v_fixed)));
 		});
 
 		ImGui::SameLine();


### PR DESCRIPTION
`Rejecting temporaries in make_format_args is an (intentionally) breaking change.`

*thumbs up*

Refactored all calls to std::make_format_args to use lvalue args so that YimMenu can compile on VS 17.10.0