### PR TITLE
Enable All DLC Vehicles

### DIFF
--- a/src/backend/script_patches.hpp
+++ b/src/backend/script_patches.hpp
@@ -27,6 +27,9 @@ namespace big
 		g_script_patcher_service->add_patch({"carmod_shop"_J, "allow all vehicles", "2D 03 16 00 00 38 00", 5, {0x72, 0x2E, 0x03, 0x01}, nullptr}); // allow all vehicles
 		g_script_patcher_service->add_patch({"carmod_shop"_J, "allow all vehicles 2", "2D 03 07 00 00 71 38 02", 5, {0x72, 0x2E, 0x03, 0x01}, nullptr}); // allow all vehicles 2
 		g_script_patcher_service->add_patch({"main_persistent"_J, "vehicle clan logo SP bypass", "56 04 00 72 2E 01 01 2C 01 04 1F 5D ? ? ? 74", 0, {0x55}, nullptr}); // vehicle clan logo SP bypass
+		g_script_patcher_service->add_patch({"appinternet"_J, "tunable vehicles posix bypass", "59 ? ? 72 2E 02 01", 0, {0x2B, 0x00, 0x00}, nullptr}); // tunable vehicles posix bypass
+		g_script_patcher_service->add_patch({"appinternet"_J, "hide tunable vehicles bypass", "56 ? ? 70 2E 04 01 38 01", 0, {0x55}, nullptr}); // hide tunable vehicles bypass
+		g_script_patcher_service->add_patch({"appinternet"_J, "allow buying tunable vehicles", "5D ? ? ? 06 56 ? ? 38 00 25 ? 50", 5, {0x55}, nullptr}); // allow buying tunable vehicles
 
 		for (auto& entry : *g_pointers->m_gta.m_script_program_table)
 		{


### PR DESCRIPTION
Added script patches that allow all vehicles to be available for purchase even if their tunables are disabled.
This should work across different game versions (unless they change the logic). So even if new vehicles with tunables are added in future DLCs, they will automatically be enabled.