### PR TITLE
fix #3406 & refractor bounds check

### DIFF
--- a/src/util/outfit.hpp
+++ b/src/util/outfit.hpp
@@ -38,20 +38,20 @@ namespace big::outfit
 		    {7, "OUTFIT_WRIST"_T.data()}};
 	};
 
-	inline void check_bounds_drawable(outfit_t* item)
+	inline void check_bounds_drawable(outfit_t* item, const int lower)
 	{
 		if(item->drawable_id > item->drawable_id_max)
 			item->drawable_id = item->drawable_id_max;
-		if(item->drawable_id < -1)
-			item->drawable_id = -1;
+		if(item->drawable_id < lower)
+			item->drawable_id = lower;
 	}
 
-	inline void check_bounds_texture(outfit_t* item)
+	inline void check_bounds_texture(outfit_t* item, const int lower)
 	{
 		if(item->texture_id > item->texture_id_max)
 			item->texture_id = item->texture_id_max;
-		if(item->texture_id < -1)
-			item->texture_id = -1;
+		if(item->texture_id < lower)
+			item->texture_id = lower;
 	}
 
 	// usually each update increases 1//

--- a/src/util/outfit.hpp
+++ b/src/util/outfit.hpp
@@ -42,16 +42,16 @@ namespace big::outfit
 	{
 		if(item->drawable_id > item->drawable_id_max)
 			item->drawable_id = item->drawable_id_max;
-		if(item->drawable_id < 0)
-			item->drawable_id = 0;
+		if(item->drawable_id < -1)
+			item->drawable_id = -1;
 	}
 
 	inline void check_bounds_texture(outfit_t* item)
 	{
 		if(item->texture_id > item->texture_id_max)
 			item->texture_id = item->texture_id_max;
-		if(item->texture_id < 0)
-			item->texture_id = 0;
+		if(item->texture_id < -1)
+			item->texture_id = -1;
 	}
 
 	// usually each update increases 1//

