### PR TITLE
revert: Tracked player update rate change

### DIFF
--- a/src/services/player_database/player_database_service.cpp
+++ b/src/services/player_database/player_database_service.cpp
@@ -323,14 +323,18 @@ namespace big
 				first_time = false;
 			}
 
+			static auto last_update = std::chrono::high_resolution_clock::now() - 45s;
+
 			while (g_running && g.player_db.update_player_online_states)
 			{
-				if (!updating)
+				const auto cur = std::chrono::high_resolution_clock::now();
+				if (cur - last_update > 45s && !updating)
 				{
 					updating = true;
 					g_fiber_pool->queue_job([this] {
 						update_player_states(true);
 						updating = false;
+						last_update = std::chrono::high_resolution_clock::now();
 					});
 				}
 


### PR DESCRIPTION
Spamming Rockstar servers every second for a couple of players for their online state is a bad idea, let's keep this limit as-is.