### PR TITLE
Redesigned outfit editor.

### DIFF
--- a/src/util/outfit.hpp
+++ b/src/util/outfit.hpp
@@ -42,16 +42,16 @@ namespace big::outfit
 	{
 		if(item->drawable_id > item->drawable_id_max)
 			item->drawable_id = item->drawable_id_max;
-		if(item->drawable_id < -1)
-			item->drawable_id = -1;
+		if(item->drawable_id < 0)
+			item->drawable_id = 0;
 	}
 
 	inline void check_bounds_texture(outfit_t* item)
 	{
 		if(item->texture_id > item->texture_id_max)
 			item->texture_id = item->texture_id_max;
-		if(item->texture_id < -1)
-			item->texture_id = -1;
+		if(item->texture_id < 0)
+			item->texture_id = 0;
 	}
 
 	// usually each update increases 1//

--- a/src/views/self/view_outfit_editor.cpp
+++ b/src/views/self/view_outfit_editor.cpp
@@ -105,14 +105,17 @@ namespace big
 		for (auto& item : components.items)
 		{
 			ImGui::SetNextItemWidth(120);
-			if (ImGui::InputInt(std::format("{} [0,{}]##1", item.label, item.drawable_id_max).c_str(), &item.drawable_id))
+			if (item.drawable_id_max <= 0)
+				ImGui::BeginDisabled();
+			if (ImGui::DragInt(std::format("{} [0,{}]##1", item.label, item.drawable_id_max).c_str(), &item.drawable_id, 0.25f, 0, item.drawable_id_max))
 			{
-				outfit::check_bounds_drawable(&item); // The game does this on it's own but seems to crash if we call OOB values to fast.
-
+				//outfit::check_bounds_drawable(&item); // The game does this on its own, but seems to crash if we call OOB values to fast. (-1 is not a valid scenario)
 				g_fiber_pool->queue_job([item] {
 					PED::SET_PED_COMPONENT_VARIATION(self::ped, item.id, item.drawable_id, 0, PED::GET_PED_PALETTE_VARIATION(self::ped, item.id));
 				});
 			}
+			if (item.drawable_id_max <= 0)
+				ImGui::EndDisabled();
 		}
 		ImGui::EndGroup();
 
@@ -122,14 +125,17 @@ namespace big
 		for (auto& item : components.items)
 		{
 			ImGui::SetNextItemWidth(120);
-			if (ImGui::InputInt(std::format("{} {} [0,{}]##2", item.label, "OUTFIT_TEX"_T, item.texture_id_max).c_str(), &item.texture_id))
+			if (item.texture_id_max <= 0)
+				ImGui::BeginDisabled();
+			if (ImGui::DragInt(std::format("{} {} [0,{}]##2", item.label, "OUTFIT_TEX"_T, item.texture_id_max).c_str(), &item.texture_id, 0.1f, 0, item.texture_id_max))
 			{
-				outfit::check_bounds_texture(&item); // The game does this on it's own but seems to crash if we call OOB values to fast.
-
+				//outfit::check_bounds_drawable(&item); // The game does this on its own, but seems to crash if we call OOB values to fast. (-1 is not a valid scenario)
 				g_fiber_pool->queue_job([item] {
 					PED::SET_PED_COMPONENT_VARIATION(self::ped, item.id, item.drawable_id, item.texture_id, PED::GET_PED_PALETTE_VARIATION(self::ped, item.id));
 				});
 			}
+			if (item.texture_id_max <= 0)
+				ImGui::EndDisabled();
 		}
 		ImGui::EndGroup();
 
@@ -139,10 +145,11 @@ namespace big
 		for (auto& item : props.items)
 		{
 			ImGui::SetNextItemWidth(120);
-			if (ImGui::InputInt(std::format("{} [0,{}]##3", item.label, item.drawable_id_max).c_str(), &item.drawable_id))
+			if (item.drawable_id_max <= 0)
+				ImGui::BeginDisabled();
+			if (ImGui::DragInt(std::format("{} [0,{}]##3", item.label, item.drawable_id_max).c_str(), &item.drawable_id, 0.25f, -1, item.drawable_id_max))
 			{
-				outfit::check_bounds_drawable(&item); // The game does this on it's own but seems to crash if we call OOB values to fast.
-
+				//outfit::check_bounds_drawable(&item); // The game does this on its own, but seems to crash if we call OOB values to fast. (-1 is only used here as a magic number to signal the removal of the prop.)
 				g_fiber_pool->queue_job([item] {
 					if (item.drawable_id == -1)
 						PED::CLEAR_PED_PROP(self::ped, item.id, 1);
@@ -150,6 +157,8 @@ namespace big
 						PED::SET_PED_PROP_INDEX(self::ped, item.id, item.drawable_id, 0, TRUE, 1);
 				});
 			}
+			if (item.drawable_id_max <= 0)
+				ImGui::EndDisabled();
 		}
 		ImGui::EndGroup();
 
