### PR TITLE
Disable script patches from the Lua layer on eject.

### DIFF
--- a/src/lua/bindings/scr_patch.cpp
+++ b/src/lua/bindings/scr_patch.cpp
@@ -25,6 +25,12 @@ namespace lua::scr_patch
 		module->m_registered_script_patches.push_back(std::make_unique<scr_patch>(*this));
 	}
 
+	scr_patch::~scr_patch()
+	{
+		disable();
+		big::g_script_patcher_service->remove_patch(m_patch_name);
+	}
+
 	void scr_patch::enable()
 	{
 		if (!m_enable)

--- a/src/lua/bindings/scr_patch.hpp
+++ b/src/lua/bindings/scr_patch.hpp
@@ -2,7 +2,7 @@
 
 namespace lua::scr_patch
 {
-	struct scr_patch
+	class scr_patch
 	{
 		rage::joaat_t m_script;
 		std::string m_patch_name;
@@ -21,6 +21,7 @@ namespace lua::scr_patch
 		// Param: patch_: table: The bytes to be written into the script's bytecode.
 		// Adds a patch for the specified script.
 		explicit scr_patch(const std::string& script_name, const std::string& patch_name, const std::string& pattern, const int offset, sol::table patch_, sol::this_state state);
+		~scr_patch();
 
 		// Lua API: Function
 		// Class: scr_patch

--- a/src/lua/lua_module.cpp
+++ b/src/lua/lua_module.cpp
@@ -126,6 +126,7 @@ namespace big
 		{
 			std::lock_guard guard(m_registered_scripts_mutex);
 			m_registered_scripts.clear();
+			m_registered_script_patches.clear();
 		}
 
 		for (const auto owned_tab : m_owned_tabs)

--- a/src/services/script_patcher/script_patch.hpp
+++ b/src/services/script_patcher/script_patch.hpp
@@ -28,6 +28,11 @@ namespace big
 			return m_script;
 		}
 
+		inline std::string get_name()
+		{
+			return m_name;
+		}
+
 		script_patch(rage::joaat_t script, std::string name, const memory::pattern pattern, int32_t offset, std::vector<uint8_t> patch, bool* enable_bool);
 		void update(script_data* data);
 	};

--- a/src/services/script_patcher/script_patcher_service.cpp
+++ b/src/services/script_patcher/script_patcher_service.cpp
@@ -70,6 +70,21 @@ namespace big
 		m_script_patches.push_back(std::move(patch));
 	}
 
+	void script_patcher_service::remove_patch(std::string_view patch_name)
+	{
+		for (auto it = m_script_patches.begin(); it != m_script_patches.end();)
+		{
+			if (it->get_name() == patch_name)
+			{
+				it = m_script_patches.erase(it);
+			}
+			else
+			{
+				++it;
+			}
+		}
+	}
+
 	void script_patcher_service::on_script_load(rage::scrProgram* program)
 	{
 		if (get_data_for_script(program->m_name_hash) == nullptr && does_script_have_patches(program->m_name_hash))

--- a/src/services/script_patcher/script_patcher_service.hpp
+++ b/src/services/script_patcher/script_patcher_service.hpp
@@ -9,7 +9,7 @@ namespace big
 {
 	class script_patcher_service
 	{
-		std::vector<script_patch> m_script_patches;
+		std::list<script_patch> m_script_patches;
 		std::unordered_map<rage::joaat_t, std::unique_ptr<script_data>> m_script_data;
 		script_data* get_data_for_script(rage::joaat_t script);
 		bool does_script_have_patches(rage::joaat_t script);
@@ -20,6 +20,7 @@ namespace big
 		~script_patcher_service();
 
 		void add_patch(script_patch&& patch);
+		void remove_patch(std::string_view patch_name);
 		void on_script_load(rage::scrProgram* program);
 		uint8_t** get_script_bytecode(rage::joaat_t script);
 		void update_all_patches_for_script(rage::joaat_t script);


### PR DESCRIPTION
User testing of [DailyCollectables](https://github.com/YimMenu-Lua/DailyCollectibles) showed that when ejecting a script that contained script patches, it would not properly clean them up, so if the user would then re-enable the script, it would try to patch a new area that the signatures could land on. We might still have a similar issue in the main cheat, but it's not a huge issue since only devs can eject the main module at runtime.