--- a/src/views/self/view_outfit_editor.cpp
+++ b/src/views/self/view_outfit_editor.cpp
@@ -106,7 +106,7 @@ namespace big
 			ImGui::SetNextItemWidth(120);
 			if (ImGui::InputInt(std::format("{} [0,{}]##1", item.label, item.drawable_id_max).c_str(), &item.drawable_id))
 			{
-				outfit::check_bounds_drawable(&item); // The game does this on it's own but seems to crash if we call OOB values to fast.
+				outfit::check_bounds_drawable(&item, 0); // The game does this on it's own but seems to crash if we call OOB values to fast.
 
 				g_fiber_pool->queue_job([item] {
 					PED::SET_PED_COMPONENT_VARIATION(self::ped, item.id, item.drawable_id, 0, PED::GET_PED_PALETTE_VARIATION(self::ped, item.id));
@@ -123,7 +123,7 @@ namespace big
 			ImGui::SetNextItemWidth(120);
 			if (ImGui::InputInt(std::format("{} {} [0,{}]##2", item.label, "OUTFIT_TEX"_T, item.texture_id_max).c_str(), &item.texture_id))
 			{
-				outfit::check_bounds_texture(&item); // The game does this on it's own but seems to crash if we call OOB values to fast.
+				outfit::check_bounds_texture(&item, 0); // The game does this on it's own but seems to crash if we call OOB values to fast.
 
 				g_fiber_pool->queue_job([item] {
 					PED::SET_PED_COMPONENT_VARIATION(self::ped, item.id, item.drawable_id, item.texture_id, PED::GET_PED_PALETTE_VARIATION(self::ped, item.id));
@@ -140,7 +140,7 @@ namespace big
 			ImGui::SetNextItemWidth(120);
 			if (ImGui::InputInt(std::format("{} [0,{}]##3", item.label, item.drawable_id_max).c_str(), &item.drawable_id))
 			{
-				outfit::check_bounds_drawable(&item); // The game does this on it's own but seems to crash if we call OOB values to fast.
+				outfit::check_bounds_drawable(&item, -1); // The game does this on it's own but seems to crash if we call OOB values to fast.
 
 				g_fiber_pool->queue_job([item] {
 					if (item.drawable_id == -1)
@@ -160,7 +160,7 @@ namespace big
 			ImGui::SetNextItemWidth(120);
 			if (ImGui::InputInt(std::format("{} {} [0,{}]##4", item.label, "OUTFIT_TEX"_T, item.texture_id_max).c_str(), &item.texture_id))
 			{
-				outfit::check_bounds_texture(&item); // The game does this on it's own but seems to crash if we call OOB values to fast.
+				outfit::check_bounds_texture(&item, -1); // The game does this on it's own but seems to crash if we call OOB values to fast.
 
 				g_fiber_pool->queue_job([item] {
 					PED::SET_PED_PROP_INDEX(self::ped, item.id, item.drawable_id, item.texture_id, TRUE, 1);

--- a/src/views/self/view_outfit_editor.cpp
+++ b/src/views/self/view_outfit_editor.cpp
@@ -104,17 +104,14 @@ namespace big
 		for (auto& item : components.items)
 		{
 			ImGui::SetNextItemWidth(120);
-			if (item.drawable_id_max <= 0)
-				ImGui::BeginDisabled();
-			if (ImGui::DragInt(std::format("{} [0,{}]##1", item.label, item.drawable_id_max).c_str(), &item.drawable_id, 0.25f, 0, item.drawable_id_max))
+			if (ImGui::InputInt(std::format("{} [0,{}]##1", item.label, item.drawable_id_max).c_str(), &item.drawable_id))
 			{
-				//outfit::check_bounds_drawable(&item); // The game does this on its own, but seems to crash if we call OOB values to fast. (-1 is not a valid scenario)
+				outfit::check_bounds_drawable(&item); // The game does this on it's own but seems to crash if we call OOB values to fast.
+
 				g_fiber_pool->queue_job([item] {
 					PED::SET_PED_COMPONENT_VARIATION(self::ped, item.id, item.drawable_id, 0, PED::GET_PED_PALETTE_VARIATION(self::ped, item.id));
 				});
 			}
-			if (item.drawable_id_max <= 0)
-				ImGui::EndDisabled();
 		}
 		ImGui::EndGroup();
 
@@ -124,17 +121,14 @@ namespace big
 		for (auto& item : components.items)
 		{
 			ImGui::SetNextItemWidth(120);
-			if (item.texture_id_max <= 0)
-				ImGui::BeginDisabled();
-			if (ImGui::DragInt(std::format("{} {} [0,{}]##2", item.label, "OUTFIT_TEX"_T, item.texture_id_max).c_str(), &item.texture_id, 0.1f, 0, item.texture_id_max))
+			if (ImGui::InputInt(std::format("{} {} [0,{}]##2", item.label, "OUTFIT_TEX"_T, item.texture_id_max).c_str(), &item.texture_id))
 			{
-				//outfit::check_bounds_drawable(&item); // The game does this on its own, but seems to crash if we call OOB values to fast. (-1 is not a valid scenario)
+				outfit::check_bounds_texture(&item); // The game does this on it's own but seems to crash if we call OOB values to fast.
+
 				g_fiber_pool->queue_job([item] {
 					PED::SET_PED_COMPONENT_VARIATION(self::ped, item.id, item.drawable_id, item.texture_id, PED::GET_PED_PALETTE_VARIATION(self::ped, item.id));
 				});
 			}
-			if (item.texture_id_max <= 0)
-				ImGui::EndDisabled();
 		}
 		ImGui::EndGroup();
 
@@ -144,11 +138,10 @@ namespace big
 		for (auto& item : props.items)
 		{
 			ImGui::SetNextItemWidth(120);
-			if (item.drawable_id_max <= 0)
-				ImGui::BeginDisabled();
-			if (ImGui::DragInt(std::format("{} [0,{}]##3", item.label, item.drawable_id_max).c_str(), &item.drawable_id, 0.25f, -1, item.drawable_id_max))
+			if (ImGui::InputInt(std::format("{} [0,{}]##3", item.label, item.drawable_id_max).c_str(), &item.drawable_id))
 			{
-				//outfit::check_bounds_drawable(&item); // The game does this on its own, but seems to crash if we call OOB values to fast. (-1 is only used here as a magic number to signal the removal of the prop.)
+				outfit::check_bounds_drawable(&item); // The game does this on it's own but seems to crash if we call OOB values to fast.
+
 				g_fiber_pool->queue_job([item] {
 					if (item.drawable_id == -1)
 						PED::CLEAR_PED_PROP(self::ped, item.id, 1);
@@ -156,8 +149,6 @@ namespace big
 						PED::SET_PED_PROP_INDEX(self::ped, item.id, item.drawable_id, 0, TRUE, 1);
 				});
 			}
-			if (item.drawable_id_max <= 0)
-				ImGui::EndDisabled();
 		}
 		ImGui::EndGroup();
 
@@ -167,17 +158,14 @@ namespace big
 		for (auto& item : props.items)
 		{
 			ImGui::SetNextItemWidth(120);
-			if (item.texture_id_max <= 0)
-				ImGui::BeginDisabled();
-			if (ImGui::DragInt(std::format("{} {} [0,{}]##4", item.label, "OUTFIT_TEX"_T, item.texture_id_max).c_str(), &item.texture_id, 0.1f, 0, item.texture_id_max))
+			if (ImGui::InputInt(std::format("{} {} [0,{}]##4", item.label, "OUTFIT_TEX"_T, item.texture_id_max).c_str(), &item.texture_id))
 			{
-				//outfit::check_bounds_drawable(&item); // The game does this on its own, but seems to crash if we call OOB values to fast. (-1 is not a valid scenario)
+				outfit::check_bounds_texture(&item); // The game does this on it's own but seems to crash if we call OOB values to fast.
+
 				g_fiber_pool->queue_job([item] {
 					PED::SET_PED_PROP_INDEX(self::ped, item.id, item.drawable_id, item.texture_id, TRUE, 1);
 				});
 			}
-			if (item.texture_id_max <= 0)
-				ImGui::EndDisabled();
 		}
 		ImGui::EndGroup();
 

--- a/src/views/self/view_outfit_editor.cpp
+++ b/src/views/self/view_outfit_editor.cpp
@@ -106,7 +106,7 @@ namespace big
 			ImGui::SetNextItemWidth(120);
 			if (item.drawable_id_max <= 0)
 				ImGui::BeginDisabled();
-			if (ImGui::SliderInt(std::format("{} [0,{}]##1", item.label, item.drawable_id_max).c_str(), &item.drawable_id, 0, item.drawable_id_max))
+			if (ImGui::DragInt(std::format("{} [0,{}]##1", item.label, item.drawable_id_max).c_str(), &item.drawable_id, 0.25f, 0, item.drawable_id_max))
 			{
 				//outfit::check_bounds_drawable(&item); // The game does this on its own, but seems to crash if we call OOB values to fast. (-1 is not a valid scenario)
 				g_fiber_pool->queue_job([item] {
@@ -126,7 +126,7 @@ namespace big
 			ImGui::SetNextItemWidth(120);
 			if (item.texture_id_max <= 0)
 				ImGui::BeginDisabled();
-			if (ImGui::SliderInt(std::format("{} {} [0,{}]##2", item.label, "OUTFIT_TEX"_T, item.texture_id_max).c_str(), &item.texture_id, 0, item.texture_id_max))
+			if (ImGui::DragInt(std::format("{} {} [0,{}]##2", item.label, "OUTFIT_TEX"_T, item.texture_id_max).c_str(), &item.texture_id, 0.1f, 0, item.texture_id_max))
 			{
 				//outfit::check_bounds_drawable(&item); // The game does this on its own, but seems to crash if we call OOB values to fast. (-1 is not a valid scenario)
 				g_fiber_pool->queue_job([item] {
@@ -146,7 +146,7 @@ namespace big
 			ImGui::SetNextItemWidth(120);
 			if (item.drawable_id_max <= 0)
 				ImGui::BeginDisabled();
-			if (ImGui::SliderInt(std::format("{} [0,{}]##3", item.label, item.drawable_id_max).c_str(), &item.drawable_id, -1, item.drawable_id_max))
+			if (ImGui::DragInt(std::format("{} [0,{}]##3", item.label, item.drawable_id_max).c_str(), &item.drawable_id, 0.25f, -1, item.drawable_id_max))
 			{
 				//outfit::check_bounds_drawable(&item); // The game does this on its own, but seems to crash if we call OOB values to fast. (-1 is only used here as a magic number to signal the removal of the prop.)
 				g_fiber_pool->queue_job([item] {
@@ -169,7 +169,7 @@ namespace big
 			ImGui::SetNextItemWidth(120);
 			if (item.texture_id_max <= 0)
 				ImGui::BeginDisabled();
-			if (ImGui::SliderInt(std::format("{} {} [0,{}]##4", item.label, "OUTFIT_TEX"_T, item.texture_id_max).c_str(), &item.texture_id, 0, item.texture_id_max))
+			if (ImGui::DragInt(std::format("{} {} [0,{}]##4", item.label, "OUTFIT_TEX"_T, item.texture_id_max).c_str(), &item.texture_id, 0.1f, 0, item.texture_id_max))
 			{
 				//outfit::check_bounds_drawable(&item); // The game does this on its own, but seems to crash if we call OOB values to fast. (-1 is not a valid scenario)
 				g_fiber_pool->queue_job([item] {

--- a/src/views/self/view_outfit_slots.cpp
+++ b/src/views/self/view_outfit_slots.cpp
@@ -88,7 +88,7 @@ namespace big
 			for (auto& item : components.items)
 			{
 				ImGui::SetNextItemWidth(120);
-				ImGui::DragInt(std::format("{} [0,{}]##1", item.label, item.drawable_id_max).c_str(), outfit::get_component_drawable_id_address(slot, item.id), 0.1f, 0, item.drawable_id_max);
+				ImGui::InputInt(std::format("{} [0,{}]##1", item.label, item.drawable_id_max).c_str(), outfit::get_component_drawable_id_address(slot, item.id));
 			}
 			ImGui::EndGroup();
 
@@ -98,7 +98,7 @@ namespace big
 			for (auto& item : components.items)
 			{
 				ImGui::SetNextItemWidth(120);
-				ImGui::DragInt(std::format("{} {} [0,{}]##2", item.label, "OUTFIT_TEX"_T, item.texture_id_max).c_str(), outfit::get_component_texture_id_address(slot, item.id), 0.1f, 0, item.texture_id_max);
+				ImGui::InputInt(std::format("{} {} [0,{}]##2", item.label, "OUTFIT_TEX"_T, item.texture_id_max).c_str(), outfit::get_component_texture_id_address(slot, item.id));
 			}
 			ImGui::EndGroup();
 
@@ -108,7 +108,7 @@ namespace big
 			for (auto& item : props.items)
 			{
 				ImGui::SetNextItemWidth(120);
-				ImGui::DragInt(std::format("{} [0,{}]##3", item.label, item.drawable_id_max).c_str(), outfit::get_prop_drawable_id_address(slot, item.id), 0.1f, 0, item.drawable_id_max);
+				ImGui::InputInt(std::format("{} [0,{}]##3", item.label, item.drawable_id_max).c_str(), outfit::get_prop_drawable_id_address(slot, item.id));
 			}
 			ImGui::EndGroup();
 
@@ -118,7 +118,7 @@ namespace big
 			for (auto& item : props.items)
 			{
 				ImGui::SetNextItemWidth(120);
-				ImGui::DragInt(std::format("{} {} [0,{}]##4", item.label, "OUTFIT_TEX"_T, item.texture_id_max).c_str(), outfit::get_prop_texture_id_address(slot, item.id), 0.1f, 0, item.texture_id_max);
+				ImGui::InputInt(std::format("{} {} [0,{}]##4", item.label, "OUTFIT_TEX"_T, item.texture_id_max).c_str(), outfit::get_prop_texture_id_address(slot, item.id));
 			}
 			ImGui::EndGroup();
 		}

--- a/src/views/self/view_outfit_slots.cpp
+++ b/src/views/self/view_outfit_slots.cpp
@@ -88,7 +88,7 @@ namespace big
 			for (auto& item : components.items)
 			{
 				ImGui::SetNextItemWidth(120);
-				ImGui::SliderInt(std::format("{} [0,{}]##1", item.label, item.drawable_id_max).c_str(), outfit::get_component_drawable_id_address(slot, item.id), 0, item.drawable_id_max);
+				ImGui::DragInt(std::format("{} [0,{}]##1", item.label, item.drawable_id_max).c_str(), outfit::get_component_drawable_id_address(slot, item.id), 0.1f, 0, item.drawable_id_max);
 			}
 			ImGui::EndGroup();
 
@@ -98,7 +98,7 @@ namespace big
 			for (auto& item : components.items)
 			{
 				ImGui::SetNextItemWidth(120);
-				ImGui::SliderInt(std::format("{} {} [0,{}]##2", item.label, "OUTFIT_TEX"_T, item.texture_id_max).c_str(), outfit::get_component_texture_id_address(slot, item.id), 0, item.texture_id_max);
+				ImGui::DragInt(std::format("{} {} [0,{}]##2", item.label, "OUTFIT_TEX"_T, item.texture_id_max).c_str(), outfit::get_component_texture_id_address(slot, item.id), 0.1f, 0, item.texture_id_max);
 			}
 			ImGui::EndGroup();
 
@@ -108,7 +108,7 @@ namespace big
 			for (auto& item : props.items)
 			{
 				ImGui::SetNextItemWidth(120);
-				ImGui::SliderInt(std::format("{} [0,{}]##3", item.label, item.drawable_id_max).c_str(), outfit::get_prop_drawable_id_address(slot, item.id), 0, item.drawable_id_max);
+				ImGui::DragInt(std::format("{} [0,{}]##3", item.label, item.drawable_id_max).c_str(), outfit::get_prop_drawable_id_address(slot, item.id), 0.1f, 0, item.drawable_id_max);
 			}
 			ImGui::EndGroup();
 
@@ -118,7 +118,7 @@ namespace big
 			for (auto& item : props.items)
 			{
 				ImGui::SetNextItemWidth(120);
-				ImGui::SliderInt(std::format("{} {} [0,{}]##4", item.label, "OUTFIT_TEX"_T, item.texture_id_max).c_str(), outfit::get_prop_texture_id_address(slot, item.id), 0, item.texture_id_max);
+				ImGui::DragInt(std::format("{} {} [0,{}]##4", item.label, "OUTFIT_TEX"_T, item.texture_id_max).c_str(), outfit::get_prop_texture_id_address(slot, item.id), 0.1f, 0, item.texture_id_max);
 			}
 			ImGui::EndGroup();
 		}


### PR DESCRIPTION
quick fix to #3406 #3400.

Also props drawable and texture can have -1 value but it should not be the case for components. That check can be added to prevent problems to which original proposal was created.