### PR TITLE
Update for b3323

### DIFF
--- a/cmake/gtav-classes.cmake
+++ b/cmake/gtav-classes.cmake
@@ -2,8 +2,8 @@ include(FetchContent)
 
 FetchContent_Declare(
     gtav_classes
-    GIT_REPOSITORY https://github.com/Mr-X-GTA/GTAV-Classes-1.git
-    GIT_TAG        e78c6b2788263cce800971d124b6d1358eeb5cbc
+    GIT_REPOSITORY https://github.com/Yimura/GTAV-Classes.git
+    GIT_TAG        e45f7f505ac2394c9213f1577831ab100cc74fa2
     GIT_PROGRESS TRUE
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""

--- a/cmake/gtav-classes.cmake
+++ b/cmake/gtav-classes.cmake
@@ -2,8 +2,8 @@ include(FetchContent)
 
 FetchContent_Declare(
     gtav_classes
-    GIT_REPOSITORY https://github.com/Yimura/GTAV-Classes.git
-    GIT_TAG        b98cf8d4dafbde003bfbde27707574da77c01134
+    GIT_REPOSITORY https://github.com/Mr-X-GTA/GTAV-Classes-1.git
+    GIT_TAG        e78c6b2788263cce800971d124b6d1358eeb5cbc
     GIT_PROGRESS TRUE
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""

--- a/src/backend/looped/spoofing/spoof_game_data_hash.cpp
+++ b/src/backend/looped/spoofing/spoof_game_data_hash.cpp
@@ -4,19 +4,19 @@
 
 namespace
 {
-	static std::array<std::uint32_t, 15> orig_hash;
+	static std::array<std::uint32_t, 16> orig_hash;
 
-	void store_data(std::array<std::uint32_t, 15>& data)
+	void store_data(std::array<std::uint32_t, 16>& data)
 	{
-		for (int i = 0; i < 15; i++)
+		for (int i = 0; i < 16; i++)
 		{
 			data[i] = (*big::g_pointers->m_gta.m_game_data_hash)->m_data[i];
 		}
 	}
 
-	void load_data(const std::array<std::uint32_t, 15>& data)
+	void load_data(const std::array<std::uint32_t, 16>& data)
 	{
-		for (int i = 0; i < 15; i++)
+		for (int i = 0; i < 16; i++)
 		{
 			(*big::g_pointers->m_gta.m_game_data_hash)->m_data[i] = data[i];
 		}

--- a/src/core/settings.hpp
+++ b/src/core/settings.hpp
@@ -731,7 +731,7 @@ namespace big
 			bool voice_chat_audio = false;
 
 			bool spoof_game_data_hash = false;
-			std::array<std::uint32_t, 15> game_data_hash{};
+			std::array<std::uint32_t, 16> game_data_hash{};
 			bool spoof_dlc_hash = false;
 			std::uint32_t dlc_hash;
 

--- a/src/pointers.cpp
+++ b/src/pointers.cpp
@@ -747,7 +747,7 @@ namespace big
         // Serialize Join Request Message 2
         {
             "SJRM2",
-            "E8 ? ? ? ? 48 8D 8D 08 01 00 00 8A D8",
+            "E8 ? ? ? ? 48 8D 8D 18 01 00 00 8A D8",
             [](memory::handle ptr)
             {
                 g_pointers->m_gta.m_serialize_join_request_message_2 = ptr.add(1).rip().as<PVOID>();
@@ -1817,7 +1817,7 @@ namespace big
         // Session Request Patch
         {
             "SRP",
-            "48 8B BD 70 01 00 00 E9 FF 00 00 00",
+            "48 8B BD 80 01 00 00 E9 FF 00 00 00",
             [](memory::handle ptr)
             {
                 g_pointers->m_gta.m_session_request_patch = ptr.add(0x13).as<PVOID>();

--- a/src/views/network/view_spoofing.cpp
+++ b/src/views/network/view_spoofing.cpp
@@ -175,7 +175,7 @@ namespace big
 
 			if (ImGui::TreeNode("DATA_HASHES"_T.data()))
 			{
-				for (int i = 0; i < 15; i++)
+				for (int i = 0; i < 16; i++)
 				{
 					ImGui::PushID(i);
 					ImGui::SetNextItemWidth(200);


### PR DESCRIPTION
This makes YimMenu usable in SP.
- Disable BattlEye in the Rockstar Games Launcher.
- If the game crashes on injection, delete `%appdata%/YimMenu/settings.json`.