### PR TITLE
Incorporate eThreadState changes.

### DIFF
--- a/cmake/gtav-classes.cmake
+++ b/cmake/gtav-classes.cmake
@@ -2,8 +2,8 @@ include(FetchContent)
 
 FetchContent_Declare(
     gtav_classes
-    GIT_REPOSITORY https://github.com/Yimura/GTAV-Classes.git
-    GIT_TAG        b9b832ab00c95a731f8472f696c5d026a29fd767
+    GIT_REPOSITORY https://github.com/gir489returns/GTAV-Classes.git
+    GIT_TAG        edb71876ab8eee1e2663eb26c06bf6905c5d3934
     GIT_PROGRESS TRUE
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""

--- a/src/backend/commands/player/toxic/turn_into_beast.cpp
+++ b/src/backend/commands/player/toxic/turn_into_beast.cpp
@@ -117,7 +117,7 @@ namespace big
 			if (!stack || !net_component)
 				return;
 
-			thread->m_context.m_state = rage::eThreadState::unk_3;
+			thread->m_context.m_state = rage::eThreadState::paused;
 			g.m_hunt_the_beast_thread = thread;
 
 			for (int i = 0; i < 15; i++)

--- a/src/services/gta_data/gta_data_service.cpp
+++ b/src/services/gta_data/gta_data_service.cpp
@@ -348,7 +348,7 @@ namespace big
 								mp_weapons_thread_id = SYSTEM::START_NEW_SCRIPT_WITH_NAME_HASH(script_hash, 1424);
 								auto thread          = gta_util::find_script_thread_by_id(mp_weapons_thread_id);
 								if (thread)
-									thread->m_context.m_state = rage::eThreadState::unk_3;
+									thread->m_context.m_state = rage::eThreadState::paused;
 								else
 									LOG(FATAL) << "Failed to find MP_Weapons script!";
 								SCRIPT::SET_SCRIPT_WITH_NAME_HASH_AS_NO_LONGER_NEEDED(script_hash);

--- a/src/services/script_connection/script_connection.cpp
+++ b/src/services/script_connection/script_connection.cpp
@@ -35,7 +35,7 @@ namespace big
 		if (!m_thread)
 			return false;
 
-		m_thread->m_context.m_state = rage::eThreadState::unk_3;
+		m_thread->m_context.m_state = rage::eThreadState::paused;
 		return true;
 	}
 

--- a/src/util/scripts.hpp
+++ b/src/util/scripts.hpp
@@ -127,7 +127,7 @@ namespace big::scripts
 				return;
 			}
 
-			launcher->m_context.m_state = rage::eThreadState::unk_3; // prevent bad things from happening to the thread in the meantime
+			launcher->m_context.m_state = rage::eThreadState::paused; // prevent bad things from happening to the thread in the meantime
 
 			// 3) Remove players from that annoying waiting stage
 			if (check_players_in_state(launcher, 5))


### PR DESCRIPTION
Depends on https://github.com/Yimura/GTAV-Classes/pull/186.

@maybegreat48 there are a few usages of eThreadState::running and eThreadState::idle, but they were backwards in the SDK. Can you please comb through the source and check those usages and make sure they were as intended? (To have the thread set to the idle state).