### PR TITLE
Fixed Weapons JSON not properly using the most recent meta file.

### DIFF
--- a/src/script_function.hpp
+++ b/src/script_function.hpp
@@ -70,6 +70,7 @@ namespace big
 		inline script_function reset_session_data("RSD", "main_persistent"_J, "2D 02 7D 00 00");
 		inline script_function add_clan_logo_to_vehicle("ACLTV", "main_persistent"_J, "2D 02 04 00 00 5D ? ? ? 61");
 		inline script_function vehicle_cannot_accept_clan_logo("CVACL", "main_persistent"_J, "2D 01 03 00 00 2C 01 00 A1 06 ? 04");
-		inline script_function get_component_display_string("GCDS", "achievement_controller"_J, "2D 02 43 00 00");
+		inline script_function get_component_name_string("GCNS", "mp_weapons"_J, "2D 02 43 00 00 38 01");
+		inline script_function get_component_desc_string("GCDS", "mp_weapons"_J, "2D 02 43 00 00 38 00");
 	}
 }

--- a/src/script_function.hpp
+++ b/src/script_function.hpp
@@ -70,5 +70,6 @@ namespace big
 		inline script_function reset_session_data("RSD", "main_persistent"_J, "2D 02 7D 00 00");
 		inline script_function add_clan_logo_to_vehicle("ACLTV", "main_persistent"_J, "2D 02 04 00 00 5D ? ? ? 61");
 		inline script_function vehicle_cannot_accept_clan_logo("CVACL", "main_persistent"_J, "2D 01 03 00 00 2C 01 00 A1 06 ? 04");
+		inline script_function get_component_display_string("GCDS", "achievement_controller"_J, "2D 02 43 00 00");
 	}
 }

--- a/src/script_function.hpp
+++ b/src/script_function.hpp
@@ -30,10 +30,18 @@ namespace big
 		{
 			auto thread  = gta_util::find_script_thread(m_script);
 			auto program = gta_util::find_script_program(m_script);
-			auto ip      = get_ip(program);
 
-			if (!thread || !program || !ip)
+			if (!thread || !program)
+			{
+				LOG(FATAL) << m_name << " failed to find its associated script running.";
 				return Ret();
+			}
+
+			auto ip = get_ip(program);
+			if (!ip)
+			{
+				return Ret();
+			}
 
 			auto tls_ctx                       = rage::tlsContext::get();
 			auto stack                         = (uint64_t*)thread->m_stack;

--- a/src/services/gta_data/gta_data_service.cpp
+++ b/src/services/gta_data/gta_data_service.cpp
@@ -330,9 +330,25 @@ namespace big
 						std::string LocName = item.child("LocName").text().as_string();
 						std::string LocDesc = item.child("LocDesc").text().as_string();
 
-						if (LocName.ends_with("INVALID") || LocName.ends_with("RAIL"))
-						{
+						if (LocName.ends_with("RAIL"))
 							continue;
+
+						if (LocName.ends_with("INVALID"))
+						{
+							while (!SCRIPT::HAS_SCRIPT_LOADED("achievement_controller"))
+								script::get_current()->yield();
+
+							Hash weapon_hash = 0;
+							if (name.starts_with("COMPONENT_KNIFE"))
+								weapon_hash = "WEAPON_KNIFE"_J;
+							if (name.starts_with("COMPONENT_KNUCKLE"))
+								weapon_hash = "WEAPON_KNUCKLE"_J;
+							if (name.starts_with("COMPONENT_BAT"))
+								weapon_hash = "WEAPON_BAT"_J;
+							const auto display_string = scr_functions::get_component_display_string.call<const char*>(hash, weapon_hash);
+							if (display_string == nullptr)
+								continue;
+							LocName = display_string;
 						}
 
 						weapon_component component;

--- a/src/services/gta_data/gta_data_service.cpp
+++ b/src/services/gta_data/gta_data_service.cpp
@@ -258,7 +258,8 @@ namespace big
 
 		std::vector<ped_item> peds;
 		std::vector<vehicle_item> vehicles;
-		std::vector<weapon_item> weapons;
+		//std::vector<weapon_item> weapons;
+		std::unordered_map<Hash, weapon_item> weapons;
 		std::vector<weapon_component> weapon_components;
 
 		constexpr auto exists = [](const hash_array& arr, uint32_t val) -> bool {
@@ -358,9 +359,8 @@ namespace big
 						if (hash == "WEAPON_BIRD_CRAP"_J)
 							continue;
 
-						if (exists(mapped_weapons, hash))
-							continue;
-						mapped_weapons.emplace_back(hash);
+						if (!exists(mapped_weapons, hash))
+							mapped_weapons.emplace_back(hash);
 
 						const auto human_name_hash = item.child("HumanNameHash").text().as_string();
 						if (std::strcmp(human_name_hash, "WT_INVALID") == 0 || std::strcmp(human_name_hash, "WT_VEHMINE") == 0)
@@ -435,7 +435,7 @@ namespace big
 
 						weapon.m_hash = hash;
 
-						weapons.emplace_back(std::move(weapon));
+						weapons[hash] = weapon;
 					skip:
 						continue;
 					}
@@ -488,7 +488,7 @@ namespace big
 			}
 			for (auto& item : weapons)
 			{
-				item.m_display_name = HUD::GET_FILENAME_FOR_AUDIO_CONVERSATION(item.m_display_name.c_str());
+				item.second.m_display_name = HUD::GET_FILENAME_FOR_AUDIO_CONVERSATION(item.second.m_display_name.c_str());
 			}
 			for (auto& item : weapon_components)
 			{
@@ -555,8 +555,8 @@ namespace big
 				m_weapons_cache.weapon_map.clear();
 				for (auto weapon : weapons)
 				{
-					add_if_not_exists(m_weapon_types, weapon.m_weapon_type);
-					m_weapons_cache.weapon_map.insert({weapon.m_name, weapon});
+					add_if_not_exists(m_weapon_types, weapon.second.m_weapon_type);
+					m_weapons_cache.weapon_map.insert({weapon.second.m_name, weapon.second});
 				}
 
 				m_weapons_cache.weapon_components.clear();

--- a/src/views/self/view_weapons.cpp
+++ b/src/views/self/view_weapons.cpp
@@ -288,8 +288,7 @@ namespace big
 						Hash attachment_hash                  = attachment_component.m_hash;
 						if (attachment_hash == NULL)
 						{
-							attachment_name = attachment;
-							attachment_hash = rage::joaat(attachment);
+							continue;
 						}
 						bool is_selected         = attachment_hash == selected_weapon_attachment_hash;
 						std::string display_name = attachment_name.append("##").append(std::to_string(attachment_hash));
@@ -298,6 +297,8 @@ namespace big
 							selected_weapon_attachment      = attachment_name;
 							selected_weapon_attachment_hash = attachment_hash;
 						}
+						if (ImGui::IsItemHovered())
+							ImGui::SetTooltip(attachment_component.m_display_desc.c_str());
 						if (is_selected)
 						{
 							ImGui::SetItemDefaultFocus();


### PR DESCRIPTION
I noticed an issue with the weapons.json file was using the non-updated WEAPON_MG components, and not the one from update.rpf, where I guess Rockstar had changed the components from COMPONENT_AT_SCOPE_SMALL to COMPONENT_AT_SCOPE_SMALL_02, which would cause Ammunation and Persist Weapons to not work properly.