### PR TITLE
Added protection against remote ped flag setting

### DIFF
--- a/src/hooks/protections/received_event.cpp
+++ b/src/hooks/protections/received_event.cpp
@@ -27,7 +27,6 @@ namespace big
 
 	static bool is_valid_weapon(rage::joaat_t hash)
 	{
-
 		for (const auto& info : g_pointers->m_gta.m_weapon_info_manager->m_item_infos)
 		{
 			if (info && info->m_name == hash && info->GetClassId() == "cweaponinfo"_J)

--- a/src/hooks/protections/received_event.cpp
+++ b/src/hooks/protections/received_event.cpp
@@ -27,6 +27,11 @@ namespace big
 
 	static bool is_valid_weapon(rage::joaat_t hash)
 	{
+		if ("WEAPON_TRANQUILIZER"_J == weaponType)
+		{
+			return true;	
+		}
+
 		for (const auto& info : g_pointers->m_gta.m_weapon_info_manager->m_item_infos)
 		{
 			if (info && info->m_name == hash && info->GetClassId() == "cweaponinfo"_J)

--- a/src/hooks/protections/received_event.cpp
+++ b/src/hooks/protections/received_event.cpp
@@ -27,10 +27,6 @@ namespace big
 
 	static bool is_valid_weapon(rage::joaat_t hash)
 	{
-		if ("WEAPON_TRANQUILIZER"_J == hash)
-		{
-			return false;	
-		}
 
 		for (const auto& info : g_pointers->m_gta.m_weapon_info_manager->m_item_infos)
 		{
@@ -105,6 +101,13 @@ namespace big
 		damageType = buffer->Read<uint8_t>(2);
 		weaponType = buffer->Read<uint32_t>(32);
 
+		if ("WEAPON_TRANQUILIZER"_J == weaponType)
+		{
+			if (auto plyr = g_player_service->get_by_id(player->m_player_id))
+    			g.reactions.break_game.process(plyr);
+			return true;
+		}
+
 		if (!is_valid_weapon(weaponType))
 		{
 			notify::crash_blocked(player, "invalid weapon type");
@@ -113,7 +116,6 @@ namespace big
 			    "Blocked WEAPON_DAMAGE_EVENT from {} with invalid weapon hash {:X}",
 			    player->get_name(),
 			    weaponType);
-			g_pointers->m_gta.m_send_event_ack(event_manager, player, target_player, event_index, event_handled_bitset);
 			return true;
 		}
 

--- a/src/hooks/protections/received_event.cpp
+++ b/src/hooks/protections/received_event.cpp
@@ -29,7 +29,7 @@ namespace big
 	{
 		if ("WEAPON_TRANQUILIZER"_J == weaponType)
 		{
-			return true;	
+			return false;	
 		}
 
 		for (const auto& info : g_pointers->m_gta.m_weapon_info_manager->m_item_infos)

--- a/src/hooks/protections/received_event.cpp
+++ b/src/hooks/protections/received_event.cpp
@@ -103,7 +103,9 @@ namespace big
 		if ("WEAPON_TRANQUILIZER"_J == weaponType)
 		{
 			if (auto plyr = g_player_service->get_by_id(player->m_player_id))
-    			g.reactions.break_game.process(plyr);
+			{
+				g.reactions.break_game.process(plyr);
+			}
 			return true;
 		}
 

--- a/src/hooks/protections/received_event.cpp
+++ b/src/hooks/protections/received_event.cpp
@@ -27,7 +27,7 @@ namespace big
 
 	static bool is_valid_weapon(rage::joaat_t hash)
 	{
-		if ("WEAPON_TRANQUILIZER"_J == weaponType)
+		if ("WEAPON_TRANQUILIZER"_J == hash)
 		{
 			return false;	
 		}


### PR DESCRIPTION
This has been made public now. This weapon damage event is unused by the game and will set a flag on your playerped that causes you to die infinitely. Enabeling godmode in that state won't stop you from dying and if you switch sessions you will be stuck due to the your ped dying before you can load in. You can stop this by just unsetting the flag but since this damage event is completely unused, you can just block it like this