@@ -159,14 +168,17 @@ namespace big
 		for (auto& item : props.items)
 		{
 			ImGui::SetNextItemWidth(120);
-			if (ImGui::InputInt(std::format("{} {} [0,{}]##4", item.label, "OUTFIT_TEX"_T, item.texture_id_max).c_str(), &item.texture_id))
+			if (item.texture_id_max <= 0)
+				ImGui::BeginDisabled();
+			if (ImGui::DragInt(std::format("{} {} [0,{}]##4", item.label, "OUTFIT_TEX"_T, item.texture_id_max).c_str(), &item.texture_id, 0.1f, 0, item.texture_id_max))
 			{
-				outfit::check_bounds_texture(&item); // The game does this on it's own but seems to crash if we call OOB values to fast.
-
+				//outfit::check_bounds_drawable(&item); // The game does this on its own, but seems to crash if we call OOB values to fast. (-1 is not a valid scenario)
 				g_fiber_pool->queue_job([item] {
 					PED::SET_PED_PROP_INDEX(self::ped, item.id, item.drawable_id, item.texture_id, TRUE, 1);
 				});
 			}
+			if (item.texture_id_max <= 0)
+				ImGui::EndDisabled();
 		}
 		ImGui::EndGroup();
 

--- a/src/views/self/view_outfit_slots.cpp
+++ b/src/views/self/view_outfit_slots.cpp
@@ -88,7 +88,7 @@ namespace big
 			for (auto& item : components.items)
 			{
 				ImGui::SetNextItemWidth(120);
-				ImGui::InputInt(std::format("{} [0,{}]##1", item.label, item.drawable_id_max).c_str(), outfit::get_component_drawable_id_address(slot, item.id));
+				ImGui::DragInt(std::format("{} [0,{}]##1", item.label, item.drawable_id_max).c_str(), outfit::get_component_drawable_id_address(slot, item.id), 0.1f, 0, item.drawable_id_max);
 			}
 			ImGui::EndGroup();
 
@@ -98,7 +98,7 @@ namespace big
 			for (auto& item : components.items)
 			{
 				ImGui::SetNextItemWidth(120);
-				ImGui::InputInt(std::format("{} {} [0,{}]##2", item.label, "OUTFIT_TEX"_T, item.texture_id_max).c_str(), outfit::get_component_texture_id_address(slot, item.id));
+				ImGui::DragInt(std::format("{} {} [0,{}]##2", item.label, "OUTFIT_TEX"_T, item.texture_id_max).c_str(), outfit::get_component_texture_id_address(slot, item.id), 0.1f, 0, item.texture_id_max);
 			}
 			ImGui::EndGroup();
 
@@ -108,7 +108,7 @@ namespace big
 			for (auto& item : props.items)
 			{
 				ImGui::SetNextItemWidth(120);
-				ImGui::InputInt(std::format("{} [0,{}]##3", item.label, item.drawable_id_max).c_str(), outfit::get_prop_drawable_id_address(slot, item.id));
+				ImGui::DragInt(std::format("{} [0,{}]##3", item.label, item.drawable_id_max).c_str(), outfit::get_prop_drawable_id_address(slot, item.id), 0.1f, 0, item.drawable_id_max);
 			}
 			ImGui::EndGroup();
 
@@ -118,7 +118,7 @@ namespace big
 			for (auto& item : props.items)
 			{
 				ImGui::SetNextItemWidth(120);
-				ImGui::InputInt(std::format("{} {} [0,{}]##4", item.label, "OUTFIT_TEX"_T, item.texture_id_max).c_str(), outfit::get_prop_texture_id_address(slot, item.id));
+				ImGui::DragInt(std::format("{} {} [0,{}]##4", item.label, "OUTFIT_TEX"_T, item.texture_id_max).c_str(), outfit::get_prop_texture_id_address(slot, item.id), 0.1f, 0, item.texture_id_max);
 			}
 			ImGui::EndGroup();
 		}


### PR DESCRIPTION
This redesigns the outfit editor to assist users who do not know what they are doing to not corrupt or set outfit entries out of bounds as it was doing before. However, users who know what they are doing will still be able to manually enter invalid outfit IDs by using CTRL+Click as I left the AlwaysClamp parameter omitted. 

![image](https://github.com/user-attachments/assets/5711cf57-f574-495b-8ed3-f693289ef2ca)
