### PR TITLE
improve(chat filter): Block all anonymous chat messages

### DIFF
--- a/src/hooks/protections/receive_net_message.cpp
+++ b/src/hooks/protections/receive_net_message.cpp
@@ -262,6 +262,7 @@ namespace big
 				}
 				break;
 			}
+			case rage::eNetMessage::MsgTextMessage: return true;
 			case rage::eNetMessage::MsgNonPhysicalData:
 			{
 				buffer.Read<int>(7); // size


### PR DESCRIPTION
Although I don't know why, there are many spammers that yimmenu cant get their player info, and some whose names can't even be found in the player list. These ads are not filtered to be blocked and still show up on the screen, interfering with the gaming experience
After testing, I don't see any messages from normal players reaching here, so I think we can just return true

![image](https://github.com/YimMenu/YimMenu/assets/54973190/441ac125-6788-4d11-8988-459f5580cb5b)

![image](https://github.com/YimMenu/YimMenu/assets/54973190/ff6c06f1-27d2-43c7-ad72-ba96f140e419)
